### PR TITLE
feat: add release update checks and publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: workisland-release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   macos-arm64:
     runs-on: macos-14
@@ -26,10 +30,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
-      - name: Verify release version
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: test "${GITHUB_REF_NAME#v}" = "$(node -p "require('./package.json').version")"
       - run: npm ci
+      - name: Verify release metadata
+        env:
+          RELEASE_TAG: ${{ startsWith(github.ref, 'refs/tags/v') && github.ref_name || '' }}
+        run: npm run release:check
       - name: Require release credentials
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ xattr -dr com.apple.quarantine "/Applications/WorkIsland.app"
 
 ## 仓库边界
 
-项目专注于本地功能。云端账号、远程开发机、遥测和自动更新不属于当前产品边界；应用不会向这些服务建立连接，也不会上传会话内容。
+项目专注于本地功能。应用不会连接云端账号、远程开发机或遥测服务，也不会上传会话内容。安装版会按设置每日请求一次 GitHub Release 版本信息，用于更新提醒；详细规则见 [发布与更新流程](./docs/RELEASE_PROCESS.md)。
 
-代码结构见 [架构说明](./docs/ARCHITECTURE.md)，不支持功能的完整原因见 [功能边界](./docs/UNAVAILABLE_FEATURES.md)，公开发布前请完成 [发布检查](./docs/RELEASE_CHECKLIST.md)。
+代码结构见 [架构说明](./docs/ARCHITECTURE.md)，不支持功能的完整原因见 [功能边界](./docs/UNAVAILABLE_FEATURES.md)，公开发布前请完成 [发布与更新流程](./docs/RELEASE_PROCESS.md)。
 
 应用图标、用量图标和提示音由仓库内 `npm run build:assets` 可重复生成（应用图标由设计师提供的 logo 生成，不会被覆盖）。刘海定位、窗口层级、圆角与触觉反馈模块的 Objective-C++ 源码位于 `native/panel-fix/`，可通过 `npm run build:native` 重建。
 
