### PR TITLE
feat(stats): 采集 Claude 与 Codex 的实际 token 用量

### DIFF
--- a/src/main/adapters-extended.cjs
+++ b/src/main/adapters-extended.cjs
@@ -147,12 +147,35 @@ const { getStatsService } = require("./stats-service.cjs");
 const lastReportedAt = /* @__PURE__ */ new Map();
 const accountedTokens = /* @__PURE__ */ new Map();
 function applyBaselineDiff(dedupeKey, cumulative) {
-  const baseline = accountedTokens.get(dedupeKey) ?? { input: 0, output: 0 };
+  let baseline = accountedTokens.get(dedupeKey);
+  if (!baseline) {
+    // 进程内没有基线时（重启后第一次采集），用统计服务里已入账的累计值兜底，
+    // 否则整段会话的历史用量会被当成本轮增量再记一遍。
+    const separator = dedupeKey.indexOf(":");
+    const tool = separator >= 0 ? dedupeKey.slice(0, separator) : dedupeKey;
+    const sessionId = separator >= 0 ? dedupeKey.slice(separator + 1) : "";
+    baseline = getStatsService().getTokenTotals(tool, sessionId);
+  }
   const deltaInput = Math.max(0, cumulative.inputTokens - baseline.input);
   const deltaOutput = Math.max(0, cumulative.outputTokens - baseline.output);
-  accountedTokens.set(dedupeKey, { input: cumulative.inputTokens, output: cumulative.outputTokens });
+  const deltaCacheRead = Math.max(0, (cumulative.cacheReadTokens ?? 0) - (baseline.cacheRead ?? 0));
+  const deltaCacheCreation = Math.max(0, (cumulative.cacheCreationTokens ?? 0) - (baseline.cacheCreation ?? 0));
+  accountedTokens.set(dedupeKey, {
+    input: cumulative.inputTokens,
+    output: cumulative.outputTokens,
+    cacheRead: cumulative.cacheReadTokens ?? 0,
+    cacheCreation: cumulative.cacheCreationTokens ?? 0
+  });
   if (deltaInput === 0 && deltaOutput === 0) return null;
-  return { inputTokens: deltaInput, outputTokens: deltaOutput, totalTokens: deltaInput + deltaOutput, model: cumulative.model, isEstimated: cumulative.isEstimated };
+  return {
+    inputTokens: deltaInput,
+    outputTokens: deltaOutput,
+    cacheReadTokens: deltaCacheRead,
+    cacheCreationTokens: deltaCacheCreation,
+    totalTokens: deltaInput + deltaOutput,
+    model: cumulative.model,
+    isEstimated: cumulative.isEstimated
+  };
 }
 function reportTokenUsage(tool, sessionId, result, remote) {
   if (result.inputTokens === 0 && result.outputTokens === 0) {
@@ -203,6 +226,101 @@ function reportTokenUsage(tool, sessionId, result, remote) {
   );
   getStatsService().recordToken(tool, sessionId, result.inputTokens, result.outputTokens, result.cacheReadTokens ?? 0, result.cacheCreationTokens ?? 0, remote);
 }
+/**
+ * 从 Claude Code transcript 累加 token 用量。
+ * 每条 assistant 消息带 message.usage（input/output/cache_read/cache_creation），
+ * 全量累加得到会话累计值，交给 applyBaselineDiff 转成增量再入账。
+ */
+async function parseClaudeTokens(transcriptPath) {
+  let content;
+  try {
+    content = await promises.readFile(transcriptPath, "utf-8");
+  } catch (err) {
+    log.warn("[claudeTokens] readFile failed for %s:", transcriptPath, err);
+    return null;
+  }
+  let input = 0;
+  let output = 0;
+  let cacheRead = 0;
+  let cacheCreation = 0;
+  let model;
+  // 同一次请求可能因流式写入出现多条记录，按 requestId 去重。
+  const seenRequestIds = new Set();
+  for (const line of content.split("\n")) {
+    if (!line) continue;
+    let item;
+    try {
+      item = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const u = item?.message?.usage;
+    if (item?.type !== "assistant" || !u) continue;
+    const requestId = item.requestId ?? item.message?.request_id ?? u.request_id;
+    if (requestId) {
+      if (seenRequestIds.has(requestId)) continue;
+      seenRequestIds.add(requestId);
+    }
+    input += u.input_tokens ?? 0;
+    output += u.output_tokens ?? 0;
+    cacheRead += u.cache_read_input_tokens ?? 0;
+    cacheCreation += u.cache_creation_input_tokens ?? 0;
+    if (item.message.model) model = item.message.model;
+  }
+  if (input === 0 && output === 0) return null;
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheRead,
+    cacheCreationTokens: cacheCreation,
+    totalTokens: input + output,
+    model,
+    isEstimated: false
+  };
+}
+/**
+ * 从 Codex rollout transcript 取 token 累计。
+ * token_count 事件的 info.total_token_usage 是会话累计值，取最后一条即可；
+ * input_tokens 含缓存部分，拆开与其他工具的口径对齐。
+ */
+async function parseCodexTokens(transcriptPath) {
+  let content;
+  try {
+    content = await promises.readFile(transcriptPath, "utf-8");
+  } catch (err) {
+    log.warn("[codexTokens] readFile failed for %s:", transcriptPath, err);
+    return null;
+  }
+  let usage = null;
+  let model;
+  for (const line of content.split("\n")) {
+    if (!line) continue;
+    let item;
+    try {
+      item = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const p = item?.payload;
+    if (!p) continue;
+    if (p.type === "token_count" && p.info?.total_token_usage) usage = p.info.total_token_usage;
+    if (p.type === "thread_settings_applied" && p.thread_settings?.model) model = p.thread_settings.model;
+  }
+  if (!usage) return null;
+  const cached = usage.cached_input_tokens ?? 0;
+  const input = Math.max(0, (usage.input_tokens ?? 0) - cached);
+  const output = usage.output_tokens ?? 0;
+  if (input === 0 && output === 0 && cached === 0) return null;
+  return {
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cached,
+    cacheCreationTokens: usage.cache_write_input_tokens ?? 0,
+    totalTokens: input + output,
+    model,
+    isEstimated: false
+  };
+}
 async function collectAndReportTokens(tool, sessionId, transcriptPath) {
   try {
     const dedupeKey = `${tool}:${sessionId}`;
@@ -226,6 +344,22 @@ async function collectAndReportTokens(tool, sessionId, transcriptPath) {
         break;
       case "hermes":
         result = getHermesCumulativeTokens(sessionId);
+        if (result) result = applyBaselineDiff(dedupeKey, result);
+        break;
+      case "claude":
+        if (!transcriptPath) {
+          log.info("[TokenCollector] 跳过：claude 缺少 transcriptPath");
+          return;
+        }
+        result = await parseClaudeTokens(transcriptPath);
+        if (result) result = applyBaselineDiff(dedupeKey, result);
+        break;
+      case "codex":
+        if (!transcriptPath) {
+          log.info("[TokenCollector] 跳过：codex 缺少 transcriptPath");
+          return;
+        }
+        result = await parseCodexTokens(transcriptPath);
         if (result) result = applyBaselineDiff(dedupeKey, result);
         break;
     }
@@ -2418,6 +2552,9 @@ function parseTraexPermissionMode(value) {
   return typeof value === "string" && TRAEX_PERMISSION_MODES.has(value) ? value : void 0;
 }
 module.exports = {
+  collectAndReportTokens,
+  parseClaudeTokens,
+  parseCodexTokens,
   GeminiAdapter,
   HermesAdapter,
   AidenAdapter,

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -21,7 +21,7 @@ const { HermesHookManager, AidenHookManager, TraexCliHookManager } = require("./
 const { PluginHookManager, DeepSeekHarnessHookManager } = require("./hooks-custom.cjs");
 const { ZCodeHookManager, WorkBuddyHookManager, CodeBuddyHookManager } = require("./hooks-work-agents.cjs");
 const { initSoundDirs, playSoundEvent } = require("./sound-service.cjs");
-const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens } = require("./adapters-extended.cjs");
+const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens, collectAndReportTokens } = require("./adapters-extended.cjs");
 const { getAgentDescriptor, validateAgentWiring } = require("../shared/agent-catalog.cjs");
 const { createPresentationRequest } = require("./presentation-policy.cjs");
 const { EVENTS } = require("../shared/telemetry.cjs");
@@ -113,6 +113,8 @@ function createAppCoordinatorClass({
      * 用 5 秒窗口 dedup 让两条通道都跑但只放行第一个。
      */
     agentEventDedup = null;
+    // claude 会话的 transcript 路径（来自 hookProcessed），turn 结束时采集 token 用
+    claudeTranscriptPaths = new Map();
     /**
      * 记录每个 Hermes session 已经写入 Flux 统计的累计 token 基线。
      *
@@ -262,6 +264,23 @@ function createAppCoordinatorClass({
             }
           }
         }
+        if (event.type === "sessionCompleted" && (event.tool === "claude" || event.tool === "codex")) {
+          // turn 结束采集一次。挂在 sessionCompleted 而不是 hookProcessed：
+          // 后者每个 hook 都触发，反复整读大 transcript 太重。
+          // codex 的 hook 常常不带 transcript_path（codexSessionMeta 为空），
+          // 但 transcript watcher 本来就按 session id 跟踪着 rollout 文件，用它兜底。
+          const transcriptPath = event.tool === "claude"
+            ? this.claudeTranscriptPaths.get(event.sessionId)
+            : this.codexSessionMeta.get(event.sessionId)?.transcriptPath
+              ?? this.codexTranscriptWatcher?.getTranscriptPath(event.sessionId);
+          if (transcriptPath) {
+            collectAndReportTokens(event.tool, event.sessionId, transcriptPath).catch((err) => {
+              log.warn("[AppCoordinator] %s token collect failed:", event.tool, err?.message ?? err);
+            });
+          } else {
+            log.info("[TokenCollector] 跳过：%s/%s 无 transcript 路径可用", event.tool, event.sessionId);
+          }
+        }
         if (shouldRecordCompletedSessionStat(event)) {
           const session = getSession(this.state, event.sessionId);
           if (session) {
@@ -277,6 +296,9 @@ function createAppCoordinatorClass({
         "hookProcessed",
         (info) => {
           const session = info.sessionId ? getSession(this.state, info.sessionId) : void 0;
+          if (info.tool === "claude" && info.sessionId && info.transcriptPath) {
+            this.claudeTranscriptPaths.set(info.sessionId, info.transcriptPath);
+          }
           if (info.tool === "codex" && info.sessionId && info.transcriptPath) {
             const prev = this.codexSessionMeta.get(info.sessionId);
             const latestTurnId = info.turnId ?? prev?.latestTurnId;
@@ -352,6 +374,18 @@ function createAppCoordinatorClass({
         });
         this.codexTranscriptWatcher.start();
         log.info("[AppCoordinator] codex transcript watcher started");
+        // 启动回填：codex 可能几小时不完成一轮，若只挂在 sessionCompleted 上，
+        // 统计里会长期停在 0。watcher 扫的是 24h 内的 rollout，逐个采集一次；
+        // applyBaselineDiff 用累计值差分，重复回填不会重复计数。
+        setTimeout(() => {
+          const tracked = this.codexTranscriptWatcher?.listTracked() ?? [];
+          for (const file of tracked) {
+            collectAndReportTokens("codex", file.sessionId, file.path).catch((err) => {
+              log.warn("[AppCoordinator] codex token backfill failed:", err?.message ?? err);
+            });
+          }
+          if (tracked.length) log.info("[AppCoordinator] codex token backfill: %d file(s)", tracked.length);
+        }, 5e3);
       } catch (err) {
         // watcher 启动失败不应阻断 app 启动；hook 通道仍可工作
         log.warn("[AppCoordinator] codex transcript watcher failed to start:", err.message);

--- a/src/main/codex-transcript-watcher.cjs
+++ b/src/main/codex-transcript-watcher.cjs
@@ -96,6 +96,11 @@ class CodexTranscriptWatcher extends EventEmitter {
     this.running = false;
   }
 
+  /** 按 session id 查 rollout transcript 路径；未跟踪返回 null。 */
+  getTranscriptPath(sessionId) {
+    return this.files.get(sessionId)?.path ?? null;
+  }
+
   listTracked() {
     return Array.from(this.files.values());
   }

--- a/src/main/stats-service.cjs
+++ b/src/main/stats-service.cjs
@@ -54,6 +54,22 @@ class StatsService {
       }
     }
   }
+  /**
+   * 某个会话已入账的 token 累计值。
+   * transcript 采集器给出的是会话累计数，重启后进程内的基线会丢失；
+   * 用已入账的累计值当基线，重复采集才不会重复计数。
+   */
+  getTokenTotals(tool, sessionId) {
+    const totals = { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
+    for (const record of this.tokens) {
+      if (record.tool !== tool || record.sessionId !== sessionId) continue;
+      totals.input += Number(record.inputTokens) || 0;
+      totals.output += Number(record.outputTokens) || 0;
+      totals.cacheRead += Number(record.cacheReadTokens) || 0;
+      totals.cacheCreation += Number(record.cacheCreationTokens) || 0;
+    }
+    return totals;
+  }
   getSnapshot(timeRange) {
     const now = Date.now();
     const startOfToday = this.getStartOfDay(now);

--- a/tests/token-capture.test.mjs
+++ b/tests/token-capture.test.mjs
@@ -1,0 +1,87 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const dir = mkdtempSync(join(tmpdir(), "wi-token-capture-"));
+
+// stats-service 在模块加载时就调用 electron.app.getPath("userData")，而普通 node
+// 下 require("electron") 只会返回二进制路径字符串。先往 require 缓存里塞一个桩，
+// 才能在 Electron 之外直接测这些主进程模块。
+const electronId = require.resolve("electron");
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: { app: { getPath: () => dir }, ipcMain: { on() {}, handle() {}, removeListener() {}, removeHandler() {} } }
+};
+
+const { parseClaudeTokens, parseCodexTokens } = require("../src/main/adapters-extended.cjs");
+const write = (name, lines) => {
+  const file = join(dir, name);
+  writeFileSync(file, lines.map((l) => (typeof l === "string" ? l : JSON.stringify(l))).join("\n"));
+  return file;
+};
+
+// ── Claude transcript ────────────────────────────────────────────────────────
+test("claude token parser sums assistant usage across the transcript", async () => {
+  const file = write("claude.jsonl", [
+    { type: "user", message: { content: "hi" } },
+    { type: "assistant", requestId: "r1", message: { model: "claude-x", usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 100, cache_creation_input_tokens: 20 } } },
+    { type: "assistant", requestId: "r2", message: { model: "claude-x", usage: { input_tokens: 7, output_tokens: 3, cache_read_input_tokens: 50 } } },
+    "",
+    "{ not json",
+    { type: "system", message: { usage: { input_tokens: 999, output_tokens: 999 } } }
+  ]);
+  const result = await parseClaudeTokens(file);
+  assert.deepEqual(result, {
+    inputTokens: 17,
+    outputTokens: 8,
+    cacheReadTokens: 150,
+    cacheCreationTokens: 20,
+    totalTokens: 25,
+    model: "claude-x",
+    isEstimated: false
+  });
+});
+
+test("claude token parser de-duplicates repeated request ids", async () => {
+  const usage = { input_tokens: 10, output_tokens: 5 };
+  const file = write("claude-dupe.jsonl", [
+    { type: "assistant", requestId: "r1", message: { usage } },
+    { type: "assistant", requestId: "r1", message: { usage } },
+    { type: "assistant", requestId: "r2", message: { usage } }
+  ]);
+  const result = await parseClaudeTokens(file);
+  assert.equal(result.inputTokens, 20, "the repeated r1 record must not be counted twice");
+  assert.equal(result.outputTokens, 10);
+});
+
+test("claude token parser returns null for an empty or unreadable transcript", async () => {
+  assert.equal(await parseClaudeTokens(write("claude-empty.jsonl", [])), null);
+  assert.equal(await parseClaudeTokens(join(dir, "does-not-exist.jsonl")), null);
+});
+
+// ── Codex rollout ────────────────────────────────────────────────────────────
+test("codex token parser takes the last cumulative total and splits cached input out", async () => {
+  const file = write("codex.jsonl", [
+    { payload: { type: "thread_settings_applied", thread_settings: { model: "gpt-x" } } },
+    { payload: { type: "token_count", info: { total_token_usage: { input_tokens: 100, cached_input_tokens: 40, output_tokens: 20 } } } },
+    { payload: { type: "token_count", info: { total_token_usage: { input_tokens: 300, cached_input_tokens: 120, output_tokens: 60, cache_write_input_tokens: 9 } } } }
+  ]);
+  const result = await parseCodexTokens(file);
+  assert.equal(result.inputTokens, 180, "cached tokens are reported separately, not inside input");
+  assert.equal(result.cacheReadTokens, 120);
+  assert.equal(result.cacheCreationTokens, 9);
+  assert.equal(result.outputTokens, 60);
+  assert.equal(result.totalTokens, 240);
+  assert.equal(result.model, "gpt-x");
+});
+
+test("codex token parser returns null when the rollout carries no token_count", async () => {
+  const file = write("codex-none.jsonl", [{ payload: { type: "thread_settings_applied", thread_settings: { model: "gpt-x" } } }]);
+  assert.equal(await parseCodexTokens(file), null);
+});


### PR DESCRIPTION
## 问题

Claude 与 Codex 的会话在统计里只有**会话数**，输入 / 输出 token 恒为 0 —— `collectAndReportTokens` 的 switch 里根本没有这两个分支。

## 改动

**两个 transcript 解析器**（`adapters-extended.cjs`）

- `parseClaudeTokens`：逐条累加 assistant 消息的 `message.usage`（input / output / cache_read / cache_creation）。按 `requestId` 去重 —— 流式写入会让同一次请求出现多条记录。
- `parseCodexTokens`：取 `token_count` 事件里 `info.total_token_usage` 的最后一条（它本身就是会话累计值）。`input_tokens` 含缓存部分，把 `cached_input_tokens` 拆出来单列，与其他工具的口径一致。

两者都返回**会话累计值**，交给既有的 `applyBaselineDiff` 转成增量再入账。

**基线在重启后不能归零**

`applyBaselineDiff` 的基线原本只存在进程内存里。重启后第一次采集会把整段会话的历史用量当成本轮增量再记一遍。现在没有内存基线时回落到统计服务里**已入账的累计值**（新增 `stats-service.getTokenTotals`）。顺带补齐了缓存字段的差分。

**采集时机**（`app-coordinator.cjs`）

- 挂在 `sessionCompleted`，而不是 `hookProcessed` —— 后者每个 hook 都触发，会反复整读大 transcript。
- Claude 用 hook 给出的 `transcript_path`（在 `hookProcessed` 时记下）。
- Codex 的 hook 常常不带该字段，回落到 transcript watcher 按 session id 跟踪的 rollout 路径（新增 `CodexTranscriptWatcher.getTranscriptPath`）。
- **Codex 启动回填**：codex 可能几小时不完成一轮，只挂 `sessionCompleted` 会让统计长期停在 0。启动后对 watcher 已跟踪的 rollout 各采集一次；差分基于累计值，重复回填不会重复计数。

## 验证

`npm run check` 全绿，新增 `tests/token-capture.test.mjs`：Claude 累加与 requestId 去重、空 / 不可读 transcript 返回 null、Codex 取最后一条累计值并拆出缓存、无 `token_count` 时返回 null。

本机实际入账（`token_records.json`）：

| 工具 | 记录数 | input | output |
|---|---|---|---|
| claude | 415 | 44,172 | 9,535,427 |
| codex | 79 | 8,417,432 | 568,575 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
