### PR TITLE
fix(sessions): 恢复会话跳转 —— 认出宿主 App 并持续刷新 jumpTarget

### DIFF
--- a/src/island/hooks-cli/index.cjs
+++ b/src/island/hooks-cli/index.cjs
@@ -27,13 +27,41 @@ function canonicalTerminalApp(value) {
   return TERMINAL_APP_ALIASES[normalized] || value.trim();
 }
 
+// 顺序有意义：更具体的放前面，先匹配到的先返回。
+const HOST_APP_MATCHERS = Object.freeze([
+  ["/codebuddy cn.app/", "CodeBuddy CN"],
+  ["/workbuddy.app/", "WorkBuddy"],
+  ["/trae solo.app/", "TraeWork"],
+  ["/trae cn.app/", "Trae CN"],
+  ["/trae.app/", "Trae"],
+  ["/claude.app/", "Claude"],
+  ["/cursor.app/", "Cursor"],
+  ["/windsurf.app/", "Windsurf"],
+  ["/visual studio code.app/", "VS Code"],
+  ["/ghostty.app/", "Ghostty"],
+  ["/iterm.app/", "iTerm"],
+  ["/terminal.app/", "Terminal"],
+  ["/warp.app/", "Warp"],
+  ["/wezterm.app/", "WezTerm"],
+  ["/alacritty.app/", "Alacritty"],
+  ["/kitty.app/", "kitty"]
+]);
+
+/**
+ * 从进程命令行认出承载会话的宿主 App。
+ *
+ * 除了几个 Agent 桌面端，还必须认出 Claude Desktop 与各终端：Claude Code 跑在
+ * Claude Desktop 里时 TERM_PROGRAM 为空，terminal_app 便恒为 undefined，
+ * bridge-server 的 updateJumpTarget 拿不到 app 会直接 return —— jumpTarget 永远
+ * 不生成，表现为「点击卡片不跳转」，且存活探测以 jumpTarget 为前提，会话也不会
+ * 自动结束。
+ */
 function desktopHostForCommand(command) {
   if (typeof command !== "string") return undefined;
   const normalized = command.toLowerCase();
-  if (normalized.includes("/codebuddy cn.app/")) return "CodeBuddy CN";
-  if (normalized.includes("/workbuddy.app/")) return "WorkBuddy";
-  if (normalized.includes("/trae solo.app/")) return "TraeWork";
-  if (normalized.includes("/trae.app/")) return "Trae";
+  for (const [needle, app] of HOST_APP_MATCHERS) {
+    if (normalized.includes(needle)) return app;
+  }
   return undefined;
 }
 

