### PR TITLE
Internal beta: targeted Island and pet notifications

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       CSC_LINK: ${{ secrets.CSC_LINK }}
       CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
       CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.CSC_LINK != '' && 'true' || 'false' }}
-      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+      APPLE_API_KEY_CONTENT: ${{ secrets.APPLE_API_KEY }}
       APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
       APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
     steps:
@@ -30,6 +30,21 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/v')
         run: test "${GITHUB_REF_NAME#v}" = "$(node -p "require('./package.json').version")"
       - run: npm ci
+      - name: Require release credentials
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          test -n "${CSC_LINK:-}"
+          test -n "${CSC_KEY_PASSWORD:-}"
+          test -n "${APPLE_API_KEY_CONTENT:-}"
+          test -n "${APPLE_API_KEY_ID:-}"
+          test -n "${APPLE_API_ISSUER:-}"
+      - name: Prepare notarization key
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          notary_key_path="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_API_KEY_CONTENT" > "$notary_key_path"
+          chmod 600 "$notary_key_path"
+          echo "APPLE_API_KEY=$notary_key_path" >> "$GITHUB_ENV"
       - name: Package macOS DMG
         # An unset CSC_LINK must stay unset. electron-builder treats an empty
         # CSC_LINK as the project directory and then reports "not a file".
@@ -39,6 +54,22 @@ jobs:
           else
             env -u CSC_LINK npm run package:mac
           fi
