### PR TITLE
fix(island): 用量单元格改显示『剩余余量』，修复 0%↔100% 翻转 (#21)

### DIFF
--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -115,17 +115,31 @@ function usagePctColor(pct) {
   if (pct >= 50) return "#FFC224";
   return "#00F873";
 }
+function remainingPctColor(pct) {
+  // 余量越低越危险：≤20% 红，≤50% 黄，其余绿
+  if (pct <= 20) return "#FF304B";
+  if (pct <= 50) return "#FFC224";
+  return "#00F873";
+}
 function AgentQuotaCell({ tool, quota }) {
   const dailyValid = isValidPeriod(quota.daily);
   const weeklyValid = isValidPeriod(quota.weekly);
   const [showTooltip, setShowTooltip] = React.useState(false);
   const activePeriod = dailyValid ? quota.daily : weeklyValid ? quota.weekly : null;
+  // 灵动岛应以「剩余余量」展示：余量 = 100 − 已用。
+  // 之前直接展示 usedPct（已用%），导致 Codex 余量耗尽（剩余 0%）时数字显示成 100%，
+  // 与用户直觉（余量应为 0%）正好相反。
+  const remainingPct = activePeriod
+    ? Math.max(0, Math.min(100, 100 - activePeriod.usedPct))
+    : 0;
   const tooltipLines = [];
   if (dailyValid) {
-    tooltipLines.push(`${i18n.k296832979({ placeholder1: quota.daily.total, placeholder2: formatPct(quota.daily.usedPct), placeholder3: quota.daily.remaining }, "{placeholder1} 额度已用 {placeholder2}%, {placeholder3} 后重置")}`);
+    const r = Math.max(0, Math.min(100, 100 - quota.daily.usedPct));
+    tooltipLines.push(`${quota.daily.total} 余量 ${formatPct(r)}%, ${quota.daily.remaining} 后重置`);
   }
   if (weeklyValid) {
-    tooltipLines.push(`${i18n.k296832979({ placeholder1: quota.weekly.total, placeholder2: formatPct(quota.weekly.usedPct), placeholder3: quota.weekly.remaining }, "{placeholder1} 额度已用 {placeholder2}%, {placeholder3} 后重置")}`);
+    const r = Math.max(0, Math.min(100, 100 - quota.weekly.usedPct));
+    tooltipLines.push(`${quota.weekly.total} 余量 ${formatPct(r)}%, ${quota.weekly.remaining} 后重置`);
   }
   return /* @__PURE__ */ React.createElement(
     "div",
@@ -135,7 +149,7 @@ function AgentQuotaCell({ tool, quota }) {
       onMouseLeave: () => setShowTooltip(false)
     },
     /* @__PURE__ */ React.createElement("span", { className: "agent-monogram", title: AGENT_TOOL_LABELS[tool], style: { background: AGENT_BADGE_COLORS[tool] ?? "#7B8794" } }, String(AGENT_TOOL_LABELS[tool] ?? tool).slice(0, 1).toUpperCase()),
-    activePeriod && /* @__PURE__ */ React.createElement("span", { className: "usage-cell-text" }, /* @__PURE__ */ React.createElement("span", { className: "usage-period" }, activePeriod.total, " ", /* @__PURE__ */ React.createElement("span", { style: { color: usagePctColor(activePeriod.usedPct) } }, formatPct(activePeriod.usedPct), "%"), " ", activePeriod.remaining)),
+    activePeriod && /* @__PURE__ */ React.createElement("span", { className: "usage-cell-text" }, /* @__PURE__ */ React.createElement("span", { className: "usage-period" }, activePeriod.total, " ", /* @__PURE__ */ React.createElement("span", { style: { color: remainingPctColor(remainingPct) } }, "余量", formatPct(remainingPct), "%"), " ", activePeriod.remaining)),
     tooltipLines.length > 0 && showTooltip && /* @__PURE__ */ React.createElement("span", { className: "usage-cell-tooltip is-visible", role: "tooltip" }, tooltipLines.join("\n"))
   );
 }


### PR DESCRIPTION
## 关联 Issue
Closes #21

## 问题
灵动岛用量单元格（Claude / Codex 共用 `AgentQuotaCell`）直接展示 `usedPct`（已用%），导致 Codex 余量耗尽（剩余 0%）时数字显示成 100%，与「余量应为 0%」的直觉相反。

## 修复
- 在 `AgentQuotaCell` 中按 `remainingPct = clamp(100 - usedPct, 0, 100)` 计算剩余余量；
- 主数字与 tooltip 文案改为「余量 X%」；
- 颜色按余量高低着色（≤20% 红 / ≤50% 黄 / 其余绿），与危险程度直觉一致。

## 改动文件
- `src/renderer/island/components/IslandPanel.js`（+17 / -3）

## 验证
- `node --check` 通过；
- 仓库无 quota / IslandPanel 相关单测受影响；
- 分支已 rebase 到 `main`，PR 仅含本修复提交。