### PR TITLE
fix(sessions): 卡片计时按本轮计，而不是整段对话

### DIFF
--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -1418,6 +1418,9 @@ function createAppCoordinatorClass({
       for (const session of this.state.sessions.values()) {
         if (session.tool !== "claude") continue;
         if (session.phase !== "running") continue;
+        // 启动时从 transcript 恢复的会话没有 hook 的 activeTool；在下一次
+        // hook 到来前不能把“暂时无输出”的长任务误判成 ESC 中断。
+        if (session.recoveredFromTranscript) continue;
         if (session.activeTool) continue;
         if (now - session.updatedAt < IDLE_INTERRUPT_THRESHOLD_MS) continue;
         log.info(

--- a/src/main/session-state.cjs
+++ b/src/main/session-state.cjs
@@ -44,6 +44,7 @@ function createSessionState({ isVisibleInIsland }) {
       isSessionEnded: false,
       isProcessAlive: false,
       isHookManaged: true,
+      recoveredFromTranscript: false,
       completionDismissed: false,
       isRemote: false
     };
@@ -68,6 +69,10 @@ function createSessionState({ isVisibleInIsland }) {
           isSessionEnded: false,
           completionDismissed: false,
           isPullColdCompleteSession: false,
+          // 启动发现补出来的会话要带上标记：它没有 hook 的 activeTool，
+          // 空闲扫描不能把「暂时没输出的长任务」误判成 ESC 中断。
+          recoveredFromTranscript: !!event.recoveredFromTranscript,
+          recoveryTranscriptPath: event.recoveryTranscriptPath ?? (event.recoveredFromTranscript ? prev.recoveryTranscriptPath : void 0),
           // 显式清 error / errorDetail：与 turnStarted 保持 parity —— 新一轮 = 干净状态。
           // sessionCompleted reducer 用 `event.error ?? prev.error` 透传，残留会让
           // 下一轮成功完成时仍渲染为错误完成卡。
@@ -77,7 +82,14 @@ function createSessionState({ isVisibleInIsland }) {
           // 已经清过，这里是防御性兜底，避免上一轮未配对的 toolUseStarted 导致
           // sweep 误判"还有工具在跑"）。
           activeTool: void 0,
-          createdAt: event.timestamp,
+          // Hook 会为同一会话的每一轮都发 SessionStart/UserPromptSubmit。
+          // createdAt 保留最初的起点（统计服务按它归档「整段对话」），
+          // 只有真正结束过的会话才重新开始计。
+          createdAt: prev.isSessionEnded ? event.timestamp : prev.createdAt,
+          // 本轮开始时间，每轮刷新。卡片计时用它 —— 直接用 createdAt 会显示
+          // 整段对话的 30 分钟+，且会话结束过/应用重启后又会重置，
+          // 表现成「时而整段时而单轮」。
+          turnStartedAt: event.timestamp,
           updatedAt: event.timestamp
         };
         break;
@@ -118,7 +130,8 @@ function createSessionState({ isVisibleInIsland }) {
           // 防御性兜底：上一轮可能有未配对的 toolUseStarted（pull adapter 不发
           // tool 事件，理论上不会出现，但保留与 sessionStarted 一致的清理语义）。
           activeTool: void 0,
-          createdAt: event.timestamp,
+          // 同 sessionStarted：整段起点不动，只刷新本轮起点。
+          turnStartedAt: event.timestamp,
           updatedAt: event.timestamp
         };
         break;

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -305,7 +305,9 @@ function useElapsed(session) {
     return () => clearInterval(id);
   }, [isRunning]);
   const end = isRunning ? now : session.updatedAt;
-  const elapsed = Math.floor((end - session.createdAt) / 1e3);
+  // 优先按本轮起点计时；老状态里没有该字段时退回整段语义
+  const start = session.turnStartedAt ?? session.createdAt;
+  const elapsed = Math.floor((end - start) / 1e3);
   return formatDuration(elapsed);
 }
 function SessionRow({

--- a/tests/session-turn-timer.test.mjs
+++ b/tests/session-turn-timer.test.mjs
@@ -1,0 +1,78 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const dir = mkdtempSync(join(tmpdir(), "wi-turn-timer-"));
+
+// stats-service 在模块加载时就调用 electron.app.getPath("userData")，而普通 node
+// 下 require("electron") 只会返回二进制路径字符串。先往 require 缓存里塞一个桩，
+// 才能在 Electron 之外直接测这些主进程模块。
+const electronId = require.resolve("electron");
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: { app: { getPath: () => dir }, ipcMain: { on() {}, handle() {}, removeListener() {}, removeHandler() {} } }
+};
+
+const { createSessionState } = require("../src/main/session-state.cjs");
+const write = (name, lines) => {
+  const file = join(dir, name);
+  writeFileSync(file, lines.map((l) => (typeof l === "string" ? l : JSON.stringify(l))).join("\n"));
+  return file;
+};
+
+// ── 每轮计时 ─────────────────────────────────────────────────────────────────
+function reduceAll(events) {
+  const api = createSessionState({ isVisibleInIsland: () => true });
+  let state = api.createInitialState();
+  for (const event of events) state = api.apply(state, event);
+  return state;
+}
+
+test("a new turn refreshes turnStartedAt but keeps createdAt for the whole conversation", () => {
+  const state = reduceAll([
+    { type: "sessionStarted", sessionId: "s1", tool: "claude", timestamp: 1000 },
+    { type: "sessionCompleted", sessionId: "s1", tool: "claude", timestamp: 2000 },
+    { type: "sessionStarted", sessionId: "s1", tool: "claude", timestamp: 5000 }
+  ]);
+  const session = state.sessions.get("s1");
+  assert.equal(session.createdAt, 1000, "createdAt keeps whole-conversation semantics (stats depend on it)");
+  assert.equal(session.turnStartedAt, 5000, "the card timer counts the current turn only");
+});
+
+test("turnStarted also advances only the per-turn clock", () => {
+  const state = reduceAll([
+    { type: "sessionStarted", sessionId: "s2", tool: "claude", timestamp: 1000 },
+    { type: "turnStarted", sessionId: "s2", tool: "claude", timestamp: 4000 }
+  ]);
+  const session = state.sessions.get("s2");
+  assert.equal(session.createdAt, 1000);
+  assert.equal(session.turnStartedAt, 4000);
+});
+
+test("a session that genuinely ended restarts its whole-conversation clock", () => {
+  const state = reduceAll([
+    { type: "sessionStarted", sessionId: "s3", tool: "claude", timestamp: 1000 },
+    { type: "sessionCompleted", sessionId: "s3", tool: "claude", timestamp: 2000, isSessionEnd: true },
+    { type: "sessionStarted", sessionId: "s3", tool: "claude", timestamp: 9000 }
+  ]);
+  const session = state.sessions.get("s3");
+  assert.equal(session.createdAt, 9000);
+  assert.equal(session.turnStartedAt, 9000);
+});
+
+test("sessions recovered from a transcript stay flagged so the idle sweep spares them", () => {
+  const state = reduceAll([
+    { type: "sessionStarted", sessionId: "s4", tool: "claude", timestamp: 1000, recoveredFromTranscript: true, recoveryTranscriptPath: "/tmp/a.jsonl" }
+  ]);
+  const session = state.sessions.get("s4");
+  assert.equal(session.recoveredFromTranscript, true);
+  assert.equal(session.recoveryTranscriptPath, "/tmp/a.jsonl");
+  const live = reduceAll([{ type: "sessionStarted", sessionId: "s5", tool: "claude", timestamp: 1000 }]);
+  assert.equal(live.sessions.get("s5").recoveredFromTranscript, false, "hook-driven sessions must not be flagged");
+});


### PR DESCRIPTION
## 问题

会话卡片上的计时不稳定：有时显示本轮耗时，有时把整段对话的时间都算进去（跑久了会看到几十分钟的吓人数字）。

原因是 `sessionStarted` 和 `turnStarted` 两个 reducer 都执行 `createdAt: event.timestamp`。Hook 会为同一会话的**每一轮**都发 `SessionStart` / `UserPromptSubmit`，所以：

- 会话在应用生命周期内被重建过 → `createdAt` 刚刚被刷新 → 显示本轮；
- 会话一直存活 → `createdAt` 停在最初 → 显示整段。

同一个字段承担了两种语义，而统计服务依赖的是「整段对话」那一种。

## 改动

- `createdAt` 恢复整段语义：`prev.isSessionEnded ? event.timestamp : prev.createdAt` —— 只有真正结束过的会话才重新开始计。
- 新增 `turnStartedAt`，每轮刷新。`useElapsed` 改用它，缺失时回落 `createdAt`，兼容升级前存下来的状态。

## 顺带修一个失效的标记

`discoverRunningClaudeSessions` 已经在合成的发现事件里带上了 `recoveredFromTranscript: true`，但 `session-state` 从不保存这个字段，空闲扫描也从不检查它 —— 整个标记形同虚设（全仓只有那一处赋值）。

这有实际后果：从 transcript 恢复出来的会话没有 hook 的 `activeTool`，空闲扫描会把「暂时没有输出的长任务」误判成 ESC 中断。现在标记会保留，扫描跳过这些会话。

## 验证

`npm run check` 全绿，新增 `tests/session-turn-timer.test.mjs`：新一轮刷新 `turnStartedAt` 但保留 `createdAt`、`turnStarted` 同样只推进本轮、真正结束过的会话重开整段计时、恢复标记只落在发现出来的会话上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