+      - name: Notarize and staple tagged release
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          xcrun notarytool submit release/*.dmg --key "$APPLE_API_KEY" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_API_ISSUER" --wait
+          xcrun stapler staple release/*.dmg
+          xcrun stapler validate release/*.dmg
+          rm -f "$APPLE_API_KEY"
+      - name: Verify signed release artifact
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          verify_mount="$(mktemp -d)"
+          hdiutil attach -readonly -nobrowse -mountpoint "$verify_mount" release/*.dmg
+          codesign --verify --deep --strict --verbose=4 "$verify_mount/WorkIsland.app"
+          spctl --assess --type execute --verbose=4 "$verify_mount/WorkIsland.app"
+          hdiutil detach "$verify_mount"
+          rmdir "$verify_mount"
       - name: Generate checksums
         run: shasum -a 256 release/*.dmg > release/SHA256SUMS.txt
       - uses: actions/upload-artifact@v4

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+</dict>
+</plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workisland",
-  "version": "0.2.8-beta.1",
+  "version": "0.2.8-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workisland",
-      "version": "0.2.8-beta.1",
+      "version": "0.2.8-beta.2",
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/utils": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workisland",
-  "version": "0.2.8-beta.3",
+  "version": "0.2.8-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workisland",
-      "version": "0.2.8-beta.3",
+      "version": "0.2.8-beta.4",
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/utils": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workisland",
-  "version": "0.2.6",
+  "version": "0.2.8-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workisland",
-      "version": "0.2.6",
+      "version": "0.2.8-beta.1",
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/utils": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workisland",
-  "version": "0.2.8-beta.2",
+  "version": "0.2.8-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workisland",
-      "version": "0.2.8-beta.2",
+      "version": "0.2.8-beta.3",
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/utils": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workisland",
   "productName": "WorkIsland",
-  "version": "0.2.7",
+  "version": "0.2.8-beta.1",
   "description": "macOS 本地 Work Agent 工作状态与注意力路由器",
   "private": true,
   "main": "./src/main/index.cjs",
@@ -96,7 +96,14 @@
         }
       ],
       "category": "public.app-category.productivity",
-      "icon": "resources/icon.icns"
+      "icon": "resources/icon.icns",
+      "hardenedRuntime": true,
+      "entitlements": "build/entitlements.mac.plist",
+      "entitlementsInherit": "build/entitlements.mac.plist",
+      "signIgnore": [
+        "/Resources/.*\\.lproj/",
+        "\\.(pak|png|webp|wav|json|icns|dat|bin)$"
+      ]
     },
     "dmg": {
       "title": "WorkIsland"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workisland",
   "productName": "WorkIsland",
-  "version": "0.2.8-beta.2",
+  "version": "0.2.8-beta.3",
   "description": "macOS 本地 Work Agent 工作状态与注意力路由器",
   "private": true,
   "main": "./src/main/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workisland",
   "productName": "WorkIsland",
-  "version": "0.2.8-beta.3",
+  "version": "0.2.8-beta.4",
   "description": "macOS 本地 Work Agent 工作状态与注意力路由器",
   "private": true,
   "main": "./src/main/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workisland",
   "productName": "WorkIsland",
-  "version": "0.2.8-beta.1",
+  "version": "0.2.8-beta.2",
   "description": "macOS 本地 Work Agent 工作状态与注意力路由器",
   "private": true,
   "main": "./src/main/index.cjs",

--- a/scripts/test-source.mjs
+++ b/scripts/test-source.mjs
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "nod
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { deriveDragDirection, derivePetBubble, derivePetStatus, statusToIntervalMs, statusToRow } from "../src/renderer/pet/model.mjs";
-import { canContinueSessionViaTerminalPrompt, isVisibleInIsland, sortVisibleSessions } from "../src/renderer/island/session-model.mjs";
+import { canContinueSessionViaTerminalPrompt, filterSurfaceSessions, isVisibleInIsland, sortVisibleSessions } from "../src/renderer/island/session-model.mjs";
 
 const require = createRequire(import.meta.url);
 const { IPC } = require("../src/shared/ipc.cjs");
@@ -110,6 +110,8 @@ const visibleSession = { id: "visible", isHookManaged: true, latestUserPrompt: "
 assert.equal(isVisibleInIsland(visibleSession), true);
 assert.equal(isVisibleInIsland({ parentSessionId: "parent", phase: "waitingForApproval" }), false);
 assert.deepEqual(sortVisibleSessions([{ ...visibleSession, id: "old", updatedAt: 1 }, visibleSession]).map(({ id }) => id), ["visible", "old"]);
+assert.deepEqual(filterSurfaceSessions([{ id: "a" }, { id: "b" }], { visibleSessionIds: ["b"] }).map(({ id }) => id), ["b"]);
+assert.deepEqual(filterSurfaceSessions([{ id: "a" }], null).map(({ id }) => id), ["a"]);
 assert.equal(canContinueSessionViaTerminalPrompt({ phase: "completed", tool: "codex", jumpTarget: { app: "Terminal", tty: "/dev/ttys001" } }), true);
 assert.equal(canContinueSessionViaTerminalPrompt({ phase: "completed", tool: "codex", jumpTarget: { app: "Terminal", tty: "/dev/ttys001", remote: true } }), false);
 assert.equal(mainSessionPolicy.canContinueSessionViaTerminalPrompt({ phase: "completed", tool: "codex", jumpTarget: { app: "Terminal", tty: "/dev/ttys001", remote: true } }), false);

--- a/scripts/test-source.mjs
+++ b/scripts/test-source.mjs
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { derivePetBubble, derivePetStatus, statusToIntervalMs, statusToRow } from "../src/renderer/pet/model.mjs";
+import { deriveDragDirection, derivePetBubble, derivePetStatus, statusToIntervalMs, statusToRow } from "../src/renderer/pet/model.mjs";
 import { canContinueSessionViaTerminalPrompt, isVisibleInIsland, sortVisibleSessions } from "../src/renderer/island/session-model.mjs";
 
 const require = createRequire(import.meta.url);
@@ -99,6 +99,11 @@ assert.equal(statusToRow("drag"), 6);
 assert.equal(statusToRow("running", { protocol: "codex-v2" }), 7);
 assert.equal(statusToRow("complete", { protocol: "codex-v2" }), 8);
 assert.equal(statusToRow("drag", { protocol: "codex-v2" }), 1);
+assert.equal(statusToRow("drag", { protocol: "codex-v2" }, "right"), 1);
+assert.equal(statusToRow("drag", { protocol: "codex-v2" }, "left"), 2);
+assert.equal(deriveDragDirection(4, "left"), "right");
+assert.equal(deriveDragDirection(-4, "right"), "left");
+assert.equal(deriveDragDirection(0, "left"), "left");
 assert.equal(statusToIntervalMs("running"), 120);
 
 const visibleSession = { id: "visible", isHookManaged: true, latestUserPrompt: "hello", updatedAt: 2 };

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -21,6 +21,7 @@ const { ZCodeHookManager, WorkBuddyHookManager } = require("./hooks-work-agents.
 const { initSoundDirs, playSoundEvent } = require("./sound-service.cjs");
 const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens } = require("./adapters-extended.cjs");
 const { getAgentDescriptor, validateAgentWiring } = require("../shared/agent-catalog.cjs");
+const { selectAutomaticSurface } = require("./presentation-policy.cjs");
 
 function createAppCoordinatorClass({
   BridgeServer,
@@ -939,29 +940,12 @@ function createAppCoordinatorClass({
       this.onJumpStateChangeCallback?.(has);
     }
     maybePresentSurface(event) {
-      // sessionStarted（任务发出）和 sessionCompleted（任务结束）是用户明确要的
-      // 两个提醒节点，必须弹 surface 显示 5 秒。permissionRequested/questionAsked
-      // 是中间过程，保留原有门控。
-      const actionableTypes = ["sessionStarted", "permissionRequested", "questionAsked", "sessionCompleted"];
-      if (!actionableTypes.includes(event.type)) return;
-      if (event.type === "sessionStarted") {
-        if (!this.settings.expandOnSessionComplete) return;
-        // 合成的发现事件（transcript watcher 补的 sessionStarted）不弹通知，
-        // 避免与真实 hook 事件重复。
-        if (event.isSynthetic) return;
-      }
-      if (event.type === "sessionCompleted") {
-        if (!this.settings.expandOnSessionComplete) return;
-        if (event.isInterrupt) return;
-        if (event.isSessionEnd) return;
-        if (event.isRalphLoopIteration) return;
-      }
-      if ((event.type === "permissionRequested" || event.type === "questionAsked") && !this.settings.expandOnActionRequired)
-        return;
+      const surface = selectAutomaticSurface(event, this.settings);
+      if (!surface) return;
       // sessionStarted / sessionCompleted 跳过"聚焦时抑制"——用户要求这两个节点
       // 无条件提醒，即便正聚焦在发起任务的 app 里也要弹。仅 permission/question
       // 保留 suppress（中间过程，聚焦时不必打扰）。
-      const skipSuppress = event.type === "sessionStarted" || event.type === "sessionCompleted";
+      const skipSuppress = event.type === "sessionCompleted";
       if (!skipSuppress && this.settings.suppressNotificationWhenFocused) {
         const session = this.state.sessions.get(event.sessionId);
         const sessionBundleIds = session ? getSessionBundleIds(session) : [];
@@ -997,15 +981,13 @@ function createAppCoordinatorClass({
         );
         if (hasBlockingSession) return;
       }
-      if (event.type === "sessionCompleted") {
-      }
       this.broadcastSurface({
-        surface: { type: "sessionList", actionableSessionId: event.sessionId },
+        surface,
         reason: "notification"
       });
     }
     broadcastSurface(payload) {
-      if (this.petMode.isActive) {
+      if (this.petMode.isActive && payload.surface.type !== "completion") {
         const session = payload.surface.type === "sessionList" && payload.surface.actionableSessionId ? this.state.sessions.get(payload.surface.actionableSessionId) : void 0;
         const shouldCollapse = shouldAutoDismiss(payload.surface, session?.phase)
           && payload.reason === "notification"

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -21,7 +21,7 @@ const { ZCodeHookManager, WorkBuddyHookManager } = require("./hooks-work-agents.
 const { initSoundDirs, playSoundEvent } = require("./sound-service.cjs");
 const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens } = require("./adapters-extended.cjs");
 const { getAgentDescriptor, validateAgentWiring } = require("../shared/agent-catalog.cjs");
-const { selectAutomaticSurface } = require("./presentation-policy.cjs");
+const { createPresentationRequest } = require("./presentation-policy.cjs");
 
 function createAppCoordinatorClass({
   BridgeServer,
@@ -47,7 +47,6 @@ function createAppCoordinatorClass({
   unwatchActiveSpace,
   requiresAttention,
   canContinueSessionViaTerminalPrompt,
-  shouldAutoDismiss,
   findLatestCodexInterrupt,
   getSessionBundleIds,
   jumpToTarget,
@@ -940,14 +939,10 @@ function createAppCoordinatorClass({
       this.onJumpStateChangeCallback?.(has);
     }
     maybePresentSurface(event) {
-      const surface = selectAutomaticSurface(event, this.settings);
-      if (!surface) return;
-      // sessionStarted / sessionCompleted 跳过"聚焦时抑制"——用户要求这两个节点
-      // 无条件提醒，即便正聚焦在发起任务的 app 里也要弹。仅 permission/question
-      // 保留 suppress（中间过程，聚焦时不必打扰）。
-      const skipSuppress = event.type === "sessionCompleted";
-      if (!skipSuppress && this.settings.suppressNotificationWhenFocused) {
-        const session = this.state.sessions.get(event.sessionId);
+      const session = this.state.sessions.get(event.sessionId);
+      const request = createPresentationRequest({ ...event, error: event.error ?? session?.error }, this.settings);
+      if (!request) return;
+      if (request.suppressWhenFocused && this.settings.suppressNotificationWhenFocused) {
         const sessionBundleIds = session ? getSessionBundleIds(session) : [];
         const frontmostBundleId = getFrontmostAppBundleId();
         const appMatches = !!frontmostBundleId && sessionBundleIds.length > 0 && sessionBundleIds.includes(frontmostBundleId);
@@ -982,23 +977,20 @@ function createAppCoordinatorClass({
         if (hasBlockingSession) return;
       }
       this.broadcastSurface({
-        surface,
-        reason: "notification"
+        surface: request.surface,
+        reason: "notification",
+        autoDismiss: request.autoDismiss
       });
     }
     broadcastSurface(payload) {
       if (this.petMode.isActive) {
-        const session = (payload.surface.type === "sessionList" || payload.surface.type === "completion")
-          && payload.surface.actionableSessionId
-          ? this.state.sessions.get(payload.surface.actionableSessionId)
-          : void 0;
-        const shouldCollapse = shouldAutoDismiss(payload.surface, session?.phase)
-          && payload.reason === "notification"
-          && !Array.from(this.state.sessions.values()).some((s) => requiresAttention(s.phase));
         this.petMode.presentSurface(
           payload.surface,
-          shouldCollapse ? this.settings.completionPopupDurationSec * 1e3 : null
+          payload.autoDismiss ? this.settings.completionPopupDurationSec * 1e3 : null
         );
+        // A pet is the user's chosen primary surface. Keep the Island passive
+        // so one event never creates two competing full-screen interruptions.
+        return;
       }
       if (!this.islandWindow || this.islandWindow.isDestroyed()) return;
       if (this.islandHiddenForFullscreen && this.islandWin) {

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -987,8 +987,11 @@ function createAppCoordinatorClass({
       });
     }
     broadcastSurface(payload) {
-      if (this.petMode.isActive && payload.surface.type !== "completion") {
-        const session = payload.surface.type === "sessionList" && payload.surface.actionableSessionId ? this.state.sessions.get(payload.surface.actionableSessionId) : void 0;
+      if (this.petMode.isActive) {
+        const session = (payload.surface.type === "sessionList" || payload.surface.type === "completion")
+          && payload.surface.actionableSessionId
+          ? this.state.sessions.get(payload.surface.actionableSessionId)
+          : void 0;
         const shouldCollapse = shouldAutoDismiss(payload.surface, session?.phase)
           && payload.reason === "notification"
           && !Array.from(this.state.sessions.values()).some((s) => requiresAttention(s.phase));

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -29,8 +29,7 @@ const {
   canContinueSessionViaTerminalPrompt,
   isPluginAgentTool,
   isVisibleInIsland,
-  requiresAttention,
-  shouldAutoDismiss
+  requiresAttention
 } = require("./session-policy.cjs");
 function _interopNamespaceDefault(e) {
   const n = Object.create(null, { [Symbol.toStringTag]: { value: "Module" } });
@@ -594,7 +593,6 @@ const AppCoordinator = createAppCoordinatorClass({
   unwatchActiveSpace,
   requiresAttention,
   canContinueSessionViaTerminalPrompt,
-  shouldAutoDismiss,
   findLatestCodexInterrupt,
   getSessionBundleIds,
   jumpToTarget,

--- a/src/main/presentation-policy.cjs
+++ b/src/main/presentation-policy.cjs
@@ -1,0 +1,18 @@
+"use strict";
+
+function selectAutomaticSurface(event, settings) {
+  if (event.type === "sessionCompleted") {
+    if (!settings.expandOnSessionComplete) return null;
+    if (event.isInterrupt || event.isSessionEnd || event.isRalphLoopIteration) return null;
+    return { type: "completion", actionableSessionId: event.sessionId };
+  }
+
+  if (event.type === "permissionRequested" || event.type === "questionAsked") {
+    if (!settings.expandOnActionRequired) return null;
+    return { type: "sessionList", actionableSessionId: event.sessionId };
+  }
+
+  return null;
+}
+
+module.exports = { selectAutomaticSurface };

--- a/src/main/presentation-policy.cjs
+++ b/src/main/presentation-policy.cjs
@@ -14,7 +14,9 @@ function createPresentationRequest(event, settings) {
       },
       priority: event.error ? "error" : "completion",
       autoDismiss: !event.error,
-      suppressWhenFocused: !event.error
+      // A completion is a user-visible outcome, not background progress. It
+      // must remain visible even when the originating Agent is frontmost.
+      suppressWhenFocused: false
     };
   }
 

--- a/src/main/presentation-policy.cjs
+++ b/src/main/presentation-policy.cjs
@@ -1,18 +1,38 @@
 "use strict";
 
-function selectAutomaticSurface(event, settings) {
+function createPresentationRequest(event, settings) {
   if (event.type === "sessionCompleted") {
     if (!settings.expandOnSessionComplete) return null;
     if (event.isInterrupt || event.isSessionEnd || event.isRalphLoopIteration) return null;
-    return { type: "completion", actionableSessionId: event.sessionId };
+    return {
+      // Notifications deliberately reuse the regular hover panel.  Restricting
+      // the list keeps a completed task from opening every live session at once.
+      surface: {
+        type: "sessionList",
+        actionableSessionId: event.sessionId,
+        visibleSessionIds: [event.sessionId]
+      },
+      priority: event.error ? "error" : "completion",
+      autoDismiss: !event.error,
+      suppressWhenFocused: !event.error
+    };
   }
 
   if (event.type === "permissionRequested" || event.type === "questionAsked") {
     if (!settings.expandOnActionRequired) return null;
-    return { type: "sessionList", actionableSessionId: event.sessionId };
+    return {
+      surface: { type: "sessionList", actionableSessionId: event.sessionId },
+      priority: "action-required",
+      autoDismiss: false,
+      suppressWhenFocused: false
+    };
   }
 
   return null;
 }
 
-module.exports = { selectAutomaticSurface };
+function selectAutomaticSurface(event, settings) {
+  return createPresentationRequest(event, settings)?.surface ?? null;
+}
+
+module.exports = { createPresentationRequest, selectAutomaticSurface };

--- a/src/main/session-policy.cjs
+++ b/src/main/session-policy.cjs
@@ -33,7 +33,7 @@ function canContinueSessionViaTerminalPrompt(session) {
 }
 
 function shouldAutoDismiss(surface, sessionPhase) {
-  return surface.type === "sessionList"
+  return (surface.type === "sessionList" || surface.type === "completion")
     && Boolean(surface.actionableSessionId)
     && sessionPhase === "completed";
 }

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -5,7 +5,7 @@ import { D as DEFAULT_NOTCH_INFO, r as requiresAttention, d as dominantPhase, I 
 import { c as create } from "../vendor/store.js";
 import { I as IslandPanel } from "./components/IslandPanel.js";
 import { isVisibleInIsland } from "./session-model.mjs";
-import { shouldCollapseOnFocusLoss } from "./focus-policy.mjs";
+import { resolveFocusLossPresentation, shouldCollapseOnFocusLoss } from "./focus-policy.mjs";
 const useSessionStore = create((set) => ({
   sessions: [],
   notchInfo: window.islandBridge?.__initialNotchInfo ?? DEFAULT_NOTCH_INFO,
@@ -124,11 +124,6 @@ function IslandApp() {
   const mouseLeaveCloseTimer = reactExports.useRef(
     null
   );
-  // 鼠标离开/失焦后，先收成可见胶囊，再经过 autoCollapseDurationMs 完全隐身。
-  // 这个 timer 负责第二阶段（胶囊→隐身 hotspot）。
-  const concealAfterCollapseTimer = reactExports.useRef(
-    null
-  );
   const warmupCloseTimerRef = reactExports.useRef(
     null
   );
@@ -206,21 +201,6 @@ function IslandApp() {
       unsubscribe?.();
     };
   }, []);
-  // 两阶段隐藏：先收成可见胶囊（close → visible-pill，opacity 1），停留
-  // autoCollapseDurationMs 后再 hideForFocusLoss（→ 透明 hotspot，opacity 0）。
-  // 这正是用户要的"光标拖出去后保持胶囊 5 秒再完全消失"。任一阶段鼠标回到
-  // 岛上（handleMouseEnter）都会清掉 concealAfterCollapseTimer 并重新展开。
-  // 定义在此处（settings effect 之后、blur effect 之前）以避免 const 暂时性死区。
-  const concealToHiddenAfterDelay = reactExports.useCallback(() => {
-    if (concealAfterCollapseTimer.current) {
-      clearTimeout(concealAfterCollapseTimer.current);
-      concealAfterCollapseTimer.current = null;
-    }
-    concealAfterCollapseTimer.current = setTimeout(() => {
-      concealAfterCollapseTimer.current = null;
-      window.islandBridge?.hideForFocusLoss?.();
-    }, autoCollapseDurationMs);
-  }, [autoCollapseDurationMs]);
   reactExports.useEffect(() => {
     setMounted(true);
   }, []);
@@ -264,8 +244,6 @@ function IslandApp() {
         clearTimeout(resizeWindowTimerRef.current);
       if (collapsePanelToPillTimerRef.current)
         clearTimeout(collapsePanelToPillTimerRef.current);
-      if (concealAfterCollapseTimer.current)
-        clearTimeout(concealAfterCollapseTimer.current);
     };
   }, []);
   reactExports.useEffect(() => {
@@ -290,11 +268,11 @@ function IslandApp() {
       if (focusLossHandledRef.current) return;
       focusLossHandledRef.current = true;
       pendingFollowUpDismissRef.current = false;
-      // 失焦也走两阶段：先收成胶囊，停留 5 秒后完全隐身。
+      if (resolveFocusLossPresentation({ isVisible: mounted, followUpFocused }) !== "pill") return;
+      // 普通失焦只收成默认胶囊，保持左侧角色可见。
       clearSurface();
       close();
       window.islandBridge?.surfaceDismissed();
-      concealToHiddenAfterDelay();
     };
     const handleWindowFocus = () => {
       focusLossHandledRef.current = false;
@@ -307,7 +285,7 @@ function IslandApp() {
       window.removeEventListener("workisland-window-blur", handleWindowBlur);
       window.removeEventListener("focus", handleWindowFocus);
     };
-  }, [close, clearSurface, mounted, concealToHiddenAfterDelay]);
+  }, [close, clearSurface, mounted]);
   const collapsePanelToPill = reactExports.useCallback(() => {
     if (mouseLeaveCloseTimer.current) {
       clearTimeout(mouseLeaveCloseTimer.current);
@@ -392,8 +370,8 @@ function IslandApp() {
       collapsePanelToPillTimerRef.current = null;
     }
     open();
-    const focusedSession = surface.type === "sessionList" && surface.actionableSessionId ? sessions.find((s) => s.id === surface.actionableSessionId) : void 0;
-    if (surface.type === "sessionList" && surface.actionableSessionId && !focusedSession) {
+    const focusedSession = (surface.type === "sessionList" || surface.type === "completion") && surface.actionableSessionId ? sessions.find((s) => s.id === surface.actionableSessionId) : void 0;
+    if ((surface.type === "sessionList" || surface.type === "completion") && surface.actionableSessionId && !focusedSession) {
       close();
       clearSurface();
       window.islandBridge?.surfaceDismissed();
@@ -528,11 +506,6 @@ function IslandApp() {
       clearTimeout(mouseLeaveCloseTimer.current);
       mouseLeaveCloseTimer.current = null;
     }
-    // 鼠标回到岛上：取消"胶囊→隐身"的第二阶段，保持可见。
-    if (concealAfterCollapseTimer.current) {
-      clearTimeout(concealAfterCollapseTimer.current);
-      concealAfterCollapseTimer.current = null;
-    }
     pendingFollowUpDismissRef.current = false;
     if (autoCollapseTimer.current) clearTimeout(autoCollapseTimer.current);
     if (attentionNotifTimer.current) {
@@ -558,8 +531,7 @@ function IslandApp() {
       hoverOpenTimer.current = null;
     }
     window.islandBridge?.leaveIsland();
-    // 鼠标脱离后两阶段隐藏：先收成可见胶囊（黑胶囊），保持 autoCollapseDurationMs
-    // （默认 5 秒）后再完全隐身（透明 hotspot）。这期间鼠标回到岛上会取消隐身。
+    // 鼠标离开后收成默认胶囊，保持左侧角色可见。
     if (!isOpen) return;
     const isFollowUpFocused = isFollowUpActiveRef.current && document.hasFocus() && document.activeElement?.closest("[data-follow-up-input]");
     if (isFollowUpFocused) {
@@ -570,9 +542,8 @@ function IslandApp() {
       clearSurface();
       close();
       window.islandBridge?.surfaceDismissed();
-      concealToHiddenAfterDelay();
     }, MOUSE_LEAVE_CLOSE_DELAY_MS);
-  }, [isOpen, close, clearSurface, concealToHiddenAfterDelay]);
+  }, [isOpen, close, clearSurface]);
   const handlePillClick = reactExports.useCallback(() => {
     if (hoverOpenTimer.current) {
       clearTimeout(hoverOpenTimer.current);

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -11,6 +11,7 @@ const useSessionStore = create((set) => ({
   notchInfo: window.islandBridge?.__initialNotchInfo ?? DEFAULT_NOTCH_INFO,
   surface: null,
   openReason: null,
+  notificationAutoDismiss: false,
   agentQuotas: {},
   onboardingExpand: false,
   toggleExpandTick: 0,
@@ -20,8 +21,8 @@ const useSessionStore = create((set) => ({
   confirmSessionTick: 0,
   setSessions: (sessions) => set({ sessions }),
   setNotchInfo: (notchInfo) => set({ notchInfo }),
-  presentSurface: (surface, openReason) => set({ surface, openReason }),
-  clearSurface: () => set({ surface: null, openReason: null }),
+  presentSurface: (surface, openReason, notificationAutoDismiss = false) => set({ surface, openReason, notificationAutoDismiss }),
+  clearSurface: () => set({ surface: null, openReason: null, notificationAutoDismiss: false }),
   setAgentQuotas: (agentQuotas) => set({ agentQuotas }),
   setOnboardingExpand: (onboardingExpand) => set({ onboardingExpand }),
   requestToggleExpand: () => set((state) => ({ toggleExpandTick: state.toggleExpandTick + 1 })),
@@ -43,8 +44,8 @@ function useIslandState() {
     bridge.onSessionUpdate((sessions) => {
       setSessions(sessions);
     });
-    bridge.onPresentSurface(({ surface, reason }) => {
-      presentSurface(surface, reason);
+    bridge.onPresentSurface(({ surface, reason, autoDismiss }) => {
+      presentSurface(surface, reason, autoDismiss);
     });
     bridge.onQuotaUpdate((quotas) => setAgentQuotas(quotas));
     void bridge.getQuotaMap().then((quotas) => {
@@ -104,6 +105,7 @@ function IslandApp() {
     notchInfo,
     surface,
     openReason,
+    notificationAutoDismiss,
     clearSurface,
     presentSurface,
     agentQuotas
@@ -387,7 +389,7 @@ function IslandApp() {
   // "时间抓不住"。现在 surface 一旦弹出就稳定倒数 autoCollapseDurationMs。
   reactExports.useEffect(() => {
     if (!surface) return;
-    if (openReason !== "notification") return;
+    if (openReason !== "notification" || !notificationAutoDismiss) return;
     if (isFollowUpActiveRef.current) return;
     if (autoCollapseTimer.current) clearTimeout(autoCollapseTimer.current);
     autoCollapseTimer.current = setTimeout(() => {
@@ -399,7 +401,7 @@ function IslandApp() {
     return () => {
       if (autoCollapseTimer.current) clearTimeout(autoCollapseTimer.current);
     };
-  }, [surface, openReason, autoCollapseDurationMs, close, clearSurface]);
+  }, [surface, openReason, notificationAutoDismiss, autoCollapseDurationMs, close, clearSurface]);
   reactExports.useEffect(() => {
     if (!onboardingExpand) return;
     setOnboardingExpand(false);

--- a/src/renderer/island/components/IslandPanel.css
+++ b/src/renderer/island/components/IslandPanel.css
@@ -1250,6 +1250,12 @@
 .plan-confirmation-jump-btn:hover {
   background: rgba(255, 255, 255, 0.15);
 }
+.completion-notification {
+  /* The full panel has AgentUsageRow occupying this space; the compact
+   * completion card needs an explicit inset below the physical MacBook notch. */
+  padding-top: var(--island-safe-top-inset, 24px);
+}
+
 .completion-card {
   display: flex;
   flex-direction: column;

--- a/src/renderer/island/components/IslandPanel.css
+++ b/src/renderer/island/components/IslandPanel.css
@@ -1250,12 +1250,6 @@
 .plan-confirmation-jump-btn:hover {
   background: rgba(255, 255, 255, 0.15);
 }
-.completion-notification {
-  /* The full panel has AgentUsageRow occupying this space; the compact
-   * completion card needs an explicit inset below the physical MacBook notch. */
-  padding-top: var(--island-safe-top-inset, 24px);
-}
-
 .completion-card {
   display: flex;
   flex-direction: column;

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -3,7 +3,7 @@ import { A as AGENT_TOOL_LABELS, j as isPluginAgentTool, g as getPluginColor, h 
 import { g as getFireIconByTokenCount, s as sanitizeAgentDisplayText, c as cleanAppName, b as buildApproveAlwaysTooltip } from "../../shared/formatters.js";
 import { f as formatTokenCount } from "../../shared/tokens.js";
 import { M as Markdown, r as remarkGfm } from "../../vendor/markdown.js";
-import { canContinueSessionViaTerminalPrompt, sortVisibleSessions } from "../session-model.mjs";
+import { canContinueSessionViaTerminalPrompt, filterSurfaceSessions, sortVisibleSessions } from "../session-model.mjs";
 const defaultIcon = new URL("../assets/status/idle.svg", import.meta.url).href;
 const runningIcon = new URL("../assets/status/running.svg", import.meta.url).href;
 const approvalIcon = new URL("../assets/status/approval.svg", import.meta.url).href;
@@ -20,8 +20,8 @@ function useActionable(sessions, surface, options) {
     return () => cancelAnimationFrame(frame);
   }, [actionableId, options?.disableScroll]);
   const visibleSessions = reactExports.useMemo(
-    () => sortVisibleSessions(sessions),
-    [sessions]
+    () => sortVisibleSessions(filterSurfaceSessions(sessions, surface)),
+    [sessions, surface]
   );
   return { actionableId, actionableRef, visibleSessions };
 }
@@ -1313,18 +1313,6 @@ function IslandPanel({
     });
     return () => cancelAnimationFrame(frame);
   }, [followUpSessionId]);
