### PR TITLE
feat(settings): expose completion notification duration

### DIFF
--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -102,7 +102,17 @@ function generalPage() {
     row("全屏时隐藏", "全屏应用位于当前屏幕时隐藏 Island。", toggle(state.settings.hideWhenFullscreen, v => save({ hideWhenFullscreen: v }), "全屏时隐藏")),
     row("没有会话时隐藏", "仅在 Agent 活动期间显示 Island。", toggle(state.settings.hideWhenNoActiveSessions, v => save({ hideWhenNoActiveSessions: v }), "无会话时隐藏")),
     row("需要操作时展开", "审批、提问或计划确认到来时自动展开。", toggle(state.settings.expandOnActionRequired, v => save({ expandOnActionRequired: v }), "操作时展开")),
-    row("任务完成时展开", "Agent 完成当前轮次时短暂展示结果。", toggle(state.settings.expandOnSessionComplete, v => save({ expandOnSessionComplete: v }), "完成时展开"))
+    row("任务完成时展开", "Agent 完成当前轮次时短暂展示结果。", toggle(state.settings.expandOnSessionComplete, v => save({ expandOnSessionComplete: v }), "完成时展开")),
+    row(
+      "完成通知停留时间",
+      "只影响任务完成通知；审批、提问和失败通知会保留到你处理为止。",
+      select(
+        state.settings.completionPopupDurationSec,
+        [["5", "5 秒"], ["10", "10 秒"], ["20", "20 秒"], ["30", "30 秒"]],
+        v => save({ completionPopupDurationSec: Number(v) }),
+        "完成通知停留时间"
+      )
+    )
   );
 
   const display = section("显示", "选择 Island 所在屏幕与信息密度。");

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -75,7 +75,7 @@ const DEFAULT_SETTINGS = {
   alwaysHide: false,
   hideWhenNoActiveSessions: false,
   autoCollapseOnMouseLeave: true,
-  completionPopupDurationSec: 5,
+  completionPopupDurationSec: 10,
   showUsageQuota: true,
   usageDisplayValue: "used",
   disableClaudeTerminalTitle: true,

--- a/tests/settings-ui.test.mjs
+++ b/tests/settings-ui.test.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+const source = readFileSync(new URL("../src/renderer/settings-app.js", import.meta.url), "utf8");
+
+test("general settings expose all completion notification duration options", () => {
+  assert.match(source, /完成通知停留时间/);
+  for (const seconds of [5, 10, 20, 30]) {
+    assert.match(source, new RegExp(`\\["${seconds}", "${seconds} 秒"\\]`));
+  }
+  assert.match(source, /save\(\{ completionPopupDurationSec: Number\(v\) \}\)/);
+});

--- a/tests/sound-service.test.mjs
+++ b/tests/sound-service.test.mjs
@@ -52,3 +52,7 @@ test("partial persisted sound settings retain every default event", () => {
   assert.equal(merged.sound.events.sessionStart.enabled, true);
   assert.equal(merged.sound.events.approvalNeeded.enabled, true);
 });
+
+test("completion notifications default to ten seconds when no user value exists", () => {
+  assert.equal(mergeSettings({}).completionPopupDurationSec, 10);
+});


### PR DESCRIPTION
## 内容
- 将任务完成通知默认停留时长由 5 秒改为 10 秒
- 在“通用 → Island 行为”提供 5 / 10 / 20 / 30 秒选项
- 设置即时同步到灵动岛和桌宠；审批、提问、失败通知继续保持直到用户处理

## 验证
- `npm run check`（30 tests passed）

Closes #8