--- a/src/main/adapters-cli.cjs
+++ b/src/main/adapters-cli.cjs
@@ -289,6 +289,14 @@ class ClaudeAdapter {
     const sessionId = payload.session_id;
     const now = Date.now();
     const hookEvent = payload.hook_event_name;
+    // 每个事件都刷新 jumpTarget，而不只在 SessionStart / UserPromptSubmit / Stop。
+    //
+    // 那三个事件只在一轮的开头和结尾出现。会话若在中途被重建 —— WorkIsland 重启、
+    // 或空闲扫描把会话清掉后又被后续工具事件带回来 —— 就再也等不到它们，
+    // 重建出来的会话永远没有 jumpTarget：点击卡片毫无反应，而且 PidWatcher 与
+    // 桌面 App 存活探测都以 jumpTarget 为前提，会话也不会自动结束。
+    // updateJumpTarget 只是按当前 hook payload 记录终端/工作目录，重复调用无副作用。
+    if (sessionId) ctx.updateJumpTarget?.(sessionId, tool);
     const subAgentId = resolveClaudeSubAgentId(payload);
     if (subAgentId && hookEvent !== "SubagentStart" && hookEvent !== "SubagentStop") {
       const parentId = this.subagentParentByAgentId.get(subAgentId) ?? sessionId;

--- a/src/main/adapters-work-agents.cjs
+++ b/src/main/adapters-work-agents.cjs
@@ -21,7 +21,8 @@ class ClaudeCompatibleWorkAgentAdapter extends ClaudeAdapter {
       detachClaudeTranscriptWatcher: () => {},
       updateJumpTarget: (sessionId, tool, overrides = {}) => {
         const terminalApp = payload.terminal_app || overrides.terminal_app || this.defaultApp;
-        ctx.updateJumpTarget(sessionId, tool, {
+        // 上游 ctx 未必提供该能力（例如只跑适配器的精简上下文），容忍缺失。
+        ctx.updateJumpTarget?.(sessionId, tool, {
           ...overrides,
           terminal_app: terminalApp,
           cwd: overrides.cwd || payload.cwd

--- a/src/main/process-monitor.cjs
+++ b/src/main/process-monitor.cjs
@@ -4,19 +4,25 @@ const childProcess = require("child_process");
 const { promisify } = require("util");
 const log = require("electron-log");
 
+function hasAppBundlePathSegment(command, appBundleNames) {
+  const segments = command.toLowerCase().split("/");
+  return appBundleNames.some((appBundleName) => segments.includes(appBundleName.toLowerCase()));
+}
+
+function isCodexDesktopAppCommand(command) {
+  if (hasAppBundlePathSegment(command, ["Codex.app", "Codex Desktop.app"])) return true;
+  // 新版 Codex Desktop 打包在 ChatGPT.app 内，只认 Codex.app 会把这些进程
+  // 整个漏掉 —— 表现为 Codex 会话既不显示也不会自动结束。
+  return hasAppBundlePathSegment(command, ["ChatGPT.app"])
+    && command.toLowerCase().includes("/codex framework.framework/");
+}
+
 function createProcessMonitorClass({ isVisibleInIsland }) {
-  function hasAppBundlePathSegment(command, appBundleNames) {
-    const segments = command.toLowerCase().split("/");
-    return appBundleNames.some((appBundleName) => segments.includes(appBundleName.toLowerCase()));
-  }
   function isCursorDesktopAppCommand(command) {
     return hasAppBundlePathSegment(command, ["Cursor.app"]);
   }
   function isClaudeDesktopAppCommand(command) {
     return hasAppBundlePathSegment(command, ["Claude.app"]);
-  }
-  function isCodexDesktopAppCommand(command) {
-    return hasAppBundlePathSegment(command, ["Codex.app", "Codex Desktop.app"]);
   }
   function isOpenCodeDesktopAppCommand(command) {
     return hasAppBundlePathSegment(command, ["OpenCode.app", "OpenCode Desktop.app"]);
@@ -172,4 +178,4 @@ function createProcessMonitorClass({ isVisibleInIsland }) {
   return ProcessMonitor;
 }
 
-module.exports = { createProcessMonitorClass };
+module.exports = { createProcessMonitorClass, isCodexDesktopAppCommand };

--- a/tests/session-jump-target.test.mjs
+++ b/tests/session-jump-target.test.mjs
@@ -1,0 +1,110 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const dir = mkdtempSync(join(tmpdir(), "wi-jump-"));
+
+// 这些主进程模块在加载时就会 require("electron")，而普通 node 下它只返回二进制
+// 路径字符串。先往 require 缓存里塞一个桩，才能在 Electron 之外直接测。
+const electronId = require.resolve("electron");
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: { app: { getPath: () => dir }, ipcMain: { on() {}, handle() {}, removeListener() {}, removeHandler() {} } }
+};
+
+const hooksCli = require("../src/island/hooks-cli/index.cjs");
+const { ClaudeAdapter } = require("../src/main/adapters-cli.cjs");
+const { isCodexDesktopAppCommand } = require("../src/main/process-monitor.cjs");
+
+// ── hook CLI：认出承载会话的宿主 App ─────────────────────────────────────────
+const procList = (cmd, pid = 501, ppid = 500) =>
+  [`${pid} ${ppid} ${cmd}`, `${ppid} 1 /sbin/launchd`].join("\n");
+
+test("the hook CLI recognizes Claude Desktop as the session host", () => {
+  // Claude Code 跑在 Claude Desktop 里时 TERM_PROGRAM 为空。认不出宿主就没有
+  // terminal_app，bridge-server 的 updateJumpTarget 会因 !app 直接 return ——
+  // jumpTarget 永远不生成，点击会话卡片没有任何反应。
+  assert.equal(
+    hooksCli.detectDesktopHostFromProcessList(procList("/Applications/Claude.app/Contents/MacOS/Claude"), 501),
+    "Claude"
+  );
+});
+
+test("the hook CLI still recognizes every host it covered before", () => {
+  const cases = [
+    ["/Applications/CodeBuddy CN.app/Contents/MacOS/CodeBuddy", "CodeBuddy CN"],
+    ["/Applications/WorkBuddy.app/Contents/MacOS/WorkBuddy", "WorkBuddy"],
+    ["/Applications/Trae Solo.app/Contents/MacOS/Trae", "TraeWork"],
+    ["/Applications/Trae.app/Contents/MacOS/Trae", "Trae"]
+  ];
+  for (const [cmd, expected] of cases) {
+    assert.equal(hooksCli.detectDesktopHostFromProcessList(procList(cmd), 501), expected, cmd);
+  }
+});
+
+test("the hook CLI falls back to the terminal that owns the process tree", () => {
+  assert.equal(hooksCli.detectDesktopHostFromProcessList(procList("/Applications/Warp.app/Contents/MacOS/stable"), 501), "Warp");
+  assert.equal(hooksCli.detectDesktopHostFromProcessList(procList("/Applications/iTerm.app/Contents/MacOS/iTerm2"), 501), "iTerm");
+  assert.equal(hooksCli.detectDesktopHostFromProcessList(procList("/usr/bin/some-random-binary"), 501), undefined);
+});
+
+test("an explicit terminal in the payload still wins over process-tree guessing", () => {
+  const enriched = hooksCli.enrichTerminalContext({ terminal_app: "iTerm.app" }, { TERM_PROGRAM: "Apple_Terminal" });
+  assert.equal(enriched.terminal_app, "iTerm.app");
+});
+
+// ── 每个 hook 事件都刷新 jumpTarget ──────────────────────────────────────────
+function runHook(payload) {
+  const calls = { jump: [], events: [] };
+  const ctx = {
+    updateJumpTarget: (sessionId, tool, overrides) => calls.jump.push({ sessionId, tool, overrides }),
+    emitEvent: (e) => calls.events.push(e),
+    sendResponse: () => {},
+    clearStalePendingInteraction: () => {},
+    playSound: () => {},
+    attachClaudeTranscriptWatcher: () => {},
+    detachClaudeTranscriptWatcher: () => {},
+    resolvePendingInteraction: () => {},
+    reportHookProcessed: () => {}
+  };
+  new ClaudeAdapter().handleHook("client", payload, ctx);
+  return calls;
+}
+
+test("a mid-turn hook refreshes the jump target, not just SessionStart/UserPromptSubmit/Stop", () => {
+  // 会话在中途被重建时（应用重启，或被空闲扫描清掉后由工具事件带回）只会收到
+  // 这类事件；没有这次刷新，重建出来的会话就永远没有 jumpTarget。
+  const mid = runHook({
+    hook_event_name: "PreToolUse",
+    session_id: "s-mid",
+    cwd: "/tmp/x",
+    terminal_app: "Warp",
+    tool_name: "Bash"
+  });
+  assert.ok(mid.jump.length >= 1, "a mid-turn hook must still set the jump target");
+  assert.equal(mid.jump[0].sessionId, "s-mid");
+  assert.equal(mid.jump[0].tool, "claude");
+});
+
+test("a hook without a session id never fabricates a jump target", () => {
+  assert.deepEqual(runHook({ hook_event_name: "PreToolUse", cwd: "/tmp/x", terminal_app: "Warp" }).jump, []);
+});
+
+// ── Codex Desktop 进程识别 ───────────────────────────────────────────────────
+test("codex desktop detection covers the ChatGPT.app bundle as well as the standalone app", () => {
+  assert.equal(isCodexDesktopAppCommand("/Applications/Codex.app/Contents/MacOS/Codex"), true);
+  assert.equal(isCodexDesktopAppCommand("/Applications/Codex Desktop.app/Contents/MacOS/Codex"), true);
+  assert.equal(
+    isCodexDesktopAppCommand("/Applications/ChatGPT.app/Contents/Frameworks/Codex Framework.framework/Versions/A/codex"),
+    true,
+    "newer Codex Desktop builds ship inside ChatGPT.app"
+  );
+  assert.equal(isCodexDesktopAppCommand("/Applications/ChatGPT.app/Contents/MacOS/ChatGPT"), false, "plain ChatGPT is not a Codex session host");
+  assert.equal(isCodexDesktopAppCommand("/Applications/Claude.app/Contents/MacOS/Claude"), false);
+});


### PR DESCRIPTION
## 问题

点击 Island 里的会话卡片没有任何反应。`~/.flux/sessions.json` 里能看到会话确实存在，但 `jumpTarget` 为空：

```
ed0c3f1a phase=running jump=（无）
```

`AppCoordinator.jumpToSession` 因此走到 `no jumpTarget for session` 直接返回。

## 两层原因

**1. hook CLI 认不出 Claude Desktop**

`enrichTerminalContext` 依次尝试 `payload.terminal_app` → `TERM_PROGRAM` → 进程树。Claude Code 跑在 Claude Desktop 里时 `TERM_PROGRAM` 是空的，而进程树识别只覆盖 CodeBuddy CN / WorkBuddy / TraeWork / Trae —— 认不出 `Claude.app`，于是 `terminal_app` 恒为 `undefined`，`bridge-server` 的 `updateJumpTarget` 第一行就 `if (!app) return`。

改为按匹配表上溯进程树：**原有四个条目原样保留**，另加 Claude / Cursor / Windsurf / Trae CN，以及常见终端（Ghostty / iTerm / Terminal / Warp / WezTerm / Alacritty / kitty / VS Code）作为 `TERM_PROGRAM` 缺失时的兜底。

**2. jumpTarget 只在一轮的首尾设置**

`ClaudeAdapter` 只在 `SessionStart` / `UserPromptSubmit` / `Stop` 调 `updateJumpTarget`。这三个事件只在一轮的开头和结尾出现，所以会话一旦**在中途被重建**就再也等不到它们：

- WorkIsland 重启后，正在跑的会话由后续的 `PreToolUse` / `PostToolUse` 等事件重新建立；
- 空闲扫描清掉会话后，它同样由工具事件带回。

这两种情况下重建出来的会话永远没有 `jumpTarget`。改为在 `handleHook` 开头对每个带 `session_id` 的事件都刷新一次 —— `updateJumpTarget` 只是按当前 payload 记录终端与工作目录，重复调用无副作用。

`ClaudeCompatibleWorkAgentAdapter` 里的转发相应改成可选调用（`ctx.updateJumpTarget?.()`），以容忍未提供该能力的精简上下文。

## 连带影响

`PidWatcher` 与桌面 App 存活探测都以 `jumpTarget` 为前提，缺失时会话结束后也不会自动消失 —— 一并修复。

## 顺带

Codex Desktop 新版打包在 `ChatGPT.app/Contents/Frameworks/Codex Framework.framework/` 下，只认 `Codex.app` 会把这些进程整个漏掉（Codex 会话既不显示也不会自动结束）。识别加上这一路径，同时排除普通的 ChatGPT 进程。

## 验证

`npm run check` 102 项全绿，新增 `tests/session-jump-target.test.mjs` 覆盖：宿主识别（含原有四个条目的回归）、显式 `terminal_app` 优先、中途事件刷新 jumpTarget、无 session id 不伪造、Codex Desktop 两种打包形态。

本机实测：修复前后同一会话
```
修复前: ed0c3f1a phase=running jump=（无）
修复后: ed0c3f1a phase=running jump={"app":"Claude","sessionId":"ed0c3f1a…","cwd":"/Users/…"}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