-  if (surface?.type === "completion") {
-    const completedSession = sessions.find((session) => session.id === actionableId);
-    if (!completedSession || completedSession.phase !== "completed") return null;
-    return /* @__PURE__ */ React.createElement("div", { className: "panel completion-notification", style: panelStyle }, /* @__PURE__ */ React.createElement(
-      CompletionCard,
-      {
-        session: completedSession,
-        isFollowUpOpen: false,
-        onCollapse
-      }
-    ));
-  }
   return /* @__PURE__ */ React.createElement("div", { className: "panel", style: panelStyle }, /* @__PURE__ */ React.createElement(
     AgentUsageRow,
     {

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -1277,7 +1277,8 @@ function IslandPanel({
   const sessionListRef = React.useRef(null);
   const followUpRef = React.useRef(null);
   const panelStyle = {
-    "--island-panel-max-height": `${panelMaxHeightPx}px`
+    "--island-panel-max-height": `${panelMaxHeightPx}px`,
+    "--island-safe-top-inset": `${Math.max(0, notchHeight)}px`
   };
   React.useEffect(() => {
     if (!followUpSessionId) return;

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -10,7 +10,7 @@ const approvalIcon = new URL("../assets/status/approval.svg", import.meta.url).h
 const completeIcon = new URL("../assets/status/complete.svg", import.meta.url).href;
 const errorIcon = new URL("../assets/status/error.svg", import.meta.url).href;
 function useActionable(sessions, surface, options) {
-  const actionableId = surface?.type === "sessionList" ? surface.actionableSessionId : void 0;
+  const actionableId = surface?.type === "sessionList" || surface?.type === "completion" ? surface.actionableSessionId : void 0;
   const actionableRef = reactExports.useRef(null);
   reactExports.useEffect(() => {
     if (!actionableId || options?.disableScroll) return;
@@ -1312,6 +1312,18 @@ function IslandPanel({
     });
     return () => cancelAnimationFrame(frame);
   }, [followUpSessionId]);
+  if (surface?.type === "completion") {
+    const completedSession = sessions.find((session) => session.id === actionableId);
+    if (!completedSession || completedSession.phase !== "completed") return null;
+    return /* @__PURE__ */ React.createElement("div", { className: "panel completion-notification", style: panelStyle }, /* @__PURE__ */ React.createElement(
+      CompletionCard,
+      {
+        session: completedSession,
+        isFollowUpOpen: false,
+        onCollapse
+      }
+    ));
+  }
   return /* @__PURE__ */ React.createElement("div", { className: "panel", style: panelStyle }, /* @__PURE__ */ React.createElement(
     AgentUsageRow,
     {

--- a/src/renderer/island/focus-policy.mjs
+++ b/src/renderer/island/focus-policy.mjs
@@ -9,3 +9,8 @@
 export function shouldCollapseOnFocusLoss({ isVisible, enabled, followUpFocused }) {
   return Boolean(isVisible && enabled && !followUpFocused);
 }
+
+export function resolveFocusLossPresentation({ isVisible, followUpFocused }) {
+  if (!isVisible || followUpFocused) return "unchanged";
+  return "pill";
+}

--- a/src/renderer/island/session-model.mjs
+++ b/src/renderer/island/session-model.mjs
@@ -29,3 +29,9 @@ export function canContinueSessionViaTerminalPrompt(session) {
 export function sortVisibleSessions(sessions) {
   return sessions.filter(isVisibleInIsland).sort((left, right) => right.updatedAt - left.updatedAt);
 }
+
+export function filterSurfaceSessions(sessions, surface) {
+  const ids = surface?.visibleSessionIds;
+  if (!Array.isArray(ids)) return sessions;
+  return sessions.filter((session) => ids.includes(session.id));
+}

--- a/src/renderer/pet/app.js
+++ b/src/renderer/pet/app.js
@@ -11,6 +11,7 @@ import {
   CODEX_V2_TOTAL_ROWS,
   CODEX_V2_CELL_WIDTH,
   isCodexV2Sprite,
+  deriveDragDirection,
   derivePetBubble,
   derivePetStatus,
   statusToIntervalMs,
@@ -43,6 +44,7 @@ const orcaSprite = new URL("./orca.png", import.meta.url).href;
 function PetApp() {
   const [sessions, setSessions] = reactExports.useState([]);
   const [isDragging, setIsDragging] = reactExports.useState(false);
+  const [dragDirection, setDragDirection] = reactExports.useState("right");
   const [isSleeping, setIsSleeping] = reactExports.useState(false);
   const [isPlaying, setIsPlaying] = reactExports.useState(false);
   const [isCompleteExpired, setIsCompleteExpired] = reactExports.useState(false);
@@ -227,11 +229,11 @@ function PetApp() {
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, dw, dh);
     ctx.imageSmoothingEnabled = true;
-    const row = statusToRow(status, spriteMeta);
+    const row = statusToRow(status, spriteMeta, dragDirection);
     const sx = frame * frameWidth;
     const sy = row * frameSize;
     ctx.drawImage(sheet, sx, sy, frameWidth, frameSize, 0, 0, dw, dh);
-  }, [status, displaySize, frameSize, frameWidth, spriteMeta]);
+  }, [status, displaySize, frameSize, frameWidth, spriteMeta, dragDirection]);
   reactExports.useEffect(() => {
     if (!sheetReady) return;
     frameRef.current = 0;
@@ -285,6 +287,7 @@ function PetApp() {
       const dx = ev.screenX - dragOffset.current.x;
       const dy = ev.screenY - dragOffset.current.y;
       dragOffset.current = { x: ev.screenX, y: ev.screenY };
+      setDragDirection((current) => deriveDragDirection(dx, current));
       window.petBridge?.movePet(dx, dy);
     };
     const onUp = () => {

--- a/src/renderer/pet/model.mjs
+++ b/src/renderer/pet/model.mjs
@@ -42,7 +42,7 @@ export const CODEX_V2_CELL_HEIGHT = 208;
 
 /**
  * Codex V2 协议下，orca 内部状态 → codex sprite 行的映射。
- * codex 没有 sleep（复用 idle）、没有 drag（用 running-right）。
+ * codex 没有 sleep（复用 idle）；drag 的左右方向由 statusToRow 单独选择。
  */
 export const CODEX_V2_STATUS_TO_ROW = Object.freeze({
   idle: CODEX_V2_ROWS.idle,
@@ -62,11 +62,20 @@ export function isCodexV2Sprite(naturalWidth, naturalHeight) {
   return naturalHeight === CODEX_V2_HEIGHT && naturalWidth === CODEX_V2_WIDTH;
 }
 
-export function statusToRow(status, spriteMeta) {
+export function statusToRow(status, spriteMeta, dragDirection = "right") {
   if (spriteMeta && spriteMeta.protocol === "codex-v2") {
+    if (status === "drag") {
+      return dragDirection === "left" ? CODEX_V2_ROWS["running-left"] : CODEX_V2_ROWS["running-right"];
+    }
     return CODEX_V2_STATUS_TO_ROW[status] ?? CODEX_V2_ROWS.idle;
   }
   return STATUS_ROWS[status];
+}
+
+export function deriveDragDirection(deltaX, currentDirection = "right") {
+  if (deltaX > 0) return "right";
+  if (deltaX < 0) return "left";
+  return currentDirection;
 }
 
 export function statusToIntervalMs(status) {

--- a/tests/focus-collapse.test.mjs
+++ b/tests/focus-collapse.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { shouldCollapseOnFocusLoss } from "../src/renderer/island/focus-policy.mjs";
+import { resolveFocusLossPresentation, shouldCollapseOnFocusLoss } from "../src/renderer/island/focus-policy.mjs";
 
 test("a visible Island hides when focus moves away and the setting is enabled", () => {
   assert.equal(shouldCollapseOnFocusLoss({ isVisible: true, enabled: true, followUpFocused: false }), true);
@@ -13,4 +13,12 @@ test("closed or disabled surfaces stay unchanged", () => {
 
 test("focused follow-up input is not dismissed by a transient focus transition", () => {
   assert.equal(shouldCollapseOnFocusLoss({ isVisible: true, enabled: true, followUpFocused: true }), false);
+});
+
+test("ordinary focus loss keeps the default character visible in the collapsed pill", () => {
+  assert.equal(resolveFocusLossPresentation({ isVisible: true, followUpFocused: false }), "pill");
+});
+
+test("focus loss leaves an active follow-up unchanged", () => {
+  assert.equal(resolveFocusLossPresentation({ isVisible: true, followUpFocused: true }), "unchanged");
 });

--- a/tests/presentation-policy.test.mjs
+++ b/tests/presentation-policy.test.mjs
@@ -1,9 +1,13 @@
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const require = createRequire(import.meta.url);
 const { selectAutomaticSurface } = require("../src/main/presentation-policy.cjs");
+const coordinatorSource = readFileSync(new URL("../src/main/app-coordinator.cjs", import.meta.url), "utf8");
+const islandPanelSource = readFileSync(new URL("../src/renderer/island/components/IslandPanel.js", import.meta.url), "utf8");
+const islandPanelCss = readFileSync(new URL("../src/renderer/island/components/IslandPanel.css", import.meta.url), "utf8");
 
 const settings = {
   expandOnSessionComplete: true,
@@ -41,4 +45,16 @@ test("disabled notification settings suppress their respective automatic surface
     selectAutomaticSurface({ type: "permissionRequested", sessionId: "a" }, { ...settings, expandOnActionRequired: false }),
     null
   );
+});
+
+test("completion notifications are also routed to an active desktop pet", () => {
+  assert.doesNotMatch(
+    coordinatorSource,
+    /petMode\.isActive\s*&&\s*payload\.surface\.type\s*!==\s*["']completion["']/
+  );
+});
+
+test("compact completion content reserves the hardware-notch safe area", () => {
+  assert.match(islandPanelSource, /--island-safe-top-inset/);
+  assert.match(islandPanelCss, /\.completion-notification[\s\S]*padding-top:\s*var\(--island-safe-top-inset/);
 });

--- a/tests/presentation-policy.test.mjs
+++ b/tests/presentation-policy.test.mjs
@@ -25,7 +25,7 @@ test("a completion opens the hover-equivalent panel filtered to its session", ()
       surface: { type: "sessionList", actionableSessionId: "completed-session", visibleSessionIds: ["completed-session"] },
       priority: "completion",
       autoDismiss: true,
-      suppressWhenFocused: true
+      suppressWhenFocused: false
     }
   );
 });

--- a/tests/presentation-policy.test.mjs
+++ b/tests/presentation-policy.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
+const { selectAutomaticSurface } = require("../src/main/presentation-policy.cjs");
+
+const settings = {
+  expandOnSessionComplete: true,
+  expandOnActionRequired: true
+};
+
+test("a normal session start does not open a surface", () => {
+  assert.equal(selectAutomaticSurface({ type: "sessionStarted", sessionId: "a" }, settings), null);
+});
+
+test("a completion opens only a compact surface for its session", () => {
+  assert.deepEqual(
+    selectAutomaticSurface({ type: "sessionCompleted", sessionId: "completed-session" }, settings),
+    { type: "completion", actionableSessionId: "completed-session" }
+  );
+});
+
+test("approval and question events retain their targeted actionable surface", () => {
+  assert.deepEqual(
+    selectAutomaticSurface({ type: "permissionRequested", sessionId: "approval-session" }, settings),
+    { type: "sessionList", actionableSessionId: "approval-session" }
+  );
+  assert.deepEqual(
+    selectAutomaticSurface({ type: "questionAsked", sessionId: "question-session" }, settings),
+    { type: "sessionList", actionableSessionId: "question-session" }
+  );
+});
+
+test("disabled notification settings suppress their respective automatic surfaces", () => {
+  assert.equal(
+    selectAutomaticSurface({ type: "sessionCompleted", sessionId: "a" }, { ...settings, expandOnSessionComplete: false }),
+    null
+  );
+  assert.equal(
+    selectAutomaticSurface({ type: "permissionRequested", sessionId: "a" }, { ...settings, expandOnActionRequired: false }),
+    null
+  );
+});

--- a/tests/presentation-policy.test.mjs
+++ b/tests/presentation-policy.test.mjs
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { test } from "node:test";
 
 const require = createRequire(import.meta.url);
-const { selectAutomaticSurface } = require("../src/main/presentation-policy.cjs");
+const { selectAutomaticSurface, createPresentationRequest } = require("../src/main/presentation-policy.cjs");
 const coordinatorSource = readFileSync(new URL("../src/main/app-coordinator.cjs", import.meta.url), "utf8");
 const islandPanelSource = readFileSync(new URL("../src/renderer/island/components/IslandPanel.js", import.meta.url), "utf8");
 const islandPanelCss = readFileSync(new URL("../src/renderer/island/components/IslandPanel.css", import.meta.url), "utf8");
@@ -18,10 +18,15 @@ test("a normal session start does not open a surface", () => {
   assert.equal(selectAutomaticSurface({ type: "sessionStarted", sessionId: "a" }, settings), null);
 });
 
-test("a completion opens only a compact surface for its session", () => {
+test("a completion opens the hover-equivalent panel filtered to its session", () => {
   assert.deepEqual(
-    selectAutomaticSurface({ type: "sessionCompleted", sessionId: "completed-session" }, settings),
-    { type: "completion", actionableSessionId: "completed-session" }
+    createPresentationRequest({ type: "sessionCompleted", sessionId: "completed-session" }, settings),
+    {
+      surface: { type: "sessionList", actionableSessionId: "completed-session", visibleSessionIds: ["completed-session"] },
+      priority: "completion",
+      autoDismiss: true,
+      suppressWhenFocused: true
+    }
   );
 });
 
@@ -47,14 +52,18 @@ test("disabled notification settings suppress their respective automatic surface
   );
 });
 
-test("completion notifications are also routed to an active desktop pet", () => {
-  assert.doesNotMatch(
-    coordinatorSource,
-    /petMode\.isActive\s*&&\s*payload\.surface\.type\s*!==\s*["']completion["']/
-  );
+test("action-required and error requests remain visible", () => {
+  assert.equal(createPresentationRequest({ type: "permissionRequested", sessionId: "approval-session" }, settings).autoDismiss, false);
+  assert.equal(createPresentationRequest({ type: "permissionRequested", sessionId: "approval-session" }, settings).suppressWhenFocused, false);
+  assert.equal(createPresentationRequest({ type: "sessionCompleted", sessionId: "failed-session", error: "failed" }, settings).autoDismiss, false);
 });
 
-test("compact completion content reserves the hardware-notch safe area", () => {
-  assert.match(islandPanelSource, /--island-safe-top-inset/);
-  assert.match(islandPanelCss, /\.completion-notification[\s\S]*padding-top:\s*var\(--island-safe-top-inset/);
+test("an active desktop pet is the exclusive automatic-notification surface", () => {
+  assert.match(coordinatorSource, /this\.petMode\.isActive[\s\S]*?this\.petMode\.presentSurface[\s\S]*?return;/);
+});
+
+test("completion notifications use the regular hover panel, not a compact card", () => {
+  assert.match(islandPanelSource, /AgentUsageRow/);
+  assert.doesNotMatch(islandPanelSource, /completion-notification/);
+  assert.doesNotMatch(islandPanelCss, /\.completion-notification/);
 });


### PR DESCRIPTION
## Internal beta scope

### Notification design
- Completion always presents a notification, even when the source Agent is frontmost.
- Island notifications reuse the regular hover-expanded panel and show only the relevant task.
- Approval, question, and error states remain visible until handled.
- When the desktop pet is active, it is the sole expanding notification surface; Island remains passive.

### Included fixes
- Preserve the default Island character through normal focus changes.
- Preserve Codex V2 pet left/right drag direction.
- Package macOS arm64 beta artifacts with Developer ID signing.

### Validation
- Local source contracts and 25 unit tests pass.
- Native macOS and source-contract CI checks pass.
- Release automation is currently blocked by missing GitHub release credentials; tracked in #12.