@@ -91,15 +91,15 @@ npm ci
 npm run package:mac
 ```
 
-产物位于 `release/WorkIsland-<version>-arm64.dmg`。GitHub Actions 的 `release` 工作流支持手动运行；推送与 `package.json` 版本一致的标签（例如 `v0.2.6`）时，会自动创建 GitHub Release 并上传 DMG 与 SHA-256 校验文件。
+产物位于 `release/WorkIsland-<version>-arm64.dmg`。GitHub Actions 的 `release` 工作流支持手动运行；推送与 `package.json` 版本一致的标签（例如 `v0.3.0`）时，会自动构建、签名、公证并创建 GitHub Release，随后上传 DMG 与 SHA-256 校验文件。完整步骤见 [发布与更新流程](./docs/RELEASE_PROCESS.md)。
 
-没有 Apple Developer 证书时仍可生成未签名 DMG，但用户首次打开需要在系统设置中确认。正式公开分发建议在 GitHub 仓库 Actions Secrets 中配置：
+正式 Tag 发布必须在 GitHub Actions Secrets 中配置：
 
 - `CSC_LINK`：Developer ID Application 证书的 Base64 或安全下载地址
 - `CSC_KEY_PASSWORD`：证书密码
 - `APPLE_API_KEY`、`APPLE_API_KEY_ID`、`APPLE_API_ISSUER`：App Store Connect API Key，用于公证
 
-这些 Secrets 都是可选的；未配置时工作流会跳过签名与公证。
+未配置这些 Secrets 时，Tag 发布会主动失败，避免把未签名安装包误作为正式版本公开。手动运行工作流仍可用于生成临时构建产物。
 
 ## 许可证与分发
 

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,78 @@
+# WorkIsland 发布与更新流程
+
+本文档是 WorkIsland 的唯一发布规范。正式发布不依赖任何个人电脑，统一由 GitHub Actions 在 macOS Runner 上完成构建、签名、公证和上传。
+
+## 发布渠道
+
+- 稳定版：`vX.Y.Z`，例如 `v0.3.0`
+- 预发布版：`vX.Y.Z-beta.N`，例如 `v0.3.0-beta.1`
+- 用户端更新检测只读取 GitHub 的稳定版 `releases/latest`
+- GitHub Release 是安装包的唯一事实来源，官网只负责展示和引导下载
+
+不要复用已经推送过的 Tag。出现问题时发布新的修复版本，并在 Release Notes 中说明变更。
+
+## 发布前检查
+
+在本地完成代码提交后：
+
+```bash
+npm ci
+npm run check
+npm run release:check -- --tag v0.3.0
+```
+
+将示例版本替换为 `package.json` 中的实际版本。`release:check` 会确认：
+
+- `package.json` 和 `package-lock.json` 使用 Apache-2.0
+- `LICENSE`、`NOTICE` 和第三方声明存在
+- electron-builder 会把这些声明放入应用包
+- Tag 与 `package.json` 版本完全一致
+
+## 正式发布
+
+1. 修改 `package.json` 和 `package-lock.json` 的版本号。
+2. 运行完整检查并提交到 `main`。
+3. 创建并推送与版本一致的 Tag：
+
+   ```bash
+   git tag -a v0.3.0 -m "Release v0.3.0"
+   git push origin v0.3.0
+   ```
+
+4. `release.yml` 自动执行：
+   - macOS 14 Apple Silicon 构建
+   - Developer ID 签名
+   - Apple 公证并 Staple
+   - DMG 签名校验和 Gatekeeper 校验
+   - SHA-256 校验文件生成
+   - GitHub Release 创建和附件上传
+5. 在 GitHub Actions 和 Release 页面确认产物可下载。
+
+## GitHub Secrets
+
+在仓库的 Settings → Secrets and variables → Actions 中配置：
+
+- `CSC_LINK`：Developer ID Application `.p12` 的 Base64 内容或安全下载地址
+- `CSC_KEY_PASSWORD`：证书密码
+- `APPLE_API_KEY`：App Store Connect API Key `.p8` 内容
+- `APPLE_API_KEY_ID`：API Key ID
+- `APPLE_API_ISSUER`：Issuer ID
+
+证书、`.p8` 文件和密码不得提交到仓库、Issue、PR 或日志。证书轮换时只更新 Secrets，不修改代码。
+
+## 更新检测行为
+
+安装版应用启动后延迟检查一次，之后最多每天检查一次。应用只请求：
+
+```text
+https://api.github.com/repos/qianzhu18/workisland/releases/latest
+```
+
+当前版本低于稳定版时，WorkIsland 会通过 macOS 通知和设置页提醒用户，点击后打开官方 Release 下载页。V1 不自动下载、不自动安装，也不上传会话、项目或使用数据。
+
+用户可以在“关于 → 更新”中关闭自动检查，仍然可以手动检查。网络失败不会影响应用启动和本地 Agent 监控。
+
+## 手动运行工作流
+
+`workflow_dispatch` 只用于验证构建和生成临时 Artifact，不会创建正式 Release，也不会代替 Tag 发布。正式公开版本必须通过版本一致的 `v*` Tag 触发。
+

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "setup:electron": "npm install --prefix ./.tools/electron-shell --no-save electron@43.3.0 --cache ./.npm-cache",
     "build:native": "node ./scripts/build-native.mjs",
     "package:mac": "npm run build:assets && npm run build:native && npm run check && electron-builder --mac --arm64 --publish never",
+    "release:check": "node ./scripts/release-check.mjs",
     "check": "npm run build:renderer && node ./scripts/check.mjs && node ./scripts/test-source.mjs && npm run test:unit",
     "test:unit": "node --test tests/*.test.mjs",
     "smoke:hook": "node ./scripts/smoke-hook.mjs",

--- a/scripts/check.mjs
+++ b/scripts/check.mjs
@@ -6,6 +6,8 @@ import { spawnSync } from "node:child_process";
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const required = [
   "package.json",
+  "LICENSE",
+  "NOTICE",
   "THIRD_PARTY_NOTICES.md",
   "src/shared/ipc.cjs",
   "src/shared/settings.cjs",
@@ -14,6 +16,7 @@ const required = [
   "src/main/log-lifecycle.cjs",
   "src/main/session-policy.cjs",
   "src/main/external-url-policy.cjs",
+  "src/main/update-service.cjs",
   "src/main/index.cjs",
   "src/preload/island.js",
   "src/preload/settings.js",
@@ -82,7 +85,7 @@ if (packageJson.main !== "./src/main/index.cjs") {
   console.error("package.json must run from src/main/index.cjs.");
   process.exit(1);
 }
-if (packageJson.license !== "MIT" || !existsSync(join(root, "LICENSE"))) {
+if (packageJson.license !== "Apache-2.0" || !existsSync(join(root, "LICENSE")) || !existsSync(join(root, "NOTICE"))) {
   console.error("The source license metadata is incomplete.");
   process.exit(1);
 }

--- a/scripts/release-check.mjs
+++ b/scripts/release-check.mjs
@@ -1,0 +1,41 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const root = resolve(new URL("..", import.meta.url).pathname);
+const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const packageLock = JSON.parse(readFileSync(join(root, "package-lock.json"), "utf8"));
+const tagArgIndex = process.argv.indexOf("--tag");
+const tag = tagArgIndex >= 0
+  ? process.argv[tagArgIndex + 1]
+  : process.env.RELEASE_TAG || (process.env.GITHUB_REF_TYPE === "tag" ? process.env.GITHUB_REF_NAME : "") || "";
+const normalizedTag = String(tag).replace(/^refs\/tags\//, "");
+const expectedTag = `v${packageJson.version}`;
+const requiredFiles = ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"];
+const missing = requiredFiles.filter((file) => !existsSync(join(root, file)));
+
+if (missing.length > 0) {
+  console.error(`Release metadata is incomplete. Missing: ${missing.join(", ")}`);
+  process.exit(1);
+}
+
+if (packageJson.license !== "Apache-2.0" || packageLock.packages?.[""]?.license !== "Apache-2.0") {
+  console.error("package.json and package-lock.json must declare Apache-2.0.");
+  process.exit(1);
+}
+
+const bundledFiles = new Set(packageJson.build?.files || []);
+for (const file of ["LICENSE", "NOTICE", "THIRD_PARTY_NOTICES.md"]) {
+  if (!bundledFiles.has(file)) {
+    console.error(`electron-builder must include ${file} in build.files.`);
+    process.exit(1);
+  }
+}
+
+if (normalizedTag && normalizedTag !== expectedTag) {
+  console.error(`Release tag ${normalizedTag} does not match package.json version ${packageJson.version}. Expected ${expectedTag}.`);
+  process.exit(1);
+}
+
+const channel = packageJson.version.includes("-") ? "prerelease" : "stable";
+console.log(`Release metadata OK: ${packageJson.productName} ${packageJson.version} (${channel})`);
+if (normalizedTag) console.log(`Release tag OK: ${normalizedTag}`);

--- a/scripts/test-source.mjs
+++ b/scripts/test-source.mjs
@@ -44,7 +44,7 @@ const {
   getWorkBuddyConfigPaths
 } = require("../src/main/hooks-work-agents.cjs");
 
-assert.equal(Object.keys(IPC).length, 89, "IPC contract changed; review both main and preload consumers");
+assert.equal(Object.keys(IPC).length, 91, "IPC contract changed; review both main and preload consumers");
 assert.equal(new Set(Object.values(IPC)).size, Object.keys(IPC).length, "IPC channels must be unique");
 assert.ok(Object.isFrozen(IPC), "IPC contract must be immutable");
 assert.equal(IPC.PET_DRAG_TO_ISLAND, "pet:drag-to-island");

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -25,6 +25,7 @@ const { buildPermissionDirective } = require("./permission-directives.cjs");
 const { createNativePlatformService } = require("./native-platform-service.cjs");
 const { configureLogTransport, createLogLifecycle } = require("./log-lifecycle.cjs");
 const { isAllowedExternalUrl } = require("./external-url-policy.cjs");
+const { createUpdateService } = require("./update-service.cjs");
 const {
   canContinueSessionViaTerminalPrompt,
   isPluginAgentTool,
@@ -608,9 +609,11 @@ const AppCoordinator = createAppCoordinatorClass({
   CODEX_IDLE_INTERRUPT_THRESHOLD_MS
 });
 const { createIpcServices } = require("./ipc-services.cjs");
+let updateService = null;
 const { registerIpcHandlers, getCustomIconDataUrl, applyDockIcon } = createIpcServices({
   performHapticFeedback,
-  isAllowedExternalUrl
+  isAllowedExternalUrl,
+  checkForUpdates: (options) => updateService?.check(options) ?? Promise.resolve({ status: "unavailable" })
 });
 const { createDisplayManagerClass, normalizeDisplayPreference } = require("./display-manager.cjs");
 const DisplayManager = createDisplayManagerClass({
@@ -697,6 +700,19 @@ async function runIslandApp() {
   } catch {
   }
   const coordinator = new AppCoordinator();
+  updateService = createUpdateService({
+    app: electron.app,
+    shell: electron.shell,
+    notificationClass: electron.Notification,
+    userDataPath: electron.app.getPath("userData"),
+    getSettings: () => coordinator.getSettings(),
+    onUpdateAvailable: (update) => {
+      for (const win of electron.BrowserWindow.getAllWindows()) {
+        if (!win.isDestroyed()) win.webContents.send(IPC.APP_UPDATE_AVAILABLE, update);
+      }
+    },
+    logger: log
+  });
   registerIpcHandlers(coordinator);
   if (!coordinator.getSettings().locale) {
     const languages = electron.app.getPreferredSystemLanguages();
@@ -728,6 +744,7 @@ async function runIslandApp() {
       quitWatchdog = null;
     }
     stopLogLifecycle();
+    updateService?.stop();
     coordinator.stop();
     displayManager?.dispose();
     electron.globalShortcut.unregisterAll();
@@ -736,8 +753,8 @@ async function runIslandApp() {
     } catch {
     }
   });
-  electron.app.setName("Orca");
-  utils.electronApp.setAppUserModelId("app.orca.desktop");
+  electron.app.setName("WorkIsland");
+  utils.electronApp.setAppUserModelId("app.workisland.desktop");
   if (process.platform === "darwin" && electron.app.dock) {
     applyDockIcon(getCustomIconDataUrl());
   }
@@ -949,6 +966,7 @@ async function runIslandApp() {
     });
   }
   coordinator.start();
+  updateService.start();
   log.info("[local-dev] session bridge, hooks, process monitor, pet, sound, and haptics enabled");
   child_process.execFile("lsof", ["-i", "TCP", "-P", "-n", "-a", "-p", String(process.pid)], {
     timeout: 3e3

--- a/src/main/ipc-services.cjs
+++ b/src/main/ipc-services.cjs
@@ -11,7 +11,7 @@ const { listCodexPets, resolveCodexPet } = require("./codex-pet.cjs");
 const { previewSound, getUserSoundsDir } = require("./sound-service.cjs");
 const path__namespace = path;
 
-function createIpcServices({ performHapticFeedback, isAllowedExternalUrl }) {
+function createIpcServices({ performHapticFeedback, isAllowedExternalUrl, checkForUpdates = async () => ({ status: "unavailable" }) }) {
   const CUSTOM_ICON_FILE = "custom-icon.png";
   const MAX_CUSTOM_ICON_BYTES = 10 * 1024 * 1024;
   function getBundledIconPath() {
@@ -182,6 +182,7 @@ function createIpcServices({ performHapticFeedback, isAllowedExternalUrl }) {
     electron.ipcMain.handle(IPC.SETTINGS_GET, () => {
       return coordinator.getSettings();
     });
+    electron.ipcMain.handle(IPC.APP_CHECK_FOR_UPDATES, () => checkForUpdates({ force: true, notify: false }));
     electron.ipcMain.handle(IPC.GET_LOCALE, () => {
       return coordinator.getSettings().locale ?? "zh";
     });

--- a/src/main/update-service.cjs
+++ b/src/main/update-service.cjs
@@ -1,0 +1,257 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DEFAULT_RELEASE_URL = "https://api.github.com/repos/qianzhu18/workisland/releases/latest";
+const DEFAULT_DOWNLOAD_URL = "https://github.com/qianzhu18/workisland/releases/latest";
+const UPDATE_CHECK_INTERVAL_MS = 24 * 60 * 60 * 1e3;
+const UPDATE_REQUEST_TIMEOUT_MS = 8e3;
+const UPDATE_STATE_FILE = "update-check.json";
+
+function parseVersion(value) {
+  const raw = String(value ?? "").trim();
+  const match = raw.replace(/^v/i, "").match(/^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/);
+  if (!match) return null;
+  return {
+    raw,
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split(".") : []
+  };
+}
+
+function compareIdentifiers(left, right) {
+  const leftNumber = /^\d+$/.test(left);
+  const rightNumber = /^\d+$/.test(right);
+  if (leftNumber && rightNumber) return Number(left) - Number(right);
+  if (leftNumber !== rightNumber) return leftNumber ? -1 : 1;
+  return left.localeCompare(right);
+}
+
+function compareVersions(left, right) {
+  const a = typeof left === "string" ? parseVersion(left) : left;
+  const b = typeof right === "string" ? parseVersion(right) : right;
+  if (!a || !b) return null;
+  for (const key of ["major", "minor", "patch"]) {
+    if (a[key] !== b[key]) return a[key] > b[key] ? 1 : -1;
+  }
+  if (a.prerelease.length === 0 && b.prerelease.length === 0) return 0;
+  if (a.prerelease.length === 0) return 1;
+  if (b.prerelease.length === 0) return -1;
+  const length = Math.max(a.prerelease.length, b.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    if (a.prerelease[index] === undefined) return -1;
+    if (b.prerelease[index] === undefined) return 1;
+    const result = compareIdentifiers(a.prerelease[index], b.prerelease[index]);
+    if (result !== 0) return result > 0 ? 1 : -1;
+  }
+  return 0;
+}
+
+function normalizeRelease(payload) {
+  if (!payload || payload.draft || payload.prerelease) return null;
+  const version = parseVersion(payload.tag_name || payload.name);
+  if (!version) return null;
+  return {
+    version: version.raw.replace(/^v/i, ""),
+    name: String(payload.name || `WorkIsland ${version.raw}`),
+    url: typeof payload.html_url === "string" && payload.html_url.startsWith("https://")
+      ? payload.html_url
+      : DEFAULT_DOWNLOAD_URL,
+    publishedAt: payload.published_at || payload.created_at || null
+  };
+}
+
+function readState(filePath) {
+  try {
+    const value = JSON.parse(fs.readFileSync(filePath, "utf8"));
+    return {
+      lastCheckedAt: Number.isFinite(value.lastCheckedAt) ? value.lastCheckedAt : 0,
+      lastNotifiedVersion: typeof value.lastNotifiedVersion === "string" ? value.lastNotifiedVersion : "",
+      latestRelease: value.latestRelease && typeof value.latestRelease === "object" ? value.latestRelease : null
+    };
+  } catch {
+    return { lastCheckedAt: 0, lastNotifiedVersion: "", latestRelease: null };
+  }
+}
+
+function writeState(filePath, state) {
+  try {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const temporaryPath = `${filePath}.tmp`;
+    fs.writeFileSync(temporaryPath, JSON.stringify(state, null, 2));
+    fs.renameSync(temporaryPath, filePath);
+  } catch {
+    // Update state is only a cache. A write failure must not affect the app.
+  }
+}
+
+async function fetchLatestRelease(fetchImpl, releaseUrl) {
+  if (typeof fetchImpl !== "function") throw new Error("更新检测需要可用的网络请求实现");
+  const controller = typeof AbortController === "function" ? new AbortController() : null;
+  const timeout = controller ? setTimeout(() => controller.abort(), UPDATE_REQUEST_TIMEOUT_MS) : null;
+  try {
+    const response = await fetchImpl(releaseUrl, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "WorkIsland-update-check"
+      },
+      signal: controller?.signal
+    });
+    if (!response?.ok) throw new Error(`版本信息请求失败（HTTP ${response?.status ?? "unknown"}）`);
+    const release = normalizeRelease(await response.json());
+    if (!release) throw new Error("官方版本信息格式无效");
+    return release;
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+function createUpdateService({
+  app,
+  shell,
+  notificationClass,
+  userDataPath,
+  getSettings = () => ({}),
+  onUpdateAvailable = () => {},
+  fetchImpl = globalThis.fetch,
+  releaseUrl = DEFAULT_RELEASE_URL,
+  now = () => Date.now(),
+  minIntervalMs = UPDATE_CHECK_INTERVAL_MS,
+  initialDelayMs = 10e3,
+  intervalMs = UPDATE_CHECK_INTERVAL_MS,
+  logger = console
+} = {}) {
+  if (!app || typeof app.getVersion !== "function") throw new TypeError("app.getVersion is required");
+  const statePath = path.join(userDataPath || ".", UPDATE_STATE_FILE);
+  let state = readState(statePath);
+  let inFlight = null;
+  let initialTimer = null;
+  let intervalTimer = null;
+
+  function currentVersion() {
+    return String(app.getVersion());
+  }
+
+  function isDevelopment() {
+    return app.isPackaged === false;
+  }
+
+  function resultForRelease(release) {
+    const current = currentVersion();
+    const comparison = compareVersions(release.version, current);
+    if (comparison === null) {
+      return { status: "error", currentVersion: current, message: "当前版本号无法比较" };
+    }
+    return {
+      status: comparison > 0 ? "update-available" : "up-to-date",
+      currentVersion: current,
+      latestVersion: release.version,
+      releaseName: release.name,
+      releaseUrl: release.url,
+      publishedAt: release.publishedAt
+    };
+  }
+
+  function showUpdateNotification(result) {
+    if (!notificationClass) return false;
+    try {
+      if (typeof notificationClass.isSupported === "function" && !notificationClass.isSupported()) return false;
+      const notification = new notificationClass({
+        title: "WorkIsland 有新版本",
+        body: `${result.latestVersion} 已发布，点击查看下载。`
+      });
+      notification.on("click", () => {
+        void shell?.openExternal?.(result.releaseUrl || DEFAULT_DOWNLOAD_URL);
+      });
+      notification.show();
+      return true;
+    } catch (error) {
+      logger.warn?.("[UpdateService] failed to show notification:", error);
+      return false;
+    }
+  }
+
+  async function runCheck({ notify = true } = {}) {
+    state.lastCheckedAt = now();
+    writeState(statePath, state);
+    try {
+      const release = await fetchLatestRelease(fetchImpl, releaseUrl);
+      state.latestRelease = release;
+      writeState(statePath, state);
+      const result = resultForRelease(release);
+      if (result.status === "update-available") {
+        onUpdateAvailable(result);
+        if (notify && state.lastNotifiedVersion !== result.latestVersion) {
+          if (showUpdateNotification(result)) {
+            state.lastNotifiedVersion = result.latestVersion;
+            writeState(statePath, state);
+          }
+        }
+      }
+      return result;
+    } catch (error) {
+      logger.warn?.("[UpdateService] check failed:", error);
+      return {
+        status: "error",
+        currentVersion: currentVersion(),
+        message: "暂时无法获取更新信息，请稍后重试。"
+      };
+    }
+  }
+
+  function check({ force = false, notify = true } = {}) {
+    if (isDevelopment()) {
+      return Promise.resolve({ status: "disabled", reason: "development", currentVersion: currentVersion() });
+    }
+    if (!force && getSettings()?.updateChecksEnabled === false) {
+      return Promise.resolve({ status: "disabled", reason: "user-disabled", currentVersion: currentVersion() });
+    }
+    if (!force && state.lastCheckedAt && now() - state.lastCheckedAt < minIntervalMs) {
+      if (state.latestRelease) return Promise.resolve(resultForRelease(state.latestRelease));
+      return Promise.resolve({ status: "skipped", reason: "recently-checked", currentVersion: currentVersion() });
+    }
+    if (!inFlight) {
+      inFlight = runCheck({ notify }).finally(() => {
+        inFlight = null;
+      });
+    }
+    return inFlight;
+  }
+
+  function start() {
+    if (isDevelopment() || initialTimer || intervalTimer) return;
+    initialTimer = setTimeout(() => {
+      initialTimer = null;
+      void check().catch(() => {});
+      intervalTimer = setInterval(() => void check().catch(() => {}), intervalMs);
+    }, initialDelayMs);
+  }
+
+  function stop() {
+    if (initialTimer) clearTimeout(initialTimer);
+    if (intervalTimer) clearInterval(intervalTimer);
+    initialTimer = null;
+    intervalTimer = null;
+  }
+
+  return {
+    check,
+    start,
+    stop,
+    getState: () => ({ ...state }),
+    getStatePath: () => statePath
+  };
+}
+
+module.exports = {
+  DEFAULT_DOWNLOAD_URL,
+  DEFAULT_RELEASE_URL,
+  UPDATE_CHECK_INTERVAL_MS,
+  compareVersions,
+  createUpdateService,
+  normalizeRelease,
+  parseVersion
+};

--- a/src/main/windows.cjs
+++ b/src/main/windows.cjs
@@ -814,7 +814,7 @@ function createWindowClasses(dependencies) {
         minimizable: true,
         maximizable: false,
         fullscreenable: false,
-        title: "Orca Settings",
+        title: "WorkIsland Settings",
         titleBarStyle: "hiddenInset",
         trafficLightPosition: { x: 14, y: 14 },
         transparent: true,
@@ -866,7 +866,7 @@ function createWindowClasses(dependencies) {
         minHeight: 600,
         show: false,
         resizable: true,
-        title: "Orca Debug Playground",
+        title: "WorkIsland Debug Playground",
         icon: path.join(__dirname, "../../resources/icon.png"),
         webPreferences: {
           preload: path.join(__dirname, "../preload/debug.js"),

--- a/src/preload/island.js
+++ b/src/preload/island.js
@@ -39,6 +39,11 @@ electron.contextBridge.exposeInMainWorld("islandBridge", {
   onQuotaUpdate(cb) {
     electron.ipcRenderer.on(ipc.IPC.ISLAND_QUOTA_UPDATE, (_event, quotas) => cb(quotas));
   },
+  onUpdateAvailable(cb) {
+    const handler = (_event, update) => cb(update);
+    electron.ipcRenderer.on(ipc.IPC.APP_UPDATE_AVAILABLE, handler);
+    return () => electron.ipcRenderer.removeListener(ipc.IPC.APP_UPDATE_AVAILABLE, handler);
+  },
   // 渲染挂载时主动拉一次当前快照，兜底"启动期间事件已错过"的场景。
   getQuotaMap() {
     return electron.ipcRenderer.invoke(ipc.IPC.USAGE_GET_QUOTA_MAP);

--- a/src/preload/settings.js
+++ b/src/preload/settings.js
@@ -39,6 +39,12 @@ electron.contextBridge.exposeInMainWorld("settingsApi", {
   openExternal: (url) => {
     electron.ipcRenderer.send(ipc.IPC.APP_OPEN_EXTERNAL, url);
   },
+  checkForUpdates: () => electron.ipcRenderer.invoke(ipc.IPC.APP_CHECK_FOR_UPDATES),
+  onUpdateAvailable: (cb) => {
+    const handler = (_event, update) => cb(update);
+    electron.ipcRenderer.on(ipc.IPC.APP_UPDATE_AVAILABLE, handler);
+    return () => electron.ipcRenderer.removeListener(ipc.IPC.APP_UPDATE_AVAILABLE, handler);
+  },
   getAppVersion: () => electron.ipcRenderer.invoke(ipc.IPC.GET_APP_VERSION),
   onNavigateToTab: (cb) => {
     electron.ipcRenderer.on(ipc.IPC.SETTINGS_NAVIGATE_TO_TAB, (_event, tab) => cb(tab));

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -14,6 +14,7 @@ const useSessionStore = create((set) => ({
   notificationAutoDismiss: false,
   agentQuotas: {},
   onboardingExpand: false,
+  hasUpdate: false,
   toggleExpandTick: 0,
   collapseTick: 0,
   switchSessionTick: 0,
@@ -25,13 +26,14 @@ const useSessionStore = create((set) => ({
   clearSurface: () => set({ surface: null, openReason: null, notificationAutoDismiss: false }),
   setAgentQuotas: (agentQuotas) => set({ agentQuotas }),
   setOnboardingExpand: (onboardingExpand) => set({ onboardingExpand }),
+  setHasUpdate: (hasUpdate) => set({ hasUpdate }),
   requestToggleExpand: () => set((state) => ({ toggleExpandTick: state.toggleExpandTick + 1 })),
   requestCollapse: () => set((state) => ({ collapseTick: state.collapseTick + 1 })),
   requestSwitchSession: (direction) => set((state) => ({ switchSessionTick: state.switchSessionTick + 1, switchSessionDirection: direction })),
   requestConfirmSession: () => set((state) => ({ confirmSessionTick: state.confirmSessionTick + 1 }))
 }));
 function useIslandState() {
-  const { setSessions, setNotchInfo, presentSurface, setAgentQuotas } = useSessionStore();
+  const { setSessions, setNotchInfo, presentSurface, setAgentQuotas, setHasUpdate } = useSessionStore();
   reactExports.useEffect(() => {
     const bridge = window.islandBridge;
     if (!bridge) {
@@ -48,6 +50,7 @@ function useIslandState() {
       presentSurface(surface, reason, autoDismiss);
     });
     bridge.onQuotaUpdate((quotas) => setAgentQuotas(quotas));
+    const offUpdate = bridge.onUpdateAvailable?.(() => setHasUpdate(true));
     void bridge.getQuotaMap().then((quotas) => {
       if (quotas && Object.keys(quotas).length > 0) setAgentQuotas(quotas);
     });
@@ -69,6 +72,7 @@ function useIslandState() {
     bridge.onConfirmSession?.(() => {
       useSessionStore.getState().requestConfirmSession();
     });
+    return () => offUpdate?.();
   }, []);
 }
 function useIslandAnimation() {
@@ -108,7 +112,8 @@ function IslandApp() {
     notificationAutoDismiss,
     clearSurface,
     presentSurface,
-    agentQuotas
+    agentQuotas,
+    hasUpdate
   } = useSessionStore();
   const onboardingExpand = useSessionStore((s) => s.onboardingExpand);
   const setOnboardingExpand = useSessionStore((s) => s.setOnboardingExpand);
@@ -150,7 +155,6 @@ function IslandApp() {
   const [hoverToOpen, setHoverToOpen] = reactExports.useState(DEFAULT_SETTINGS.hoverToOpen);
   const [autoCollapseOnMouseLeave, setAutoCollapseOnMouseLeave] = reactExports.useState(DEFAULT_SETTINGS.autoCollapseOnMouseLeave);
   const [showUsageQuota, setShowUsageQuota] = reactExports.useState(DEFAULT_SETTINGS.showUsageQuota);
-  const hasUpdate = false;
   const [tokenBurnTotal, setTokenBurnTotal] = reactExports.useState(0);
   const [autoCollapseDurationMs, setAutoCollapseDurationMs] = reactExports.useState(
     DEFAULT_SETTINGS.completionPopupDurationSec * 1e3

--- a/src/renderer/settings-app.css
+++ b/src/renderer/settings-app.css
@@ -32,6 +32,7 @@ button, select, input { font:inherit; }
 .switch input:checked + .switch-track::after { transform:translateX(16px); }
 select { min-width:142px; height:30px; padding:0 28px 0 9px; color:inherit; background:rgba(255,255,255,.68); border:1px solid var(--line); border-radius:7px; }
 .inline-controls { display:flex; align-items:center; gap:8px; flex:0 0 auto; }
+.update-status { color:var(--muted); font-size:12px; white-space:nowrap; }
 .inline-controls select { min-width:220px; }
 .text-input { width:230px; height:30px; padding:0 9px; color:inherit; background:rgba(255,255,255,.68); border:1px solid var(--line); border-radius:7px; }
 .compact-select { min-width:130px; height:27px; margin-top:7px; font-size:12px; }

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -3,7 +3,7 @@
 const api = window.settingsApi;
 
 const DEFAULT_PET_SPRITE = "codex:qianxue";
-const state = { settings: null, statuses: new Map(), displays: [], codexPets: [], activeTab: "general", busy: new Set() };
+const state = { settings: null, statuses: new Map(), displays: [], codexPets: [], activeTab: "general", busy: new Set(), latestUpdate: null };
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -324,10 +324,46 @@ function aboutPage() {
   version.append(el("div", "app-mark", "O"), el("div", "about-copy", "WorkIsland\n正在读取版本…"));
   api.getAppVersion().then(v => version.querySelector(".about-copy").textContent = `WorkIsland\n版本 ${v}`).catch(() => {});
   about.append(version);
+  const updates = section("更新", "仅请求官方版本信息，不上传会话内容或使用数据。");
+  const updateStatus = el("div", "update-status", state.latestUpdate ? `发现新版本 ${state.latestUpdate.latestVersion}` : "尚未检查");
+  let latestUrl = state.latestUpdate?.releaseUrl || "";
+  const openButton = button("打开下载页", () => {
+    if (latestUrl) api.openExternal(latestUrl);
+  });
+  openButton.hidden = !latestUrl;
+  const checkButton = button("检查更新", async () => {
+    checkButton.disabled = true;
+    updateStatus.textContent = "正在检查…";
+    try {
+      const result = await api.checkForUpdates();
+      if (result?.status === "update-available") {
+        state.latestUpdate = result;
+        latestUrl = result.releaseUrl || "";
+        openButton.hidden = !latestUrl;
+        updateStatus.textContent = `发现新版本 ${result.latestVersion}`;
+      } else if (result?.status === "up-to-date") {
+        updateStatus.textContent = `当前已是最新版本（${result.currentVersion}）`;
+      } else if (result?.status === "disabled") {
+        updateStatus.textContent = "开发模式下不执行更新检查";
+      } else {
+        updateStatus.textContent = result?.message || "暂时无法获取更新信息";
+      }
+    } catch (error) {
+      updateStatus.textContent = error?.message || "暂时无法获取更新信息";
+    } finally {
+      checkButton.disabled = false;
+    }
+  });
+  const updateControls = el("div", "inline-controls");
+  updateControls.append(updateStatus, checkButton, openButton);
+  updates.append(
+    row("自动检查更新", "安装版每天检查一次 GitHub Release；关闭后仍可手动检查。", toggle(state.settings.updateChecksEnabled, v => save({ updateChecksEnabled: v }), "自动检查更新")),
+    row("版本检查", "发现新版本后会提醒，并提供官方下载页。", updateControls)
+  );
   const actions = el("div", "section-actions");
   actions.append(button("导出诊断日志", async () => { const path = await api.collectLogs(); showToast(path ? "日志已导出" : "日志导出完成"); }), button("退出应用", () => api.quitApp(), "danger"));
   about.append(actions);
-  root.append(about);
+  root.append(about, updates);
   return root;
 }
 
@@ -361,6 +397,10 @@ async function start() {
     const aliases = { hooks: "agents", pet: "appearance", display: "general" };
     const next = aliases[tab] || tab;
     if (PAGES[next]) { state.activeTab = next; renderPage(); }
+  });
+  api.onUpdateAvailable?.(update => {
+    state.latestUpdate = update;
+    if (state.activeTab === "about") renderPage();
   });
   api.onSettingsChanged?.(settings => { state.settings = settings; renderPage(); });
   renderPage();

--- a/src/renderer/shared/settings.js
+++ b/src/renderer/shared/settings.js
@@ -93,7 +93,8 @@ const DEFAULT_PILL_FIRST_ROW = {
   claudeSubscription: true,
   codexSubscription: true,
   tokenCount: true,
-  soundIcon: true
+  soundIcon: true,
+  upgradeButton: true
 };
 const DEFAULT_SHORTCUTS = {
   modifiers: ["Ctrl"],
@@ -124,6 +125,7 @@ const DEFAULT_SETTINGS = {
   expandOnSessionComplete: true,
   expandOnActionRequired: true,
   suppressNotificationWhenFocused: true,
+  updateChecksEnabled: true,
   hookToggles: { ...DEFAULT_HOOK_TOGGLES },
   approvalModes: { ...DEFAULT_APPROVAL_MODES },
   showDebugWindow: false,

--- a/src/shared/ipc.cjs
+++ b/src/shared/ipc.cjs
@@ -89,6 +89,8 @@ const IPC = Object.freeze({
   SET_LOCALE: "locale:set",
   APP_QUIT: "app:quit",
   APP_OPEN_EXTERNAL: "app:open-external",
+  APP_CHECK_FOR_UPDATES: "app:check-for-updates",
+  APP_UPDATE_AVAILABLE: "app:update-available",
   USAGE_GET_QUOTA: "usage:get-quota",
   USAGE_GET_QUOTA_MAP: "usage:get-quota-map",
   STATS_GET_SNAPSHOT: "stats:get-snapshot",

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -41,7 +41,8 @@ const DEFAULT_PILL_FIRST_ROW = {
   claudeSubscription: true,
   codexSubscription: true,
   tokenCount: true,
-  soundIcon: true
+  soundIcon: true,
+  upgradeButton: true
 };
 
 const DEFAULT_SHORTCUTS = {
@@ -79,6 +80,7 @@ const DEFAULT_SETTINGS = {
   expandOnSessionComplete: true,
   expandOnActionRequired: true,
   suppressNotificationWhenFocused: true,
+  updateChecksEnabled: true,
   hookToggles: { ...DEFAULT_HOOK_TOGGLES },
   approvalModes: { ...DEFAULT_APPROVAL_MODES },
   showDebugWindow: false,

--- a/tests/update-service.test.mjs
+++ b/tests/update-service.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { compareVersions, createUpdateService } = require("../src/main/update-service.cjs");
+
+function makeApp(version, isPackaged = true) {
+  return { isPackaged, getVersion: () => version };
+}
+
+test("version comparison treats stable releases as newer than prereleases", () => {
+  assert.equal(compareVersions("1.0.0", "1.0.0-beta.2"), 1);
+  assert.equal(compareVersions("1.0.0-beta.10", "1.0.0-beta.2"), 1);
+  assert.equal(compareVersions("1.2.0", "1.10.0"), -1);
+  assert.equal(compareVersions("v1.0.0", "1.0.0"), 0);
+});
+
+test("update service reports and notifies about a newer stable release once", async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), "workisland-update-"));
+  const shown = [];
+  const opened = [];
+  const available = [];
+  class FakeNotification {
+    static isSupported() { return true; }
+    constructor(options) { this.options = options; }
+    on(event, handler) { if (event === "click") this.click = handler; }
+    show() { shown.push(this); }
+  }
+  const service = createUpdateService({
+    app: makeApp("0.2.0"),
+    shell: { openExternal: (url) => opened.push(url) },
+    notificationClass: FakeNotification,
+    userDataPath,
+    onUpdateAvailable: (update) => available.push(update),
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({
+        tag_name: "v0.3.0",
+        name: "WorkIsland 0.3.0",
+        html_url: "https://github.com/qianzhu18/workisland/releases/tag/v0.3.0",
+        prerelease: false
+      })
+    }),
+    logger: { warn() {} }
+  });
+
+  const first = await service.check({ force: true });
+  assert.equal(first.status, "update-available");
+  assert.equal(first.latestVersion, "0.3.0");
+  assert.equal(available.length, 1);
+  assert.equal(shown.length, 1);
+  shown[0].click();
+  assert.deepEqual(opened, [first.releaseUrl]);
+
+  await service.check({ force: true });
+  assert.equal(shown.length, 1);
+});
+
+test("development builds never contact the release endpoint", async () => {
+  let fetchCount = 0;
+  const service = createUpdateService({
+    app: makeApp("0.2.0", false),
+    userDataPath: mkdtempSync(join(tmpdir(), "workisland-update-dev-")),
+    fetchImpl: async () => {
+      fetchCount += 1;
+      return { ok: true, json: async () => ({ tag_name: "v9.0.0" }) };
+    }
+  });
+  const result = await service.check({ force: true });
+  assert.equal(result.status, "disabled");
+  assert.equal(fetchCount, 0);
+});


### PR DESCRIPTION
## Summary

- Add a packaged-app update service that checks the stable GitHub Release once per day.
- Add manual update checking, a settings toggle, macOS notification, and Island update indicator.
- Add semver-aware release metadata validation and unit tests.
- Standardize Tag, Release, signing, notarization, and update behavior in docs.
- Update the release workflow with concurrency protection and release validation.
- Align runtime app name and app user model ID with WorkIsland.

## Validation

- `npm run check`
- `npm run release:check -- --tag v0.2.8-beta.6`
- `npm run package:mac` (local unsigned DMG generated successfully)

## Release note

Official Tag releases still require the configured GitHub Actions Secrets for Developer ID signing and Apple notarization.