### PR TITLE
chore: prepare 0.2.8-beta.5 internal beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workisland",
-  "version": "0.2.8-beta.4",
+  "version": "0.2.8-beta.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workisland",
-      "version": "0.2.8-beta.4",
+      "version": "0.2.8-beta.5",
       "license": "MIT",
       "dependencies": {
         "@electron-toolkit/utils": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workisland",
   "productName": "WorkIsland",
-  "version": "0.2.8-beta.4",
+  "version": "0.2.8-beta.5",
   "description": "macOS 本地 Work Agent 工作状态与注意力路由器",
   "private": true,
   "main": "./src/main/index.cjs",


### PR DESCRIPTION
Bumps the package version after merging the internal notification fixes and Echo desktop pet.