### PR TITLE
fix(pilot): keep telemetry consent window usable

### DIFF
--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -891,21 +891,35 @@ async function runIslandApp() {
       islandWindow?.moveToDisplay(t, { force: !!reason });
     });
   }
+  function startIsland({ expandAfterOnboarding = false } = {}) {
+    if (islandWindow) return islandWindow;
+    islandWindow = createIslandWindow();
+    if (!islandWindow) return void 0;
+    bindDisplayListener();
+    if (expandAfterOnboarding) {
+      const iw = islandWindow;
+      iw.browserWindow.webContents.once("did-finish-load", () => {
+        setTimeout(() => {
+          iw.send(IPC.ISLAND_ONBOARDING_EXPAND);
+        }, 500);
+      });
+    }
+    return islandWindow;
+  }
   const needsOnboarding = !coordinator.getSettings().hasCompletedOnboarding;
   const needsTelemetryConsent = isTelemetryConsentPending(coordinator.getSettings());
 
   function showWelcomeWindow({ consentOnly = false, afterComplete } = {}) {
-    const welcomeWindow = new WelcomeWindow({
-      consentOnly,
-      parent: consentOnly ? islandWindow?.browserWindow : undefined
-    });
-    bindCommandW(welcomeWindow.browserWindow, () => welcomeWindow.close());
+    const welcomeWindow = new WelcomeWindow({ consentOnly });
 
     let resolved = false;
+    const cleanupWelcome = () => {
+      electron.ipcMain.removeListener(IPC.WELCOME_GET_STARTED, onGetStarted);
+    };
     const finishWelcome = (payload = {}) => {
       if (resolved) return;
       resolved = true;
-      electron.ipcMain.removeListener(IPC.WELCOME_GET_STARTED, onGetStarted);
+      cleanupWelcome();
 
       if (needsTelemetryConsent) {
         const choice = createTelemetryConsentChoice(payload.telemetry);
@@ -921,7 +935,12 @@ async function runIslandApp() {
       finishWelcome(payload);
     };
     electron.ipcMain.on(IPC.WELCOME_GET_STARTED, onGetStarted);
-    welcomeWindow.browserWindow.once("closed", () => finishWelcome());
+    welcomeWindow.browserWindow.once("closed", () => {
+      cleanupWelcome();
+      if (resolved || isQuitting) return;
+      log.warn("[main] WelcomeWindow closed before an explicit choice; consent remains pending");
+      electron.app.quit();
+    });
   }
 
   if (needsOnboarding) {
@@ -931,20 +950,15 @@ async function runIslandApp() {
     }
     showWelcomeWindow({ afterComplete: () => {
       coordinator.updateSettings({ hasCompletedOnboarding: true });
-      islandWindow = createIslandWindow();
-      if (!islandWindow) return;
-      bindDisplayListener();
-      const iw = islandWindow;
-      iw.browserWindow.webContents.once("did-finish-load", () => {
-        setTimeout(() => {
-          iw.send(IPC.ISLAND_ONBOARDING_EXPAND);
-        }, 500);
-      });
+      startIsland({ expandAfterOnboarding: true });
     } });
+  } else if (needsTelemetryConsent) {
+    showWelcomeWindow({
+      consentOnly: true,
+      afterComplete: startIsland
+    });
   } else {
-    islandWindow = createIslandWindow();
-    bindDisplayListener();
-    if (needsTelemetryConsent) showWelcomeWindow({ consentOnly: true });
+    startIsland();
   }
   coordinator.setPetWindowFactory((x, y) => {
     const petWindow = new PetWindow(x, y, coordinator.getSettings().petScale);

--- a/src/main/windows.cjs
+++ b/src/main/windows.cjs
@@ -892,8 +892,7 @@ function createWindowClasses(dependencies) {
   }
   class WelcomeWindow {
     win;
-    constructor({ consentOnly = false, parent } = {}) {
-      const parentWindow = parent && !parent.isDestroyed?.() ? parent : undefined;
+    constructor({ consentOnly = false } = {}) {
       this.win = new electron.BrowserWindow({
         width: 420,
         height: 540,
@@ -905,8 +904,6 @@ function createWindowClasses(dependencies) {
         transparent: true,
         backgroundColor: "#00000000",
         center: true,
-        parent: parentWindow,
-        modal: Boolean(parentWindow),
         icon: path.join(__dirname, "../../resources/icon.png"),
         webPreferences: {
           preload: path.join(__dirname, "../preload/welcome.js"),
@@ -924,6 +921,7 @@ function createWindowClasses(dependencies) {
       }
       this.win.once("ready-to-show", () => {
         this.win.show();
+        this.win.focus();
       });
     }
     get browserWindow() {

--- a/tests/telemetry-ui.test.mjs
+++ b/tests/telemetry-ui.test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import path from "node:path";
+import { createRequire } from "node:module";
 import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
+const { createWindowClasses } = require("../src/main/windows.cjs");
 
 const settingsSource = readFileSync(new URL("../src/renderer/settings-app.js", import.meta.url), "utf8");
 const welcomeSource = readFileSync(new URL("../src/renderer/assets/welcome-view.js", import.meta.url), "utf8");
@@ -37,8 +42,44 @@ test("telemetry stays opt-in by default in shared settings", () => {
 
 test("upgraded users see a standalone consent window once", () => {
   assert.match(mainSource, /isTelemetryConsentPending\(coordinator\.getSettings\(\)\)/);
-  assert.match(mainSource, /showWelcomeWindow\(\{ consentOnly: true \}\)/);
+  assert.match(mainSource, /showWelcomeWindow\(\{\s*consentOnly: true,\s*afterComplete: startIsland\s*\}\)/);
   assert.match(windowSource, /\?mode=telemetry/);
   assert.match(welcomeSource, /telemetryConsentOnly/);
   assert.match(welcomeSource, /你的隐私选择/);
+});
+
+test("telemetry consent is independent from the auto-hiding Island window", () => {
+  let browserWindowOptions;
+  class FakeBrowserWindow {
+    constructor(options) {
+      browserWindowOptions = options;
+    }
+    loadFile() {}
+    once() {}
+  }
+
+  const { WelcomeWindow } = createWindowClasses({
+    electron: { BrowserWindow: FakeBrowserWindow },
+    path,
+    utils: { is: { dev: false } },
+    IPC: {},
+    fixPanel() {},
+    fixPetWindow() {},
+    setWindowCornerRadius() {},
+    log: { debug() {}, error() {}, warn() {} },
+    isVisibleInIsland() { return false; },
+    getIsQuitting() { return false; }
+  });
+
+  new WelcomeWindow({
+    consentOnly: true,
+    parent: { isDestroyed: () => false }
+  });
+
+  assert.equal("parent" in browserWindowOptions, false);
+  assert.equal("modal" in browserWindowOptions, false);
+});
+
+test("closing the consent window cannot silently record a decision", () => {
+  assert.doesNotMatch(mainSource, /\.once\("closed", \(\) => finishWelcome\(\)\)/);
 });


### PR DESCRIPTION
修复 v0.3.0-beta.1 的 P0 启动问题：

- 升级用户先完成独立隐私选择，再创建灵动岛，避免灵动岛失焦收回连带协议窗口。
- 协议窗口异常关闭不再隐式记录拒绝。
- 增加 Electron 窗口配置与生命周期回归测试。
- 已通过 npm run check，并用隔离用户数据启动真实 DMG 内 Electron 进程验证协议页和选择后的窗口顺序。