### PR TITLE
feat(island): 贴边（dock）模式 —— 可拖动、clip-path 形变、三边吸附

### DIFF
--- a/scripts/test-source.mjs
+++ b/scripts/test-source.mjs
@@ -44,7 +44,7 @@ const {
   getWorkBuddyConfigPaths
 } = require("../src/main/hooks-work-agents.cjs");
 
-assert.equal(Object.keys(IPC).length, 91, "IPC contract changed; review both main and preload consumers");
+assert.equal(Object.keys(IPC).length, 95, "IPC contract changed; review both main and preload consumers");
 assert.equal(new Set(Object.values(IPC)).size, Object.keys(IPC).length, "IPC channels must be unique");
 assert.ok(Object.isFrozen(IPC), "IPC contract must be immutable");
 assert.equal(IPC.PET_DRAG_TO_ISLAND, "pet:drag-to-island");

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -583,6 +583,13 @@ function createAppCoordinatorClass({
           this.telemetry.trackSettingChange("sound.enabled");
         }
       }
+      // 落位形态改了要立即生效，不能等重启。
+      if ("islandPlacement" in partial) {
+        this.islandWin?.setPlacement?.(
+          partial.islandPlacement,
+          this.settings.islandDock
+        );
+      }
       if ("launchAtLogin" in partial) {
         electron.app.setLoginItemSettings({
           openAtLogin: partial.launchAtLogin,

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -827,6 +827,22 @@ async function runIslandApp() {
           browserWindow.webContents.send(IPC.ISLAND_WINDOW_BLUR);
         }
       });
+      // floating 落位：读设置决定形态，拖动结束后把位置写回设置。
+      iw.onDockChange = (dock) => {
+        try {
+          coordinator.updateSettings({ islandDock: dock }, "island");
+        } catch (err) {
+          log.warn("[main] 保存贴边位置失败:", err);
+        }
+      };
+      try {
+        const s0 = coordinator.getSettings?.() ?? {};
+        if (s0.islandPlacement === "docked") {
+          iw.setPlacement("docked", s0.islandDock);
+        }
+      } catch (err) {
+        log.warn("[main] 应用初始落位失败:", err);
+      }
       coordinator.setIslandWindow(iw.browserWindow);
       coordinator.setIslandWin(iw);
       coordinator.setDisplayManager(displayManager);

--- a/src/main/windows.cjs
+++ b/src/main/windows.cjs
@@ -14,11 +14,39 @@ function createWindowClasses(dependencies) {
     getIsQuitting
   } = dependencies;
 
+  // 隐身热区：光标轮询间隔，以及热区在胶囊两侧的容错余量（与渲染层保持一致）。
+  const HOTSPOT_POLL_INTERVAL_MS = 80;
+  const HOTSPOT_SIDE_PADDING_PX = 48;
+  // ── dock（贴边）落位 ────────────────────────────────────────────────────
+  // 唯一状态源：主进程持有 edge + mode，窗口尺寸与渲染层形状都由它推导。
+  // 分开各算各的正是此前「找不到 / 长条 / 竖侧边栏」的共同成因。
+  const DOCK_SQUARE = 56;        // 拖动中的小方块
+  // 条的几何在两个方向上完全对称：厚 44、长 160。
+  const DOCK_STRIP_W = 44;       // 左右竖条（厚 × 长）
+  const DOCK_STRIP_H = 160;
+  const DOCK_TOP_W = 160;        // 顶部横条（长 × 厚）
+  const DOCK_TOP_H = 44;
+  const DOCK_VPANEL_W = 380;     // 侧边展开的竖长面板
+  const DOCK_VPANEL_H = 560;
+  const DOCK_TOP_WINDOW_H = 620;
+  const DOCK_HPANEL_W = 740;     // 顶部展开的横向面板
+  const DOCK_DRAG_POLL_MS = 16;
+  const DOCK_DRAG_MAX_MS = 15e3; // mouseup 丢失时的安全上限
   const ISLAND_WIDTH = 740;
   const ISLAND_HEIGHT = 750;
   class IslandWindow {
     win;
     currentTarget;
+    _hotspotTimer = null;
+    _placement = "notch";
+    _dockEdge = "right";        // "top" | "left" | "right"
+    _dockOffset = 0.25;         // 沿边的位置，0-1 比例，跨分辨率仍成立
+    _dockDragging = false;
+    _dragTimer = null;
+    _dragOrigin = null;
+    // 渲染层是否处于展开态。只由渲染层的 PANEL_EXPANDED/COLLAPSED 上报驱动，
+    // 不受主进程自己的 isPanelExpanded 推测影响 —— 后者会被隐藏路径提前置 false。
+    _rendererExpanded = false;
     _isFullscreenHidden = false;
     _isFocusHidden = false;
     isHoverRevealedWhileFullscreenHidden = false;
@@ -55,17 +83,73 @@ function createWindowClasses(dependencies) {
     handleSyncClosedWindow = (event) => {
       if (this.win.isDestroyed()) return;
       if (event.sender !== this.win.webContents) return;
+      // 面板正处于展开态时，收起同步一律丢弃。
+      // 渲染层的 resize effect 只在 notchStatus/transitionClass 变化时重跑，
+      // 面板稳定展开后不会再发高度；此时若被压到收起高度，就再没有东西会把它
+      // 改回去 —— 于是展开态的宽形状被裁成顶部一条，长时间滞留成一根黑色长条。
+      if (this.isPanelExpanded) {
+        log.debug("[IslandWindow] 忽略展开态下的 syncClosedWindow");
+        return;
+      }
       this.landClosedWindow();
+    };
+    handleDragStart = (event) => {
+      if (this.win.isDestroyed()) return;
+      if (event.sender !== this.win.webContents) return;
+      if (!this.isDocked) return;
+      const c = electron.screen.getCursorScreenPoint();
+      // 按下即收成小方块，方块中心落在光标下（窗口是面板大小，保留原位置会让
+      // 方块出现在面板左上角、离光标很远）。
+      this._dockDragging = true;
+      const sx = c.x - Math.round(DOCK_SQUARE / 2);
+      const sy = c.y - Math.round(DOCK_SQUARE / 2);
+      this.win.setBounds({ x: sx, y: sy, width: DOCK_SQUARE, height: DOCK_SQUARE });
+      this._dragOrigin = { cx: c.x, cy: c.y, wx: sx, wy: sy, startedAt: Date.now() };
+      this.sendDockState();
+      // 主进程轮询光标来跟手，而不是依赖渲染层持续上报 mousemove：
+      // 拖动中鼠标常常已经移出窗口范围，渲染层就收不到事件了。
+      this.stopDragFollow();
+      this._dragTimer = setInterval(() => {
+        if (this.win.isDestroyed() || !this._dragOrigin) {
+          this.stopDragFollow();
+          return;
+        }
+        if (Date.now() - this._dragOrigin.startedAt > DOCK_DRAG_MAX_MS) {
+          // mouseup 没能传回来（例如鼠标在别的窗口上松开），别无限跟随。
+          this.stopDragFollow();
+          this._dragOrigin = null;
+          this.snapToNearestEdge();
+          return;
+        }
+        const now = electron.screen.getCursorScreenPoint();
+        this.win.setPosition(
+          this._dragOrigin.wx + (now.x - this._dragOrigin.cx),
+          this._dragOrigin.wy + (now.y - this._dragOrigin.cy)
+        );
+      }, DOCK_DRAG_POLL_MS);
+    };
+    handleDragEnd = (event) => {
+      if (this.win.isDestroyed()) return;
+      if (event.sender !== this.win.webContents) return;
+      this.stopDragFollow();
+      if (!this.isDocked) return;
+      this._dragOrigin = null;
+      this.snapToNearestEdge();
     };
     handlePanelExpanded = (event) => {
       if (this.win.isDestroyed()) return;
       if (event.sender !== this.win.webContents) return;
       this.isPanelExpanded = true;
+      this._rendererExpanded = true;
+      // mode 变了（strip→panel），渲染层的形态类名要跟上
+      if (this.isDocked) this.sendDockState();
     };
     handlePanelCollapsed = (event) => {
       if (this.win.isDestroyed()) return;
       if (event.sender !== this.win.webContents) return;
       this.isPanelExpanded = false;
+      this._rendererExpanded = false;
+      if (this.isDocked) this.sendDockState();
     };
     constructor(target, options = {}) {
       this.currentTarget = target;
@@ -115,9 +199,38 @@ function createWindowClasses(dependencies) {
       this.win.webContents.on("did-finish-load", () => {
         const notchInfo = this.buildNotchInfo(this.currentTarget);
         this.win.webContents.send(IPC.ISLAND_NOTCH_INFO, notchInfo);
-        this.applyRequestedHeight(this.getClosedHeight());
+        // 补发落位状态。setPlacement 可能在页面加载完成前就调用过（启动时按设置
+        // 落位），那时 webContents.send 会被直接丢弃，渲染层便一直以为自己是
+        // notch 模式：窗口已按卡片尺寸缩小，渲染层却仍按刘海 clip-path 裁切，
+        // 裁切区落在可见范围外 —— 表现为「卡片彻底看不见」或各种条状残影。
+        this.send(IPC.ISLAND_PLACEMENT, this.dockState());
+        if (this.isDocked) {
+          this.applyDockBounds();
+        } else {
+          this.applyRequestedHeight(this.getClosedHeight());
+        }
         this.win.show();
+        // 调试开关：WORKISLAND_CAPTURE=1 启动时，2s 后把渲染帧写到 /tmp。
+        // 外部截屏工具抓不到面板级窗口，这是验证实际渲染的唯一手段；平时不跑。
+        if (process.env.WORKISLAND_CAPTURE) {
+          // 先收起再抓：活跃会话的审批事件可能已把面板弹开
+          setTimeout(() => {
+            if (!this.win.isDestroyed()) this.send(IPC.ISLAND_COLLAPSE);
+          }, 1400);
+          setTimeout(() => {
+            if (this.win.isDestroyed()) return;
+            this.win.webContents.capturePage().then((img) => {
+              require("node:fs").writeFileSync("/tmp/island-capture.png", img.toPNG());
+              log.info("[island capture] written");
+            }).catch(() => {});
+          }, 2000);
+        }
         log.debug("[IslandWindow] ready on display:", this.currentTarget.screenInfo.label);
+      });
+      // 把渲染层的报错接到主日志：岛的渲染进程没有可见的 devtools，
+      // 一旦 React 抛错整页空白，从外面看就只是「什么都不显示」，无从判断。
+      this.win.webContents.on("console-message", (_e, level, message, line, sourceId) => {
+        if (level >= 2) log.error("[island renderer]", message, `${sourceId}:${line}`);
       });
       this.win.webContents.on("did-fail-load", (_event, errorCode, errorDescription, validatedURL) => {
         log.error("[IslandWindow] did-fail-load:", { errorCode, errorDescription, validatedURL });
@@ -140,11 +253,21 @@ function createWindowClasses(dependencies) {
         electron.ipcMain.removeListener(IPC.ISLAND_PANEL_EXPANDED, this.handlePanelExpanded);
         electron.ipcMain.removeListener(IPC.ISLAND_PANEL_COLLAPSED, this.handlePanelCollapsed);
         electron.ipcMain.removeListener(IPC.ISLAND_SYNC_CLOSED_WINDOW, this.handleSyncClosedWindow);
+        electron.ipcMain.removeHandler(IPC.ISLAND_GET_PLACEMENT);
+        electron.ipcMain.removeListener(IPC.ISLAND_DRAG_START, this.handleDragStart);
+        electron.ipcMain.removeListener(IPC.ISLAND_DRAG_END, this.handleDragEnd);
+        this.stopHotspotCursorWatch();
+        this.stopDragFollow();
         log.warn("[IslandWindow] window closed");
       });
       electron.ipcMain.on(IPC.ISLAND_ENTER, this.handleIslandEnter);
       electron.ipcMain.on(IPC.ISLAND_LEAVE, this.handleIslandLeave);
       electron.ipcMain.on(IPC.ISLAND_RESIZE, this.handleIslandResize);
+      // 必须返回完整 dock 状态。只回 {placement} 会把推送过的 edge/mode/strip
+      // 覆盖成 undefined，渲染层直接退化成一整块无裁切的黑矩形。
+      electron.ipcMain.handle(IPC.ISLAND_GET_PLACEMENT, () => this.dockState());
+      electron.ipcMain.on(IPC.ISLAND_DRAG_START, this.handleDragStart);
+      electron.ipcMain.on(IPC.ISLAND_DRAG_END, this.handleDragEnd);
       electron.ipcMain.on(IPC.ISLAND_PANEL_EXPANDED, this.handlePanelExpanded);
       electron.ipcMain.on(IPC.ISLAND_PANEL_COLLAPSED, this.handlePanelCollapsed);
       electron.ipcMain.on(IPC.ISLAND_SYNC_CLOSED_WINDOW, this.handleSyncClosedWindow);
@@ -180,6 +303,8 @@ function createWindowClasses(dependencies) {
      */
     setFullscreenHidden(hidden) {
       if (this.win.isDestroyed()) return;
+      // floating 是常驻卡片，不参与全屏/失焦隐身。
+      if (this.isDocked) return;
       if (this._isFullscreenHidden === hidden) return;
       this._isFullscreenHidden = hidden;
       this.shouldConcealAfterCloseAnimation = false;
@@ -204,6 +329,8 @@ function createWindowClasses(dependencies) {
     /** Hide the Island after focus leaves the WorkIsland surface. */
     setFocusHidden(hidden) {
       if (this.win.isDestroyed()) return;
+      // floating 是常驻卡片，不参与全屏/失焦隐身。
+      if (this.isDocked) return;
       const next = Boolean(hidden);
       if (this._isFocusHidden === next && (!next || this.shouldStayConcealed)) return;
       this._isFocusHidden = next;
@@ -255,11 +382,48 @@ function createWindowClasses(dependencies) {
     // ── Private helpers ────────────────────────────────────────────────────────
     // Hover reveal: user moved mouse into the island area while fullscreen-hidden.
     // Show the island and enable clicks so it behaves normally.
+    /**
+     * 原生窗口透明度的补间。
+     * BrowserWindow.setOpacity 是瞬时的 —— 隐藏时直接 setOpacity(0)，
+     * island 会「啪」地消失，没有任何过渡。CSS 在这里帮不上忙：
+     * 窗口整体的 opacity 属于原生层，渲染层管不到。
+     */
+    fadeOpacityTo(target, durationMs, onDone) {
+      if (this.win.isDestroyed()) return;
+      if (this._fadeTimer) {
+        clearInterval(this._fadeTimer);
+        this._fadeTimer = null;
+      }
+      const from = this.win.getOpacity();
+      if (durationMs <= 0 || Math.abs(target - from) < 0.01) {
+        this.win.setOpacity(target);
+        onDone?.();
+        return;
+      }
+      const started = Date.now();
+      this._fadeTimer = setInterval(() => {
+        if (this.win.isDestroyed()) {
+          clearInterval(this._fadeTimer);
+          this._fadeTimer = null;
+          return;
+        }
+        const t = Math.min(1, (Date.now() - started) / durationMs);
+        // ease-out：起步快、收尾缓，和 CSS 的 ease-out 观感一致
+        const eased = 1 - Math.pow(1 - t, 3);
+        this.win.setOpacity(from + (target - from) * eased);
+        if (t >= 1) {
+          clearInterval(this._fadeTimer);
+          this._fadeTimer = null;
+          onDone?.();
+        }
+      }, 16);
+    }
     revealForHover() {
       if (this.win.isDestroyed()) return;
       this.isHoverRevealedWhileFullscreenHidden = true;
       this.applyRequestedHeight(this.requestedHeight);
-      this.win.setOpacity(1);
+      // 唤出要跟手，用更短的淡入
+      this.fadeOpacityTo(1, 110);
       this.win.setIgnoreMouseEvents(false);
     }
     // Convert DisplayTarget → NotchInfo for the island renderer.
@@ -321,34 +485,227 @@ function createWindowClasses(dependencies) {
     }
     applyClosedWindowTarget(target, options) {
       if (this.win.isDestroyed()) return;
+      // floating 下没有「隐身到顶部热区」这回事：卡片常驻可见，收起只是变回卡片尺寸。
+      if (this.isDocked) {
+        // 贴边态窗口固定为面板大小，这里不改尺寸；收起后回到穿透，
+        // 让面板区域下方的应用可以正常点击。
+        this.win.setOpacity(1);
+        this.win.setIgnoreMouseEvents(true, { forward: true });
+        return;
+      }
       const interactive = options?.interactive ?? false;
       const [width] = this.win.getSize();
       const closedHeight = this.getClosedHeight();
       this.requestedHeight = closedHeight;
       if (target === "hidden-hotspot") {
-        // 透明热区：opacity 0（用户看不见），但窗口保持胶囊高度并**接收鼠标事件**
-        // （不能 forward——forward 会把鼠标事件转给下方应用，窗口自己收不到
-        // mouseenter，hover 就永远唤不回 island）。高度用 closedHeight（无刘海屏
-        // 即菜单栏高度），保证鼠标扫过屏幕顶部能命中热区。这是"完全隐身 + 可 hover
-        // 唤出"的关键：窗口透明地占据顶部一条，鼠标进入即 revealForHover。
+        // 透明热区：opacity 0（用户看不见），窗口保持胶囊高度占住屏幕顶部一条。
+        //
+        // 这里**不能捕获鼠标**。旧实现用 setIgnoreMouseEvents(false) 让窗口收下
+        // 全部鼠标事件，代价是连点击一起吞掉 —— 于是热区覆盖的那段菜单栏在岛
+        // 完全不可见的情况下也点不动，用户只会觉得"顶部有一块坏了"。
+        //
+        // 改为不拦截 + 主进程轮询光标坐标来判断是否进入热区：点击全部穿透给下方
+        // 应用，悬停探测则完全不依赖窗口收到鼠标事件。
         this.isHoverRevealedWhileFullscreenHidden = false;
-        this.win.setSize(width, closedHeight);
-        this.win.setOpacity(0);
-        this.win.setIgnoreMouseEvents(false);
+        // 先淡出、淡完再压高度。
+        // 顺序反过来会露出「长条」：面板展开时若焦点丢失（setFocusHidden /
+        // setFullscreenHidden 都是立刻调到这里），窗口高度瞬间压到 closedHeight，
+        // 而渲染层的 clip-path 还停在展开态那个 740 宽的形状 —— 于是只露出顶部
+        // 一条，看起来就是一根横贯的黑色长条。
+        this.fadeOpacityTo(0, 200, () => {
+          if (this.win.isDestroyed()) return;
+          const [w] = this.win.getSize();
+          this.win.setSize(w, closedHeight);
+        });
+        this.win.setIgnoreMouseEvents(true, { forward: true });
+        this.startHotspotCursorWatch();
+        // 仅当渲染层确实处于展开态时才强制它收起。少了这一步，主进程隐藏时两边
+        // 状态会分叉：主进程把 requestedHeight 记成收起高度，渲染层却仍在画展开
+        // 面板；之后 revealForHover 按 requestedHeight 恢复并置 opacity 1，就得到
+        // 「展开态宽形状 + 收起态高度 + 完全可见」= 那根黑色长条。
+        //
+        // 条件必须收窄：无条件发会把「只有胶囊、面板本就没展开」的温和隐藏也变成
+        // 强制收起，表现为点一下就整个消失。
+        if (this._rendererExpanded) {
+          this.send(IPC.ISLAND_COLLAPSE);
+        }
         return;
       }
+      this.stopHotspotCursorWatch();
       this.win.setSize(width, closedHeight);
-      this.win.setOpacity(1);
+      this.fadeOpacityTo(1, 110);
       if (interactive) {
         this.win.setIgnoreMouseEvents(false);
       } else {
         this.win.setIgnoreMouseEvents(true, { forward: true });
       }
     }
+    /**
+     * 隐身热区期间轮询光标位置，进入热区矩形即唤出。
+     * 之所以轮询而不是靠窗口的 mouseenter：窗口此时对鼠标完全透明（点击要穿透
+     * 给菜单栏），自然也收不到进入事件。轮询只在隐身态运行，唤出即停。
+     */
+    startHotspotCursorWatch() {
+      this.stopHotspotCursorWatch();
+      if (this.isDocked) return;
+      this._hotspotTimer = setInterval(() => {
+        if (this.win.isDestroyed() || !this.shouldStayConcealed) {
+          this.stopHotspotCursorWatch();
+          return;
+        }
+        const pt = electron.screen.getCursorScreenPoint();
+        const r = this.getPillRect();
+        const inside = pt.x >= r.x - HOTSPOT_SIDE_PADDING_PX && pt.x <= r.x + r.width + HOTSPOT_SIDE_PADDING_PX && pt.y >= r.y && pt.y <= r.y + r.height;
+        if (inside) {
+          this.stopHotspotCursorWatch();
+          this.revealForHover();
+        }
+      }, HOTSPOT_POLL_INTERVAL_MS);
+    }
+    stopHotspotCursorWatch() {
+      if (this._hotspotTimer) {
+        clearInterval(this._hotspotTimer);
+        this._hotspotTimer = null;
+      }
+    }
+    stopDragFollow() {
+      if (this._dragTimer) {
+        clearInterval(this._dragTimer);
+        this._dragTimer = null;
+      }
+    }
+    get isDocked() {
+      return this._placement === "docked";
+    }
+    /**
+     * 切换落位形态。
+     * notch   = 顶部刘海居中（原有形态，走 fixPanel + 菜单栏对齐那套几何）
+     * docked  = 贴边（不碰 fixPanel，位置由 edge + offset 决定）
+     */
+    setPlacement(placement, dock) {
+      if (this.win.isDestroyed()) return;
+      const next = placement === "docked" ? "docked" : "notch";
+      const changed = this._placement !== next;
+      this._placement = next;
+      if (next === "docked") {
+        // 贴边态是常驻可见的，「隐身到顶部热区」那套整体停用。
+        this.stopHotspotCursorWatch();
+        this._isFullscreenHidden = false;
+        this._isFocusHidden = false;
+        if (dock?.edge) this._dockEdge = dock.edge;
+        if (typeof dock?.offset === "number") this._dockOffset = dock.offset;
+        this.applyDockBounds();
+        this.win.setOpacity(1);
+        // 空闲态穿透 + 转发：条的可点击性由渲染层 mouseenter → ISLAND_ENTER 开启，
+        // 和刘海模式同一套机制。
+        this.win.setIgnoreMouseEvents(true, { forward: true });
+      } else {
+        this.stopDragFollow();
+        this._dragOrigin = null;
+        this._dockDragging = false;
+        const { display } = this.currentTarget;
+        fixPanel(this.win.getNativeWindowHandle(), display.id);
+        this.applyRequestedHeight(this.getClosedHeight());
+      }
+      if (changed) log.info("[IslandWindow] placement ->", next, next === "docked" ? this._dockEdge : "");
+      this.sendDockState();
+    }
+    /** 当前 dock 形态：dragging | strip | panel。窗口尺寸与渲染层形状都由它推导。 */
+    get dockMode() {
+      if (this._dockDragging) return "dragging";
+      return this._rendererExpanded ? "panel" : "strip";
+    }
+    /**
+     * 贴边几何。窗口在整个贴边生命周期里**固定为面板大小**（贴边锚定），
+     * 条↔面板的切换全部交给渲染层的 clip-path 形变 —— 和刘海模式同构。
+     * 此前让主进程逐帧改窗口 bounds 来做动画，渲染层的形状异步追着重算，
+     * 两边永远差几帧，就是「小块冲出去一下再展开」的成因。
+     * 窗口 bounds 只在拖动（小方块跟手）和吸附换边时变化。
+     */
+    dockGeometry() {
+      const d = this.currentTarget.display;
+      const wa = d.workArea;
+      const b = d.bounds;
+      const edge = this._dockEdge;
+      if (edge === "top") {
+        const w = DOCK_HPANEL_W;
+        const winX = Math.max(b.x, Math.min(
+          b.x + Math.round((b.width - w) * this._dockOffset),
+          b.x + b.width - w
+        ));
+        const stripX = Math.max(b.x, Math.min(
+          b.x + Math.round((b.width - DOCK_TOP_W) * this._dockOffset),
+          b.x + b.width - DOCK_TOP_W
+        ));
+        return {
+          bounds: { x: winX, y: b.y, width: w, height: DOCK_TOP_WINDOW_H },
+          strip: { spanOffset: stripX - winX, len: DOCK_TOP_W, depth: DOCK_TOP_H }
+        };
+      }
+      const w = DOCK_VPANEL_W;
+      const h = DOCK_VPANEL_H;
+      const stripCenter = wa.y + this._dockOffset * wa.height;
+      const stripTop = Math.max(wa.y, Math.min(
+        Math.round(stripCenter - DOCK_STRIP_H / 2),
+        wa.y + wa.height - DOCK_STRIP_H
+      ));
+      const winY = Math.max(wa.y, Math.min(stripTop, wa.y + wa.height - h));
+      const x = edge === "left" ? wa.x : wa.x + wa.width - w;
+      return {
+        bounds: { x, y: winY, width: w, height: h },
+        strip: { spanOffset: stripTop - winY, len: DOCK_STRIP_H, depth: DOCK_STRIP_W }
+      };
+    }
+    /** 把窗口摆到当前 dock 几何（瞬时）。形变动画在渲染层。 */
+    applyDockBounds() {
+      if (this.win.isDestroyed() || !this.isDocked) return;
+      if (this._dockDragging) return;
+      this.win.setBounds(this.dockGeometry().bounds);
+      this.sendDockState();
+    }
+    /** 把完整 dock 状态推给渲染层。渲染层只照着画，不自行推断。 */
+    sendDockState() {
+      this.send(IPC.ISLAND_PLACEMENT, this.dockState());
+    }
+    dockState() {
+      const state = {
+        placement: this._placement,
+        edge: this._dockEdge,
+        mode: this.isDocked ? this.dockMode : "notch"
+      };
+      if (this.isDocked && !this._dockDragging) {
+        state.strip = this.dockGeometry().strip;
+      }
+      return state;
+    }
+    /** 松手：一定吸附到最近的边（上/左/右，不含底部），并记住位置。 */
+    snapToNearestEdge() {
+      if (this.win.isDestroyed() || !this.isDocked) return;
+      const [w, h] = this.win.getSize();
+      const [x, y] = this.win.getPosition();
+      const wa = electron.screen.getDisplayMatching({ x, y, width: w, height: h }).workArea;
+      const cx = x + w / 2;
+      const cy = y + h / 2;
+      const dTop = cy - wa.y;
+      const dLeft = cx - wa.x;
+      const dRight = wa.x + wa.width - cx;
+      const nearest = Math.min(dTop, dLeft, dRight);
+      this._dockEdge = nearest === dTop ? "top" : nearest === dLeft ? "left" : "right";
+      this._dockOffset = this._dockEdge === "top"
+        ? Math.max(0, Math.min(1, (cx - wa.x) / Math.max(1, wa.width)))
+        : Math.max(0, Math.min(1, (cy - wa.y) / Math.max(1, wa.height)));
+      this._dockDragging = false;
+      this.applyDockBounds();
+      // 吸附完成后回到穿透态：窗口是面板大小，空闲时绝不能挡住下面的点击。
+      this.win.setIgnoreMouseEvents(true, { forward: true });
+      this.onDockChange?.({ edge: this._dockEdge, offset: this._dockOffset });
+    }
     applyRequestedHeight(height) {
       if (this.win.isDestroyed()) return;
       const clamped = Math.max(1, Math.min(ISLAND_HEIGHT, Math.round(height)));
       this.requestedHeight = clamped;
+      // 贴边态窗口固定为面板大小，高度上报只记录、不改窗口。
+      if (this.isDocked) return;
       if (this.shouldStayConcealed) return;
       const [width] = this.win.getSize();
       this.win.setSize(width, clamped);

--- a/src/preload/island.js
+++ b/src/preload/island.js
@@ -64,6 +64,19 @@ electron.contextBridge.exposeInMainWorld("islandBridge", {
     return () => electron.ipcRenderer.off(ipc.IPC.ISLAND_WINDOW_BLUR, handler);
   },
   // ── Renderer → main ────────────────────────────────────────────────────────
+  // floating 拖动：按下/松手各发一次，中间由主进程轮询光标跟手。
+  dragStart() {
+    electron.ipcRenderer.send(ipc.IPC.ISLAND_DRAG_START);
+  },
+  dragEnd() {
+    electron.ipcRenderer.send(ipc.IPC.ISLAND_DRAG_END);
+  },
+  getPlacement() {
+    return electron.ipcRenderer.invoke(ipc.IPC.ISLAND_GET_PLACEMENT);
+  },
+  onPlacement(cb) {
+    electron.ipcRenderer.on(ipc.IPC.ISLAND_PLACEMENT, (_e, payload) => cb(payload));
+  },
   enterIsland() {
     electron.ipcRenderer.send(ipc.IPC.ISLAND_ENTER);
   },

--- a/src/renderer/island/app.css
+++ b/src/renderer/island/app.css
@@ -1,3 +1,30 @@
+/* ── Echo 令牌层 ──────────────────────────────────────────────────────────
+ * 抽取前：205 处硬编码颜色 / 103 个不同色值，且存在三类重复：
+ *   · 大小写重复      #9599A6 与 #9599a6
+ *   · 肉眼无差重复    #d1d3db 与 #d1d3dd（蓝通道差 2）
+ *   · 同角色多基色    浅色叠加层同时用了 rgb(224,226,242) / (224,230,242)
+ *                     / (221,230,244) / (255,255,255) 四种基色，4%-16% 透明度下
+ *                     根本分辨不出，却让换肤无从下手
+ * 现统一到 Echo 的宣纸暖调（#F8F2E6）。岛体本身保持纯黑 —— 那是为了和刘海
+ * 无缝融合，不能换成墨色。 */
+:root {
+  --isl-fg: #F2ECDE;          /* 主文字   ← #d1d3db #d1d3dd #EEEEEE */
+  --isl-fg-strong: #FFFFFF;   /* 最强对比 ← #ffffff */
+  --isl-fg-2: #A79E90;        /* 次级     ← #9599a6 */
+  --isl-fg-3: #6E6559;        /* 三级     ← #646b77 */
+
+  /* 叠加层：单一基色 + 五档透明度，替代原来的四种基色混用 */
+  --isl-layer-1: rgba(248, 242, 230, 0.04);
+  --isl-layer-2: rgba(248, 242, 230, 0.06);
+  --isl-layer-3: rgba(248, 242, 230, 0.10);
+  --isl-layer-4: rgba(248, 242, 230, 0.14);
+  --isl-layer-5: rgba(248, 242, 230, 0.16);
+
+  --isl-accent: #C4452D;      /* 朱砂 ← #387bff。仅用于链接/聚焦/accent-color，
+                                 不涉及批准按钮，所以换成红色没有语义风险 */
+  --isl-ok: #42E86B;
+}
+
 /* island.css — Dynamic Island layout, shape morphing, and animations.
  *
  * Shape transitions use CSS clip-path: inset() so the black pill/panel shape
@@ -10,12 +37,12 @@
  *
  * Color palette (mirrors Swift IslandPanelView):
  *   Background:   #000
- *   Text primary:    rgba(255,255,255,0.9)
- *   Text secondary:  rgba(255,255,255,0.55)
- *   Text tertiary:   rgba(255,255,255,0.28)
- *   Border:          rgba(255,255,255,0.07)  (open)  / rgba(255,255,255,0.04) (closed)
+ *   Text primary:    rgba(248, 242, 230, 0.9)
+ *   Text secondary:  rgba(248, 242, 230, 0.55)
+ *   Text tertiary:   rgba(248, 242, 230, 0.28)
+ *   Border:          rgba(248, 242, 230, 0.07)  (open)  / var(--isl-layer-1) (closed)
  *   Phase-running:   #6E9FFF  (blue)
- *   Phase-active:    #42E86B  (green)
+ *   Phase-active:    var(--isl-ok)  (green)
  *   Phase-attention: #FF9F0A  (orange)
  *   Phase-question:  #FFD60A  (yellow)
  *   Badge bg:        #232326
@@ -45,7 +72,7 @@ body {
 
 /* 与 Trae 参考一致：卡片顶栏比内容区更深一层，全岛统一 */
 html {
-  --island-card-header-bg: rgba(221, 230, 244, 0.04);
+  --island-card-header-bg: var(--isl-layer-1);
 }
 
 body {
@@ -67,12 +94,36 @@ body {
  * automatically follows the island shape during clip-path animation.
  * Adjust blur/spread/color to taste. */
 .island-pop-wrapper {
-  filter: drop-shadow(0 0 0 1px rgba(255, 255, 255, 0.1));
-  transition: filter 0.3s ease-out;
+  filter: drop-shadow(0 0 0 1px var(--isl-layer-3));
 }
 
 .island-pop-wrapper.is-open {
   filter: drop-shadow(0 8px 8px rgba(0, 0, 0, 0.35)) drop-shadow(0 0 0 rgba(0, 0, 0, 0.23));
+}
+
+/* 形变期间摘掉 filter。
+ * 这个 wrapper 是 position:fixed; inset:0，铺满整个窗口；filter 会强制 Chromium
+ * 把整棵子树栅格化成纹理再做模糊，而子树里的 clip-path 每帧都在变 —— 于是每帧
+ * 都要按「展开后的完整窗口尺寸」重来一次。这是 hover 展开卡顿的主要来源。
+ * 原来还额外挂了 transition: filter 0.3s，等于把这份开销再单独跑一遍。 */
+.island-pop-wrapper.is-morphing {
+  filter: none;
+}
+
+/* 隐形唤醒热区：透明、不可见，只负责接住鼠标。
+ * 放在 .island 之前，z 序在其下方，所以不会抢走胶囊本体的点击。
+ *
+ * 宽度只比胶囊本体宽出两侧余量，不铺满整个岛窗口 —— 铺满时热区约占屏宽一半，
+ * 鼠标沿菜单栏移动几乎必然触发，胶囊会毫无理由地冒出来挡住菜单栏。
+ * 收窄不会让胶囊变难点：.island 自身就是 pointer-events:auto，命中它的可见轮廓
+ * 照样唤醒，热区只是轮廓周围的容错余量。 */
+.island-hotspot {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  background: transparent;
+  pointer-events: auto;
 }
 
 /* ── Island — the morphing black shape ────────────────────────────────────── */
@@ -154,7 +205,7 @@ body {
   flex: 1;
   font-size: 12px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(248, 242, 230, 0.9);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -166,7 +217,7 @@ body {
 }
 
 .pill-label-completed {
-  color: #42e86b;
+  color: var(--isl-ok);
 }
 
 .pill-label-idle {
@@ -190,7 +241,7 @@ body {
   flex-shrink: 0;
   border: 0;
   border-radius: 8px;
-  background: rgba(255, 255, 255, 0.08);
+  background: rgba(248, 242, 230, 0.08);
   color: #fff;
   font-size: 14px;
   line-height: 1;
@@ -217,7 +268,7 @@ body {
 }
 
 .panel-btn.panel-pet-button:hover {
-  background: rgba(255, 255, 255, 0.18);
+  background: rgba(248, 242, 230, 0.18);
   transform: scale(1.06);
 }
 
@@ -264,7 +315,7 @@ body {
 .pill-count {
   font-size: 12px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(248, 242, 230, 0.9);
   letter-spacing: -0.2px;
 }
 
@@ -293,7 +344,7 @@ body {
 .panel-title {
   font-size: 13px;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(248, 242, 230, 0.9);
   letter-spacing: -0.2px;
 }
 
@@ -308,7 +359,7 @@ body {
   border: none;
   display: flex;
   align-items: center;
-  color: rgba(255, 255, 255, 0.5);
+  color: rgba(248, 242, 230, 0.5);
   cursor: pointer;
   border-radius: 6px;
   transition:
@@ -322,13 +373,13 @@ body {
   -webkit-user-drag: none;
 }
 .panel-btn:hover {
-  color: rgba(255, 255, 255, 0.85);
-  background: rgba(255, 255, 255, 0.08);
+  color: rgba(248, 242, 230, 0.85);
+  background: rgba(248, 242, 230, 0.08);
 }
 
 .panel-divider {
   height: 1px;
-  background: rgba(255, 255, 255, 0.07);
+  background: rgba(248, 242, 230, 0.07);
   margin: 0 18px;
   flex-shrink: 0;
 }
@@ -350,7 +401,7 @@ body {
   background: transparent;
 }
 .session-list::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(248, 242, 230, 0.2);
   border-radius: 2px;
 }
 
@@ -372,7 +423,7 @@ body {
 
 .session-list-empty-text {
   font-size: 11px;
-  color: rgba(255, 255, 255, 0.9);
+  color: rgba(248, 242, 230, 0.9);
 }
 .session-row-container {
   display: flex;
@@ -399,7 +450,7 @@ body {
     sans-serif;
   font-size: 12px;
   font-weight: 400;
-  color: #d1d3db;
+  color: var(--isl-fg);
   line-height: 16px;
   overflow-wrap: break-word;
 }
@@ -432,13 +483,13 @@ body {
 }
 
 .island-markdown li::marker {
-  color: #d1d3db;
+  color: var(--isl-fg);
 }
 
 .island-markdown code {
   font-family: "SF Mono", Menlo, Monaco, monospace;
   font-size: 12px;
-  background: rgba(224, 230, 242, 0.1);
+  background: var(--isl-layer-3);
   padding: 1px 4px;
   border-radius: 3px;
 }
@@ -446,7 +497,7 @@ body {
 .island-markdown pre {
   padding: 8px;
   margin: 4px 0;
-  background: rgba(224, 230, 242, 0.06);
+  background: var(--isl-layer-2);
   border-radius: 4px;
   overflow-x: auto;
 }
@@ -462,11 +513,11 @@ body {
 
 .island-markdown strong {
   font-weight: 600;
-  color: #ffffff;
+  color: var(--isl-fg-strong);
 }
 
 .island-markdown a {
-  color: #387bff;
+  color: var(--isl-accent);
   text-decoration: none;
 }
 
@@ -478,7 +529,7 @@ body {
 .island-markdown h6 {
   margin: 4px 0 2px;
   font-weight: 600;
-  color: #ffffff;
+  color: var(--isl-fg-strong);
   line-height: 1.3;
 }
 
@@ -506,16 +557,241 @@ body {
 .island-markdown th,
 .island-markdown td {
   padding: 4px 8px;
-  border: 1px solid rgba(224, 226, 242, 0.16);
+  border: 1px solid var(--isl-layer-5);
   text-align: left;
 }
 
 .island-markdown th {
   font-weight: 600;
-  color: #ffffff;
-  background: rgba(224, 230, 242, 0.08);
+  color: var(--isl-fg-strong);
+  background: rgba(248, 242, 230, 0.08);
 }
 
 .island-markdown td {
-  color: #d1d3db;
+  color: var(--isl-fg);
+}
+
+/* ── dock（贴边）落位 ──────────────────────────────────────────────────────
+ * 贴边态下窗口尺寸已经紧贴可见形状，所以一律不用 clip-path：
+ * 窗口和绘制形状同源，不会再出现「窗口缩了但裁切没跟上」的条状残影。 */
+.island.is-docked {
+  background: #000;
+  border-radius: 0;
+}
+
+/* 拖动中的小方块没有贴边关系，用普通圆角 */
+.island.is-dock-dragging {
+  clip-path: none !important;
+  border-radius: 14px;
+}
+
+/* 阴影只朝屏幕内侧投，不能往贴边那一侧糊。
+ * 四周均匀的大模糊阴影会在黑色形状外糊出一圈暗晕，浅色背景下看起来就像
+ * 四角都是圆的、而且和屏幕边缘之间还有条缝 —— 贴边那侧必须是干净的直边。 */
+.island.is-dock-dragging {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+/* 拖动中的小方块 */
+.island.is-dock-dragging {
+  border-radius: 14px;
+}
+
+
+
+
+
+/* 抓取区：只占贴边那一侧、宽度等于收起态竖条的那条带子。
+ *
+ * 不能盖住整个面板 —— 悬停就会展开，手一放上去面板已经是 380×620，
+ * 若整块都是抓取区，就等于「永远抓在面板上」，既拖不动也点不了面板内容。
+ * 收窄成边缘带子后：带子上按下 = 拖动，面板其余部分照常交互。 */
+.island-drag-handle {
+  position: absolute;
+  z-index: 5;
+  cursor: grab;
+}
+
+.island-drag-handle:active {
+  cursor: grabbing;
+}
+
+.island-drag-handle.is-dock-right {
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 40px;
+}
+
+.island-drag-handle.is-dock-left {
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 40px;
+}
+
+.island-drag-handle.is-dock-top {
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 46px;
+}
+
+/* 拖动中是小方块，整块都能拖 */
+.island-drag-handle.is-dragging {
+  inset: 0;
+  width: auto;
+  height: auto;
+}
+
+/* ── 竖条收起态内容：只留头像，整体居中 ─────────────────────────────────
+ * 竖条只有 40pt 宽，胶囊那排「头像 + 标题 + 计时 + 按钮」放不下。
+ * 定位由 JSX 按主进程下发的条几何内联给出，这里只管内容排布。 */
+/* 左右竖条：40pt 宽放不下整排胶囊内容 —— 竖向排布，头像 + 状态点。
+ * 顶部横条保留原本胶囊的标题与状态。 */
+
+/* 顶条：两端内凹弧线各占 14pt，形状主体比胶囊层窄一圈 ——
+ * 内边距必须让开，否则头像会悬在弧线外面。右侧再多留出状态点的位置。 */
+.island.is-dock-top.is-dock-strip .pill {
+  padding: 0 40px 0 26px;
+}
+
+.island.is-dock-top.is-dock-strip .pill-label {
+  display: none;
+}
+
+
+/* 两个方向的收起态内容完全镜像：头像(距起点 26) → 数量 → 状态点(距终点 18)。
+ * 文字一律不显示 —— 窄条里截断的文字只是噪音，数量 + 状态点已足够。 */
+.island.is-dock-left.is-dock-strip .pill,
+.island.is-dock-right.is-dock-strip .pill {
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 26px 0 0;
+  gap: 10px;
+}
+
+.island.is-dock-left.is-dock-strip .pill-label,
+.island.is-dock-right.is-dock-strip .pill-label {
+  display: none;
+}
+
+.island.is-dock-left.is-dock-strip .pill-right,
+.island.is-dock-right.is-dock-strip .pill-right {
+  margin-left: 0;
+}
+
+/* 拖动中的小方块同样只显示头像 */
+.island.is-dock-dragging .pill {
+  justify-content: center;
+  padding: 0;
+  gap: 0;
+}
+
+.island.is-dock-dragging .pill-label,
+.island.is-dock-dragging .pill-right {
+  display: none;
+}
+
+/* ── 侧边窄幅面板排版 ──────────────────────────────────────────────────────
+ * 面板层占满 380 宽的窗口，内部按窄幅重排。会话行自身已有 min-width:0 +
+ * ellipsis，会自适应；需要动的是那些按 680+ 宽度设计的横向排布。 */
+
+/* 顶栏：配额格子和按钮组允许换行，行高放开 */
+.island-panel-layer.is-side-dock .usage-row {
+  flex-wrap: wrap;
+  /* 左右各让开 20px：贴边侧顶端有 14px 的内凹弧线，12px 内边距会让
+   * 顶栏最外侧的按钮被弧线削掉一角 */
+  padding: 8px 20px;
+  row-gap: 4px;
+  min-height: 0 !important;
+  height: auto;
+}
+
+.island-panel-layer.is-side-dock .usage-row-agents {
+  flex-basis: 100%;
+  overflow-x: auto;
+}
+
+.island-panel-layer.is-side-dock .usage-row-actions {
+  margin-left: auto;
+}
+
+/* 会话行：标题与元信息改为上下两行，不再左右争宽度 */
+.island-panel-layer.is-side-dock .session-headline {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.island-panel-layer.is-side-dock .session-meta {
+  margin-left: 0;
+}
+
+/* 提示语与活动行给窄幅多留点行数 */
+.island-panel-layer.is-side-dock .session-prompt,
+.island-panel-layer.is-side-dock .session-activity {
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* 审批按钮组窄幅下允许换行 */
+.island-panel-layer.is-side-dock .approval-actions {
+  flex-wrap: wrap;
+}
+
+
+/* ── 竖条状态点 ───────────────────────────────────────────────────────────
+ * 相位配色与面板一致：running 蓝 / completed 绿 / 待批准橙 / 待回答黄。
+ * 挂在胶囊层内、头像下方；待处理相位加呼吸提醒。 */
+.dock-status-dot {
+  position: absolute;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #5c564b;
+  pointer-events: none;
+}
+
+.dock-status-dot.is-running {
+  background: #6E9FFF;
+}
+
+.dock-status-dot.is-completed {
+  background: var(--isl-ok);
+}
+
+.dock-status-dot.is-waitingForApproval {
+  background: #FF9F0A;
+}
+
+.dock-status-dot.is-waitingForAnswer {
+  background: #FFD60A;
+}
+
+/* 顶条的状态点靠右垂直居中（竖条则是底部水平居中） */
+.dock-status-dot.dock-dot-top {
+  left: auto;
+  right: 18px;
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* 呼吸只动透明度：transform 由各方位的定位持有，动画不能覆盖它 */
+@keyframes dock-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.dock-status-dot.is-waitingForApproval,
+.dock-status-dot.is-waitingForAnswer {
+  animation: dock-dot-pulse 1.2s ease-in-out infinite;
 }

--- a/src/renderer/island/app.css
+++ b/src/renderer/island/app.css
@@ -699,6 +699,14 @@ body {
  * ellipsis，会自适应；需要动的是那些按 680+ 宽度设计的横向排布。 */
 
 /* 顶栏：配额格子和按钮组允许换行，行高放开 */
+/* 侧边面板兜底：内容永远不越出窗口。用纯 CSS 而不是内联高度 + React 状态：
+ * panelLayerRef 的 ResizeObserver 挂在同一元素上，经 React 的高度反馈有成环
+ * 风险（实测 #185 爆栈）。 */
+.island-panel-layer.is-side-dock {
+  max-height: 100%;
+  overflow: hidden;
+}
+
 .island-panel-layer.is-side-dock .usage-row {
   flex-wrap: wrap;
   /* 左右各让开 20px：贴边侧顶端有 14px 的内凹弧线，12px 内边距会让

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -6,6 +6,7 @@ import { c as create } from "../vendor/store.js";
 import { I as IslandPanel } from "./components/IslandPanel.js";
 import { isVisibleInIsland } from "./session-model.mjs";
 import { resolveFocusLossPresentation, shouldCollapseOnFocusLoss } from "./focus-policy.mjs";
+import { b as buildDockClipPath } from "./dock-shape.js";
 const useSessionStore = create((set) => ({
   sessions: [],
   notchInfo: window.islandBridge?.__initialNotchInfo ?? DEFAULT_NOTCH_INFO,
@@ -101,7 +102,12 @@ const WINDOW_H = 750;
 const HOVER_OPEN_DELAY_MS = 200;
 const MOUSE_LEAVE_CLOSE_DELAY_MS = 300;
 const CLOSE_WINDOW_RESIZE_DELAY_MS = 300;
+// 唤醒热区在胶囊两侧各留的容错余量（pt）。
+const HOTSPOT_SIDE_PADDING_PX = 48;
 const OPEN_WINDOW_SHADOW_MARGIN_PX = 32;
+// 贴边轮廓：与屏幕边缘相接处的内凹半径，以及自由端的凸圆角半径。
+const DOCK_CONCAVE_R = 14;
+const DOCK_CONVEX_R = 14;
 function IslandApp() {
   useIslandState();
   const {
@@ -124,6 +130,56 @@ function IslandApp() {
   const { notchStatus, transitionClass, isPopping, open, close } = useIslandAnimation();
   const panelLayerRef = reactExports.useRef(null);
   const [panelHeight, setPanelHeight] = reactExports.useState(300);
+  // dock 状态完全由主进程给定：{placement, edge, mode}。
+  // 渲染层不自行推断形状 —— 窗口尺寸和这里画的形状必须同源，
+  // 各算各的正是此前「看不见 / 长条 / 竖侧边栏」的共同成因。
+  const [dock, setDock] = reactExports.useState({ placement: "notch", edge: "right", mode: "notch" });
+  reactExports.useEffect(() => {
+    window.islandBridge?.onPlacement?.((d) => d && setDock(d));
+    // 主动拉一次：did-finish-load 的补发与 React 挂载之间仍有空隙，
+    // 落在空隙里的那一次推送会丢。
+    void window.islandBridge?.getPlacement?.().then((d) => d && setDock(d)).catch(() => {});
+  }, []);
+  const isDocked = dock.placement === "docked";
+  const isSideDock = isDocked && dock.edge !== "top";
+  const isDragging = isDocked && dock.mode === "dragging";
+  const [winSize, setWinSize] = reactExports.useState([window.innerWidth, window.innerHeight]);
+  reactExports.useEffect(() => {
+    const onResize = () => setWinSize([window.innerWidth, window.innerHeight]);
+    window.addEventListener("resize", onResize);
+    onResize();
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+  // 主进程一旦进入拖动形态，渲染层必须同步收起：窗口已经缩成 56×56 小方块，
+  // 若渲染层还在画展开面板，就又回到了「窗口与形状不同源」的老问题。
+  // Command + 拖动 = 移动贴边岛。
+  // 用 window 捕获阶段监听，而不是铺一层覆盖 div：覆盖层会连带吃掉面板内部的
+  // 点击，正是前两版「拖不动又点不了」的成因。按住 Command 才拦截，其余情况
+  // 事件原样流向面板内容。
+  reactExports.useEffect(() => {
+    if (!isDocked) return;
+    const onDown = (e) => {
+      if (!e.metaKey) return;
+      e.preventDefault();
+      e.stopPropagation();
+      window.islandBridge?.dragStart?.();
+      const onUp = () => {
+        window.removeEventListener("mouseup", onUp, true);
+        window.islandBridge?.dragEnd?.();
+      };
+      window.addEventListener("mouseup", onUp, true);
+    };
+    window.addEventListener("mousedown", onDown, true);
+    return () => window.removeEventListener("mousedown", onDown, true);
+  }, [isDocked]);
+  reactExports.useEffect(() => {
+    if (!isDragging) return;
+    if (hoverOpenTimer.current) {
+      clearTimeout(hoverOpenTimer.current);
+      hoverOpenTimer.current = null;
+    }
+    useSessionStore.getState().requestCollapse();
+  }, [isDragging]);
   const [mounted, setMounted] = reactExports.useState(false);
   const autoCollapseTimer = reactExports.useRef(null);
   const attentionNotifTimer = reactExports.useRef(null);
@@ -476,7 +532,13 @@ function IslandApp() {
     }
     if (notchStatus === "opened" || transitionClass === "is-opening") {
       bridge.resizeWindow(maxExpandedWindowHeight);
-      return void 0;
+      // 兜底：展开动画结束后再确认一次高度。
+      // 若有迟到的收起同步在 PANEL_EXPANDED 之前把窗口压矮了，这里会把它拉回来；
+      // 否则本 effect 在面板稳定展开后不再重跑，窗口会一直卡在收起高度上。
+      const confirm = setTimeout(() => {
+        bridge.resizeWindow(maxExpandedWindowHeight);
+      }, 340);
+      return () => clearTimeout(confirm);
     }
     const delay = transitionClass === "is-closing" ? CLOSE_WINDOW_RESIZE_DELAY_MS : 0;
     resizeWindowTimerRef.current = setTimeout(() => {
@@ -505,8 +567,57 @@ function IslandApp() {
     topRadius: openedTopR,
     windowWidth: WINDOW_W
   });
-  const clipPath = mounted ? isOpen ? openedShape.clipPath : closedShape.clipPath : closedShape.clipPath;
+  const notchClip = mounted ? isOpen ? openedShape.clipPath : closedShape.clipPath : closedShape.clipPath;
+  // 贴边态的两个形状：条形与面板形，同一（面板大小的）窗口坐标系下生成，
+  // 路径指令结构一致，CSS clip-path 过渡可以直接插值 —— 形变全在渲染层，
+  // 窗口 bounds 不动，这正是刘海模式丝滑的原因。
+  const dockClips = reactExports.useMemo(() => {
+    if (!isDocked || isDragging || !dock.strip) return null;
+    const [w, h] = winSize;
+    const top = dock.edge === "top";
+    const span = top ? w : h;
+    const strip = buildDockClipPath({
+      edge: dock.edge,
+      winW: w,
+      winH: h,
+      bodyLen: Math.max(0, dock.strip.len - 2 * DOCK_CONCAVE_R),
+      depth: dock.strip.depth,
+      concaveR: DOCK_CONCAVE_R,
+      convexR: DOCK_CONVEX_R,
+      spanStart: dock.strip.spanOffset
+    });
+    const panelDepth = top ? Math.min(actualPanelH + 8, h) : w;
+    // 侧边面板的纵向跨度跟随内容高度：内容短时不至于拖一大块空黑到屏幕下方。
+    const panelSpan = top ? span : Math.max(dock.strip.len, Math.min(panelHeight + 16, span));
+    const panel = buildDockClipPath({
+      edge: dock.edge,
+      winW: w,
+      winH: h,
+      bodyLen: Math.max(0, panelSpan - 2 * DOCK_CONCAVE_R),
+      depth: panelDepth,
+      concaveR: DOCK_CONCAVE_R,
+      convexR: DOCK_CONVEX_R,
+      spanStart: 0
+    });
+    return { strip, panel };
+  }, [isDocked, isDragging, dock, winSize, actualPanelH, panelHeight]);
+  const clipPath = isDocked
+    ? isDragging ? "none" : dockClips ? (mounted && isOpen ? dockClips.panel : dockClips.strip) : "none"
+    : notchClip;
   const transition = mounted ? transitionClass : "";
+  /**
+   * 全宽热区的进入处理：只负责「唤醒」，不负责「展开」。
+   *
+   * 两件事必须分开：唤醒是把隐身的胶囊显形，热区应该宽松；展开是打开整个面板，
+   * 必须精确命中胶囊本体。若热区复用 handleMouseEnter，它里面的 hoverToOpen 分支
+   * 会让鼠标扫过屏幕顶部就展开面板 —— 用菜单栏时会被反复误触发。
+   */
+  const handleHotspotEnter = reactExports.useCallback(() => {
+    window.islandBridge?.enterIsland();
+  }, []);
+  const handleHotspotLeave = reactExports.useCallback(() => {
+    window.islandBridge?.leaveIsland();
+  }, []);
   const handleMouseEnter = reactExports.useCallback((e) => {
     if (mouseLeaveCloseTimer.current) {
       clearTimeout(mouseLeaveCloseTimer.current);
@@ -530,7 +641,7 @@ function IslandApp() {
         open();
       }, HOVER_OPEN_DELAY_MS);
     }
-  }, [hoverToOpen, notchStatus, open, presentSurface, surface]);
+  }, [hoverToOpen, notchStatus, open, presentSurface, surface, isDocked]);
   const handleMouseLeave = reactExports.useCallback(() => {
     if (hoverOpenTimer.current) {
       clearTimeout(hoverOpenTimer.current);
@@ -620,7 +731,9 @@ function IslandApp() {
   return /* @__PURE__ */ React.createElement(
     "div",
     {
-      className: `island-pop-wrapper${isPopping ? " is-popping" : ""}${isOpen || transitionClass === "is-opening" ? " is-open" : ""}`,
+      // is-morphing：形变进行中。用它在动画期间摘掉 wrapper 上的 drop-shadow，
+      // 否则每一帧 clip-path 变化都要把整个窗口大小的子树重新栅格化再模糊一次。
+      className: `island-pop-wrapper${isPopping ? " is-popping" : ""}${isOpen || transitionClass === "is-opening" ? " is-open" : ""}${transitionClass === "is-opening" || transitionClass === "is-closing" ? " is-morphing" : ""}`,
       style: { position: "fixed", inset: 0, pointerEvents: "none" }
     },
     /* @__PURE__ */ React.createElement(
@@ -634,10 +747,29 @@ function IslandApp() {
         }
       }
     ),
+    // 全宽隐形唤醒热区。
+    // 此前整个窗口里只有 .island 是 pointer-events:auto，而它被 clip-path 裁成了
+    // 胶囊轮廓 —— 于是唤醒热区恰好等于胶囊的可见轮廓，必须精确命中才有反应。
+    // 主进程那侧其实早就把窗口铺满屏幕宽度并 setIgnoreMouseEvents(false) 了，
+    // 缺的只是渲染层没有对应的可命中区域。展开后撤掉，避免挡住面板自身的交互。
+    // notch 下才需要顶部隐形唤醒热区；贴边态是常驻可见的，不需要。
+    !isDocked && !isOpen && /* @__PURE__ */ React.createElement(
+      "div",
+      {
+        className: "island-hotspot",
+        // 胶囊宽度 + 两侧各 48pt 容错。之前是铺满窗口（740pt，约占屏宽一半）。
+        style: {
+          width: pillWidth + HOTSPOT_SIDE_PADDING_PX * 2,
+          height: Math.max(notchH, 24)
+        },
+        onMouseEnter: handleHotspotEnter,
+        onMouseLeave: handleHotspotLeave
+      }
+    ),
     /* @__PURE__ */ React.createElement(
       "div",
       {
-        className: `island ${transition}`,
+        className: `island ${transition}${isDocked ? ` is-docked is-dock-${dock.edge} is-dock-${dock.mode}` : ""}`,
         style: { clipPath },
         onMouseEnter: handleMouseEnter,
         onMouseLeave: handleMouseLeave
@@ -646,8 +778,28 @@ function IslandApp() {
         "div",
         {
           className: `island-pill-layer${isOpen ? " is-hidden" : ""}`,
-          style: { width: pillWidth, height: notchH }
+          style: isDocked
+            ? isDragging
+              ? { left: 0, top: 0, transform: "none", width: "100%", height: "100%" }
+              : dock.edge === "top"
+                ? { left: dock.strip?.spanOffset ?? 0, top: 0, transform: "none", width: dock.strip?.len ?? 160, height: dock.strip?.depth ?? 44 }
+                : {
+                    left: dock.edge === "left" ? 0 : "auto",
+                    right: dock.edge === "right" ? 0 : "auto",
+                    top: dock.strip?.spanOffset ?? 0,
+                    transform: "none",
+                    width: dock.strip?.depth ?? 44,
+                    height: dock.strip?.len ?? 160
+                  }
+            : { width: pillWidth, height: notchH }
         },
+        isDocked && !isDragging && /* @__PURE__ */ React.createElement(
+          "div",
+          {
+            className: `dock-status-dot is-${phase ?? "idle"} dock-dot-${dock.edge}`,
+            title: phase ?? "idle"
+          }
+        ),
         /* @__PURE__ */ React.createElement(
           IslandPill,
           {
@@ -666,8 +818,10 @@ function IslandApp() {
         "div",
         {
           ref: panelLayerRef,
-          className: `island-panel-layer${isOpen ? "" : " is-hidden"}`,
-          style: { width: panelWidth }
+          className: `island-panel-layer${isOpen ? "" : " is-hidden"}${isSideDock ? " is-side-dock" : ""}`,
+          style: isSideDock
+            ? { left: 0, transform: "none", width: winSize[0] }
+            : { width: panelWidth }
         },
         /* @__PURE__ */ React.createElement(
           IslandPanel,

--- a/src/renderer/island/dock-shape.js
+++ b/src/renderer/island/dock-shape.js
@@ -30,9 +30,14 @@ function buildDockClipPath({ edge, winW, winH, bodyLen, depth, concaveR, convexR
   // 沿边方向的总跨度 = 本体 + 两端各一个内凹半径
   const span = edge === "top" ? winW : winH;
   const outer = Math.min(bodyLen + 2 * concaveR, span);
-  const u0 = spanStart == null
+  let u0 = spanStart == null
     ? (span - outer) / 2
     : Math.max(0, Math.min(spanStart, span - outer));
+  // 左边缘的旋转映射是 (u,v) → [v, H-u]，u 轴方向被翻转 —— 调用方传入的
+  // spanStart 语义是「距窗口顶部」，这里补一次翻转，否则形状会落到窗口底部、
+  // 与胶囊层（按顶部定位）分家：左侧贴边就只剩一块空黑。形状沿边对称，
+  // 翻转起点即完成整体镜像。
+  if (edge === "left") u0 = span - u0 - outer;
   const u1 = u0 + outer;
   const cR = Math.min(concaveR, outer / 4, depth / 4);
   const vR = Math.min(convexR, outer / 4, depth / 2);

--- a/src/renderer/island/dock-shape.js
+++ b/src/renderer/island/dock-shape.js
@@ -1,0 +1,54 @@
+// 贴边形态的裁切路径。
+//
+// 复用刘海那套「贴边侧内凹、自由端凸圆角」的轮廓：与屏幕边缘相接处用一段反向
+// 弧线（sweep=0），看起来像是从边缘长出来的，而不是一块贴上去的圆角矩形。
+//
+// 路径先写在「沿边 u / 深度 v」坐标系里，再按边做 90° 旋转映射到窗口坐标。
+// 旋转是正交变换（行列式为 1），所以弧线的 sweep 标志无需改动即可保持方向。
+const MAP = {
+  // (u 沿边, v 深度) → (x, y)
+  top: (u, v) => [u, v],
+  right: (u, v, W) => [W - v, u],
+  left: (u, v, W, H) => [v, H - u]
+};
+
+/**
+ * @param edge      "top" | "left" | "right"
+ * @param winW/winH 窗口尺寸
+ * @param bodyLen   本体沿边方向的长度（不含两端内凹外扩的部分）
+ * @param depth     本体垂直于边的深度
+ * @param concaveR  贴边侧内凹半径
+ * @param convexR   自由端凸圆角半径
+ * @param spanStart 形状沿边方向的起点（窗口内坐标）；缺省时居中
+ */
+function buildDockClipPath({ edge, winW, winH, bodyLen, depth, concaveR, convexR, spanStart }) {
+  const map = MAP[edge] ?? MAP.top;
+  const p = (u, v) => {
+    const [x, y] = map(u, v, winW, winH);
+    return `${Math.round(x * 100) / 100},${Math.round(y * 100) / 100}`;
+  };
+  // 沿边方向的总跨度 = 本体 + 两端各一个内凹半径
+  const span = edge === "top" ? winW : winH;
+  const outer = Math.min(bodyLen + 2 * concaveR, span);
+  const u0 = spanStart == null
+    ? (span - outer) / 2
+    : Math.max(0, Math.min(spanStart, span - outer));
+  const u1 = u0 + outer;
+  const cR = Math.min(concaveR, outer / 4, depth / 4);
+  const vR = Math.min(convexR, outer / 4, depth / 2);
+  const d = depth;
+  return `path('${[
+    `M ${p(u0, 0)}`,
+    `L ${p(u1, 0)}`,
+    `A ${cR},${cR} 0 0,0 ${p(u1 - cR, cR)}`,      // 贴边侧内凹
+    `L ${p(u1 - cR, d - vR)}`,
+    `A ${vR},${vR} 0 0,1 ${p(u1 - cR - vR, d)}`,  // 自由端凸角
+    `L ${p(u0 + cR + vR, d)}`,
+    `A ${vR},${vR} 0 0,1 ${p(u0 + cR, d - vR)}`,
+    `L ${p(u0 + cR, cR)}`,
+    `A ${cR},${cR} 0 0,0 ${p(u0, 0)}`,            // 贴边侧内凹
+    "Z"
+  ].join(" ")}')`;
+}
+
+export { buildDockClipPath as b };

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -122,6 +122,7 @@ function generalPage() {
   const behavior = section("Island 行为", "控制灵动岛何时出现以及如何收起。");
   behavior.append(
     row("登录时启动", "开机登录后自动启动 WorkIsland。", toggle(state.settings.launchAtLogin, v => save({ launchAtLogin: v }), "登录时启动")),
+    row("贴边模式", "脱离顶部刘海，变成可拖动的贴边条：拖动时收成小方块，松手吸附到最近的边（上/左/右）。贴左右时是竖条、展开为竖长面板；贴顶部时是横条。", toggle(state.settings.islandPlacement === "docked", v => save({ islandPlacement: v ? "docked" : "notch" }), "贴边模式")),
     row("悬停展开", "鼠标停留在 Island 上时展开面板。", toggle(state.settings.hoverToOpen, v => save({ hoverToOpen: v }), "悬停展开")),
     row("失去焦点后隐藏", "失去窗口焦点后隐藏 Island；鼠标移到顶部热区可恢复。", toggle(state.settings.autoCollapseOnMouseLeave, v => save({ autoCollapseOnMouseLeave: v }), "失去焦点后隐藏")),
     row("全屏时隐藏", "全屏应用位于当前屏幕时隐藏 Island。", toggle(state.settings.hideWhenFullscreen, v => save({ hideWhenFullscreen: v }), "全屏时隐藏")),

--- a/src/shared/ipc.cjs
+++ b/src/shared/ipc.cjs
@@ -24,6 +24,11 @@ const IPC = Object.freeze({
   ISLAND_WINDOW_BLUR: "island:window-blur",
   ISLAND_FOCUS_LOSS_HIDE: "island:focus-loss-hide",
   ISLAND_SYNC_CLOSED_WINDOW: "island:sync-closed-window",
+  // floating 模式拖动：渲染层按下并上报位移，主进程移动窗口；松手时贴边吸附。
+  ISLAND_DRAG_START: "island:drag-start",
+  ISLAND_DRAG_END: "island:drag-end",
+  ISLAND_PLACEMENT: "island:placement",
+  ISLAND_GET_PLACEMENT: "island:get-placement",
   ISLAND_DRAG_TO_PET: "island:drag-to-pet",
   ISLAND_TODAY_BURN_UPDATE: "island:today-burn-update",
   ISLAND_RESIZE: "island:resize",

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -75,6 +75,10 @@ const DEFAULT_SETTINGS = {
     events: { ...DEFAULT_SOUND_EVENTS },
     autoDetectProbing: false
   },
+  // 灵动岛落位：notch = 顶部刘海居中（原有形态）；docked = 贴边（上/左/右）。
+  islandPlacement: "notch",
+  // 贴边状态：edge 为所贴的边，offset 是沿边位置的 0-1 比例（跨分辨率仍成立）。
+  islandDock: { edge: "right", offset: 0.25 },
   hoverToOpen: true,
   autoCollapseDelayMs: 4e3,
   hideWhenFullscreen: true,


### PR DESCRIPTION
## 内容

灵动岛新增第二种落位：脱离顶部刘海，作为贴边条停靠在屏幕**上/左/右**缘（不支持底部，避让 Dock）。设置 → Island 行为新增「贴边模式」开关，运行时即时生效。

## 核心设计

**窗口在贴边生命周期内固定为面板大小，条↔面板切换全部由渲染层 clip-path 形变完成**——与刘海模式同构。空闲时窗口对鼠标穿透（下方应用照常点击），悬停到条上才接管交互；窗口 bounds 只在拖动与吸附换边时变化。

主进程持有唯一 dock 状态（edge / mode / 条几何），渲染层只照着画。曾试过主进程逐帧 setBounds 做动画、渲染层异步追尺寸——两边永远差几帧，各种撕裂残影；同源化之后一次成立。

- **Command + 按住任意位置拖动**：收成小方块跟手，松手一定吸附最近的边；位置以 0-1 比例持久化，跨分辨率有效
- 贴边侧内凹过渡：复用刘海的轮廓语言，路径按边做 90° 旋转映射（正交变换，弧线 sweep 不变）
- 条内容两方向镜像：头像(距起点26) → 会话数 → 状态点(距终点18)；状态点相位配色：运行蓝 / 完成绿 / 待批准橙(呼吸) / 待回答黄(呼吸)
- 侧边展开为 380 宽竖长面板，上沿对齐条位向下铺出
- 附带两个独立交互修复：顶部隐身热区不再吞菜单栏点击（穿透 + 主进程光标轮询）；唤醒热区从全宽收窄到胶囊±48pt

## 已知边界

- 竖长面板的窄幅排版为初版（顶栏换行、会话行两行制、提示语两行截断），复杂卡片（diff/审批）未逐一调优
- windows.cjs 含 `WORKISLAND_CAPTURE=1` 环境变量门控的渲染帧抓取（外部截屏工具抓不到面板级窗口，这是唯一可用的渲染验证手段），默认不运行
- `ISLAND_DRAG_MOVE` 通道已声明未使用（拖动改为主进程光标轮询后不再需要），留作接口

## 验证

在 2560×1600 无刘海屏实测：三边吸附/形变展开收起/Command 拖动/状态点相位/位置持久化均正常；条形与面板轮廓经渲染帧逐像素校验（贴边侧直角、内凹过渡、单侧阴影）。

## 备注

与 #3 都改了 settings-app.js，分属不同 section，预计无冲突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)