### PR TITLE
feat(claude): 识别 Claude Desktop 会话 —— 启动发现、Cowork 感知、深链跳转

### DIFF
--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -12,6 +12,7 @@ const { QuotaService } = require("./quota-service.cjs");
 const { getStatsService } = require("./stats-service.cjs");
 const { resolveApprovalMode } = require("../shared/approval-policy.cjs");
 const { saveSessions } = require("./hook-shared.cjs");
+const { readClaudeTranscriptState } = require("./transcript-recovery.cjs");
 const { ClaudeHookManager, CodexHookManager } = require("./hooks-core.cjs");
 const { CocoHookManager, CursorHookManager, TraeHookManager, TraeCnHookManager } = require("./hooks-editors.cjs");
 const { OpenCodePluginManager, SaraPluginManager, KimiHookManager, GeminiHookManager, CopilotCliHookManager } = require("./hooks-plugins.cjs");
@@ -300,6 +301,19 @@ function createAppCoordinatorClass({
       this.quotaService.start();
       this.processMonitor.start();
       this.startCodexTranscriptWatcher();
+      // 启动发现：WorkIsland 只靠 hook 被动感知会话，它启动之前就在跑的对话
+      // 要等下一个 hook 事件才会现身。主动扫一次正在运行的 claude CLI 进程
+      // 与 Cowork 本地会话，合成 sessionStarted 注入现有管线。
+      setTimeout(() => {
+        try {
+          this.scanCoworkSessions();
+        } catch (err) {
+          log.warn("[AppCoordinator] cowork scan failed:", err?.message ?? err);
+        }
+        this.discoverRunningClaudeSessions().catch((err) => {
+          log.warn("[AppCoordinator] claude session discovery failed:", err?.message ?? err);
+        });
+      }, 2e3);
       this.startReconciliation();
       this.startFullscreenCheck();
       this.autoReInstallHooks();
@@ -332,6 +346,202 @@ function createAppCoordinatorClass({
         log.warn("[AppCoordinator] codex transcript watcher failed to start:", err.message);
         this.codexTranscriptWatcher = null;
       }
+    }
+    /**
+     * 发现已在运行的 claude CLI 会话（WorkIsland 启动前就开始的那些）。
+     *
+     * 路线：ps 找 claude 进程 → lsof 拿各自 cwd → 映射到
+     * ~/.claude/projects/<转义后 cwd>/ 下最新的 transcript（文件名即 session id）
+     * → 读尾部抽出最近一条用户消息 → 合成 sessionStarted 注入 agentEvent 管线。
+     *
+     * latestUserPrompt 必须带上：isVisibleInIsland 对 hook 管理的 claude 会话
+     * 要求它非空，缺了就算注入成功也不会显示。
+     * jumpTarget 不合成 —— 它来自 hook 环境（tty/pid），猜出来的会跳错地方；
+     * 该会话的下一个 hook 事件会自然补上。
+     */
+    async discoverRunningClaudeSessions() {
+      const RECOVERY_LOOKBACK_MS = 24 * 60 * 60 * 1e3;
+      const cp = require("child_process");
+      const { promisify: pify } = require("util");
+      const run = pify(cp.execFile);
+      const fs = require("fs");
+      const path = require("path");
+      const os = require("os");
+      let stdout;
+      try {
+        // comm= 只输出可执行路径、不带参数 —— 不能用 command= 取第一个词：
+        // Claude Desktop 内嵌 CLI 的路径含空格（Application Support），
+        // 按空白切词会断在 "Application"，basename 永远匹配不上。
+        ({ stdout } = await run("/bin/ps", ["-axo", "pid=,comm="], { timeout: 2e3 }));
+      } catch {
+        return;
+      }
+      const pids = [];
+      for (const line of stdout.split("\n")) {
+        const m = line.match(/^\s*(\d+)\s+(.+)$/);
+        if (!m) continue;
+        const base = m[2].trim().split("/").pop();
+        if (base === "claude") pids.push(m[1]);
+      }
+      if (pids.length === 0) return;
+      // lsof 批量拿 cwd：-F pn 输出 pPID / n路径 成对出现
+      let cwdOut = "";
+      try {
+        ({ stdout: cwdOut } = await run(
+          "/usr/sbin/lsof",
+          ["-a", "-p", pids.join(","), "-d", "cwd", "-Fpn"],
+          { timeout: 3e3 }
+        ));
+      } catch {
+        return;
+      }
+      const cwds = new Map();
+      let curPid = null;
+      for (const line of cwdOut.split("\n")) {
+        if (line.startsWith("p")) curPid = line.slice(1);
+        else if (line.startsWith("n") && curPid) cwds.set(curPid, line.slice(1));
+      }
+      const projectsRoot = path.join(os.homedir(), ".claude", "projects");
+      const dirs = new Set(cwds.values());
+      let discovered = 0;
+      for (const cwd of dirs) {
+        const projDir = path.join(projectsRoot, cwd.replace(/[\/.]/g, "-"));
+        let files;
+        try {
+          files = fs.readdirSync(projDir)
+            .filter((f) => f.endsWith(".jsonl"))
+            .map((f) => ({ f, mtime: fs.statSync(path.join(projDir, f)).mtimeMs }))
+            .sort((a, b) => b.mtime - a.mtime);
+        } catch {
+          continue;
+        }
+        const now = Date.now();
+        // 同一工作目录可能有多个并行 Claude 会话，不能只取最新文件。以 transcript
+        // 的最后一轮是否有终止记录判定“未完成”，因此长时间无输出的任务也能恢复。
+        for (const { f, mtime } of files) {
+          if (now - mtime > RECOVERY_LOOKBACK_MS) continue;
+          const sessionId = f.slice(0, -6);
+          if (this.state.sessions.has(sessionId)) continue;
+          const transcriptPath = path.join(projDir, f);
+          const transcript = this.readClaudeTranscriptState(transcriptPath);
+          if (!transcript.unfinished || !transcript.latestPrompt) continue;
+          this.bridge.emitEvent({
+            type: "sessionStarted",
+            sessionId,
+            tool: "claude",
+            timestamp: now,
+            latestUserPrompt: transcript.latestPrompt,
+            title: transcript.latestPrompt.length > 40 ? transcript.latestPrompt.slice(0, 40) + "…" : transcript.latestPrompt,
+            detectionSource: "discovery",
+            recoveredFromTranscript: true,
+            recoveryTranscriptPath: transcriptPath
+          });
+          discovered++;
+        }
+      }
+      if (discovered > 0) {
+        log.info("[AppCoordinator] discovered %d running claude session(s)", discovered);
+      }
+    }
+    /**
+     * 发现 Claude Desktop 的 Cowork（本地 Agent 模式）会话。
+     *
+     * Cowork 跑在 VM 沙箱里：进程在 VM 内（宿主机 ps 看不见）、hook 也没装，
+     * 现有两条感知通道全部失明。但宿主机上有完整痕迹：
+     *   local-agent-mode-sessions/<org>/<acct>/local_<id>.json   元数据（标题等）
+     *   local-agent-mode-sessions/<org>/<acct>/local_<id>/audit.jsonl  transcript 镜像
+     * 用 audit 的 mtime 判活（与 claude 发现同一个 3 分钟窗口），周期扫描：
+     * 新会话注入 sessionStarted，已知会话用 activityUpdated 续命，
+     * 停止写入后由现有 claude 闲置 sweep 自然停表。
+     */
+    scanCoworkSessions() {
+      const fs = require("fs");
+      const path = require("path");
+      const os = require("os");
+      const ACTIVE_WINDOW_MS = 3 * 6e4;
+      const root = path.join(
+        os.homedir(),
+        "Library", "Application Support", "Claude", "local-agent-mode-sessions"
+      );
+      let orgs;
+      try {
+        orgs = fs.readdirSync(root);
+      } catch {
+        return;
+      }
+      const now = Date.now();
+      for (const org of orgs) {
+        const orgDir = path.join(root, org);
+        let accts;
+        try {
+          if (!fs.statSync(orgDir).isDirectory()) continue;
+          accts = fs.readdirSync(orgDir);
+        } catch {
+          continue;
+        }
+        for (const acct of accts) {
+          const acctDir = path.join(orgDir, acct);
+          let names;
+          try {
+            if (!fs.statSync(acctDir).isDirectory()) continue;
+            names = fs.readdirSync(acctDir);
+          } catch {
+            continue;
+          }
+          for (const name of names) {
+            if (!name.startsWith("local_") || !name.endsWith(".json")) continue;
+            let rec;
+            try {
+              rec = JSON.parse(fs.readFileSync(path.join(acctDir, name), "utf8"));
+            } catch {
+              continue;
+            }
+            if (!rec?.cliSessionId || rec.isArchived) continue;
+            const audit = path.join(acctDir, name.slice(0, -5), "audit.jsonl");
+            let mtime;
+            try {
+              mtime = fs.statSync(audit).mtimeMs;
+            } catch {
+              continue;
+            }
+            if (now - mtime > ACTIVE_WINDOW_MS) continue;
+            const known = this.state.sessions.get(rec.cliSessionId);
+            if (known) {
+              // 续命：audit 还在写就说明 VM 里还在跑，把 updatedAt 顶上去，
+              // 免得被闲置 sweep 提前停表
+              if (!known.isSessionEnded && mtime > known.updatedAt + 1e3) {
+                this.bridge.emitEvent({
+                  type: "activityUpdated",
+                  sessionId: rec.cliSessionId,
+                  tool: "claude",
+                  timestamp: Math.round(mtime),
+                  detectionSource: "cowork"
+                });
+              }
+              continue;
+            }
+            const prompt = this.readLatestUserPrompt(audit)
+              ?? (typeof rec.initialMessage === "string" ? rec.initialMessage.trim().slice(0, 200) : null);
+            if (!prompt) continue;
+            this.bridge.emitEvent({
+              type: "sessionStarted",
+              sessionId: rec.cliSessionId,
+              tool: "claude",
+              timestamp: Math.round(mtime),
+              latestUserPrompt: prompt,
+              title: rec.title || (prompt.length > 40 ? prompt.slice(0, 40) + "…" : prompt),
+              detectionSource: "cowork"
+            });
+            log.info("[AppCoordinator] cowork session discovered: %s (%s)", rec.cliSessionId, rec.title ?? "");
+          }
+        }
+      }
+    }
+    readLatestUserPrompt(file) {
+      return this.readClaudeTranscriptState(file).latestPrompt;
+    }
+    readClaudeTranscriptState(file) {
+      return readClaudeTranscriptState(file);
     }
     async autoReInstallHooks() {
       const toggles = this.settings.hookToggles ?? {};
@@ -1080,6 +1290,13 @@ function createAppCoordinatorClass({
         // 主动发现：transcript watcher 已知的 session 但 state 里还没有
         // （说明 hook 没装或没发），合成 sessionStarted 让灵动岛能看到它们。
         const codexDiscoveredChanged = this.discoverUntrackedCodexSessions();
+        // Cowork（VM 内会话）既无宿主进程也无 hook，靠周期扫描感知；
+        // 事件经 bridge.emitEvent 走标准管线，广播由 agentEvent handler 自理
+        try {
+          this.scanCoworkSessions();
+        } catch (err) {
+          log.warn("[AppCoordinator] cowork scan failed:", err?.message ?? err);
+        }
         const beforeIds = new Set(this.state.sessions.keys());
         const beforeVisibilityPruneCount = this.state.sessions.size;
         const { state: cleaned } = removeInvisibleSessions(this.state);

--- a/src/main/bridge-server.cjs
+++ b/src/main/bridge-server.cjs
@@ -376,6 +376,9 @@ function createBridgeServerClass({
           if (!app) return;
           const jumpTarget = {
             app: app || "",
+            // Claude Desktop 靠 claude://resume?session=<uuid> 深链定位会话，
+            // 需要把会话 id 一路带到 TerminalJumpService
+            sessionId,
             tty: pickStr("terminal_tty"),
             tabId: pickStr("terminal_session_id"),
             paneId: pickStr("warp_pane_uuid"),

--- a/src/main/terminal-navigation.cjs
+++ b/src/main/terminal-navigation.cjs
@@ -52,6 +52,65 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL }) {
   const CURSOR_BUNDLE_ID = "com.todesktop.230313mzl4w4u92";
   const CODEX_APP_BUNDLE_ID = "com.openai.codex";
   const CLAUDE_DESKTOP_BUNDLE_ID = "com.anthropic.claudefordesktop";
+  // 与 Claude Desktop 自身对 resume 深链参数的校验保持一致
+  const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+  /**
+   * 在 Claude Desktop 的本地会话存储里，按 cliSessionId 反查桌面会话 id。
+   *
+   * 存储布局：~/Library/Application Support/Claude/claude-code-sessions/<org>/<account>/local_*.json
+   * 每条记录同时有 sessionId（记录自身，形如 local_<uuid>）和 cliSessionId
+   * （当前挂载的 CLI 会话）。两者的 uuid 通常不同 —— 桌面会话先建、之后才挂上
+   * CLI 会话，且 resume/fork 后 cliSessionId 还会变。
+   *
+   * 注意：这是读另一个应用的内部存储，格式随版本可能变化。所以整段都在 try 里，
+   * 任何异常都退回上层的兜底路径，不影响跳转本身可用。
+   */
+  // 反查结果的短缓存。桌面会话的 cliSessionId 会随 resume/fork 变化，
+  // 不能永久缓存；10s 只覆盖「连续点击」的场景，陈旧风险可忽略。
+  let claudeSessionScanCache = null;
+  function findClaudeDesktopSessionId(cliSessionId) {
+    const now = Date.now();
+    if (claudeSessionScanCache && now - claudeSessionScanCache.at < 1e4) {
+      return claudeSessionScanCache.map.get(cliSessionId) ?? null;
+    }
+    try {
+      // Cowork（local-agent-mode-sessions）与普通 Code 会话（claude-code-sessions）
+      // 记录结构同款（sessionId/cliSessionId/lastActivityAt），一并扫描，
+      // 点击 Cowork 会话卡片同样能经 epitaxy 深链跳进对应对话
+      const roots = ["claude-code-sessions", "local-agent-mode-sessions"].map((d) =>
+        path__namespace.join(os__namespace.homedir(), "Library", "Application Support", "Claude", d)
+      ).filter((r) => fs__namespace.existsSync(r));
+      if (roots.length === 0) return null;
+      const best = new Map();
+      for (const root of roots) for (const org of fs__namespace.readdirSync(root)) {
+        const orgDir = path__namespace.join(root, org);
+        if (!fs__namespace.statSync(orgDir).isDirectory()) continue;
+        for (const acct of fs__namespace.readdirSync(orgDir)) {
+          const acctDir = path__namespace.join(orgDir, acct);
+          if (!fs__namespace.statSync(acctDir).isDirectory()) continue;
+          for (const name of fs__namespace.readdirSync(acctDir)) {
+            if (!name.startsWith("local_") || !name.endsWith(".json")) continue;
+            let rec;
+            try {
+              rec = JSON.parse(fs__namespace.readFileSync(path__namespace.join(acctDir, name), "utf8"));
+            } catch { continue; }
+            if (!rec?.cliSessionId || rec.isArchived) continue;
+            // 同一个 cliSessionId 可能对应多条（例如之前误导入过），取最近活跃的那条
+            const prev = best.get(rec.cliSessionId);
+            if (!prev || (rec.lastActivityAt ?? 0) > (prev.lastActivityAt ?? 0)) best.set(rec.cliSessionId, rec);
+          }
+        }
+      }
+      const map = new Map();
+      for (const [k, v] of best) map.set(k, v.sessionId);
+      claudeSessionScanCache = { at: now, map };
+      return map.get(cliSessionId) ?? null;
+    } catch (err) {
+      log.debug("[TerminalJumpService] findClaudeDesktopSessionId failed:", err);
+      return null;
+    }
+  }
   const VSCODE_BUNDLE_ID = "com.microsoft.VSCode";
   const VSCODE_INSIDERS_BUNDLE_ID = "com.microsoft.VSCodeInsiders";
   const WINDSURF_BUNDLE_ID = "com.exafunction.windsurf";
@@ -969,6 +1028,56 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL }) {
   }
   async function jumpClaudeAgentSession(target) {
     log.debug("[TerminalJumpService] jumpClaudeAgentSession:", target);
+    // Claude Desktop 是单窗口应用，会话都在侧边栏里 —— 按窗口标题匹配那套
+    // （jumpTraeAgentSession 用的办法）在这里根本无从下手，一共就一个窗口。
+    //
+    // 它自己注册了 claude:// 协议，其中 resume 分支的实现是：
+    //   claude://resume?session=<uuid>  →  importCliSession(uuid) 并导航过去
+    // 参数正是 Claude Code 的 session_id，我们在 hook 里本来就有。
+    // 走深链既准确又不需要辅助功能权限。
+    const sessionId = target.sessionId;
+    if (sessionId && UUID_RE.test(sessionId)) {
+      // 优先：本地已有对应的桌面会话记录，直接导航过去。
+      // 不能拿 CLI uuid 去走 resume —— importCliSession 是按 `local_${uuid}` 查表的，
+      // 而桌面会话有自己的 id（记录键是 local_<自身uuid>，cliSessionId 才是我们手上
+      // 这个 uuid），查不到就会新建一条，这正是「跳过去多出一个一模一样的对话」的成因。
+      // 先把窗口带到前台，深链并行送达。Claude Desktop 处理深链偏慢（大内存
+      // Electron 应用，常在换页），若等它处理完才激活，观感就是「点了没反应」。
+      // 并行后窗口立即前置，导航随后落位。应用未运行时两个 open 会被
+      // LaunchServices 合并成单实例启动，无副作用。
+      const activation = activateMacAppByBundle(CLAUDE_DESKTOP_BUNDLE_ID).catch((err) => {
+        log.debug("[TerminalJumpService] parallel activation failed:", err);
+      });
+      const desktopId = findClaudeDesktopSessionId(sessionId);
+      if (desktopId) {
+        try {
+          await execFileAsync$6(
+            "open",
+            [`claude://claude.ai/epitaxy/${encodeURIComponent(desktopId)}`],
+            { timeout: 5e3 }
+          );
+          await activation;
+          return;
+        } catch (err) {
+          log.debug("[TerminalJumpService] epitaxy deep link failed:", err);
+        }
+      } else {
+        // 没有桌面记录 = 纯终端起的 CLI 会话，此时 resume 的导入正是想要的行为，
+        // 且 local_<uuid> 与记录键一致，不会产生重复。
+        try {
+          await execFileAsync$6(
+            "open",
+            [`claude://resume?session=${encodeURIComponent(sessionId)}`],
+            { timeout: 5e3 }
+          );
+          await activation;
+          return;
+        } catch (err) {
+          log.debug("[TerminalJumpService] claude://resume failed:", err);
+        }
+      }
+    }
+    // 深链不可用时退回纯激活
     try {
       await activateMacAppByBundle(CLAUDE_DESKTOP_BUNDLE_ID);
     } catch (err) {

--- a/src/main/transcript-recovery.cjs
+++ b/src/main/transcript-recovery.cjs
@@ -1,0 +1,61 @@
+"use strict";
+
+const fs = require("node:fs");
+
+const MAX_CLAUDE_READ_BYTES = 512 * 1024;
+
+/**
+ * Read the tail of a Claude Code transcript and determine whether its latest
+ * user turn has a terminal assistant response.
+ */
+function readClaudeTranscriptState(file, maxReadBytes = MAX_CLAUDE_READ_BYTES) {
+  try {
+    const size = fs.statSync(file).size;
+    const readLen = Math.min(size, maxReadBytes);
+    const buf = Buffer.alloc(readLen);
+    const fd = fs.openSync(file, "r");
+    try {
+      fs.readSync(fd, buf, 0, readLen, size - readLen);
+    } finally {
+      fs.closeSync(fd);
+    }
+    let unfinished = false;
+    let latestPrompt = null;
+    let lastEventAt = 0;
+    let latestPromptAt = 0;
+    for (const line of buf.toString("utf8").split("\n")) {
+      let rec;
+      try {
+        rec = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const eventAt = rec?.timestamp ? new Date(rec.timestamp).getTime() : 0;
+      if (Number.isFinite(eventAt) && eventAt > lastEventAt) lastEventAt = eventAt;
+      if (rec?.type === "user" && !rec.isMeta) {
+        const content = rec.message?.content;
+        const blocks = Array.isArray(content) ? content : [];
+        const text = typeof content === "string"
+          ? content
+          : blocks.find((block) => block?.type === "text")?.text;
+        if (typeof text === "string" && text.trim() && !text.trim().startsWith("<")) {
+          latestPrompt = text.trim().slice(0, 200);
+          latestPromptAt = eventAt || latestPromptAt;
+          unfinished = true;
+        }
+      }
+      if (rec?.type === "assistant") {
+        const stopReason = rec.message?.stop_reason ?? rec.stop_reason;
+        if (stopReason === "end_turn") unfinished = false;
+      }
+      if (rec?.type === "system" && rec.subtype === "stop_hook_summary") {
+        unfinished = false;
+      }
+    }
+    return { unfinished, latestPrompt, lastEventAt, latestPromptAt };
+  } catch {
+    return { unfinished: false, latestPrompt: null, lastEventAt: 0, latestPromptAt: 0 };
+  }
+}
+
+module.exports = { readClaudeTranscriptState, MAX_CLAUDE_READ_BYTES };


### PR DESCRIPTION
## 范围说明

**只含 Claude Desktop 会话识别功能，不碰主题/UI/其他定制**。与 #28（贴边模式）互不依赖、可独立合并，两者共同取代已撤回的 #25。

## 内容

三个盲区的修复：

1. **启动发现**：WorkIsland 启动前就在跑的 claude 会话（含 Claude Desktop 内嵌 CLI）主动扫描恢复——ps `comm=` 匹配进程（`command=` 按空白切词会被 Desktop 路径里的空格坑掉）、lsof 映射工作目录、按 transcript 末轮终止记录判定未完成任务
2. **Cowork 感知**：VM 沙箱内的本地 Agent 会话（进程与 hook 双盲）经宿主机元数据 + audit.jsonl 镜像捕获，mtime 判活、周期续命。云端沙箱会话本地无痕迹，为已知边界
3. **深链跳转**：Desktop 是单窗口应用，窗口标题匹配无从下手。cliSessionId → 桌面会话 id 反查（覆盖 Code 与 Cowork 两套存储 + 10s 缓存）经 `claude://claude.ai/epitaxy/` 直达对应对话；无记录时 `claude://resume` 导入。激活与导航并行以消除「点了没反应」的观感——直接拿 CLI uuid 走 resume 会因存储键不匹配每次新建重复对话，这是反查存在的原因

新增 `transcript-recovery.cjs`（61 行自包含，仅依赖 node:fs）。

## 验证

- `npm run check` 全绿
- 长时间实机使用：启动发现/跳转/去重均正常；Cowork 扫描经 touch audit 实测 6s 内捕获、反查映射正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)