### PR TITLE
feat(pet): Echo 的导演层 —— 空闲轮换、状态转场、点击反馈、视线跟随

### DIFF
--- a/src/renderer/pet/app.js
+++ b/src/renderer/pet/app.js
@@ -59,6 +59,7 @@ function PetApp() {
       setEchoFrame((f) => {
         const n = f + 1;
         __setFrame(n);
+        echoFrameRef.current = n;
         return n;
       });
     }, 1000 / 15);
@@ -228,6 +229,118 @@ function PetApp() {
     };
   }, [effectiveBaseStatus]);
   const status = isDragging ? "drag" : isPlaying ? "play" : effectiveBaseStatus === "idle" && isSleeping ? "sleep" : effectiveBaseStatus;
+
+  // ── Echo 导演层 ──────────────────────────────────────────────────────
+  // LittleEcho 有 12 种情绪、6 种动作和视线向量，静态映射只用到零头，观感死板。
+  // 导演层做四件事：空闲情绪轮换 + 随机小动作、状态转场的一次性动作、
+  // 点击分级反馈、视线跟随鼠标。全部只在 echoMode 下运行。
+  //
+  // 整块必须放在 `const status` 之后：下面的 effect 依赖 status，提前声明会在
+  // 求值时撞上 TDZ，让整个宠物渲染失败（表现为「宠物召唤不出来」）。
+  const echoFrameRef = reactExports.useRef(0);
+  const echoModeRef = reactExports.useRef(false);
+  echoModeRef.current = echoMode;
+  const [echoIdleMood, setEchoIdleMood] = reactExports.useState("calm");
+  const [echoOverride, setEchoOverride] = reactExports.useState(null);
+  const [echoAction, setEchoAction] = reactExports.useState(null);
+  const [echoGaze, setEchoGaze] = reactExports.useState(null);
+  const echoPrevStatus = reactExports.useRef("idle");
+  const fireEchoAction = reactExports.useCallback((name) => {
+    // +2 帧：给组件留出一次渲染，动作从下一拍干净地起头
+    setEchoAction({ name, at: echoFrameRef.current + 2 });
+  }, []);
+  const overrideEcho = reactExports.useCallback((patch, ms) => {
+    setEchoOverride({ ...patch, until: Date.now() + ms });
+  }, []);
+  // 临时覆盖到点自动失效
+  reactExports.useEffect(() => {
+    if (!echoOverride) return;
+    const ms = echoOverride.until - Date.now();
+    if (ms <= 0) {
+      setEchoOverride(null);
+      return;
+    }
+    const timer = setTimeout(() => setEchoOverride(null), ms);
+    return () => clearTimeout(timer);
+  }, [echoOverride]);
+  // 空闲时不再永远 calm：情绪按权重轮换，偶尔来一个小动作（歪头/探头/点头）
+  reactExports.useEffect(() => {
+    if (!echoMode || status !== "idle") return;
+    let alive = true;
+    let moodTimer;
+    let actionTimer;
+    const rotate = () => {
+      if (!alive) return;
+      const r = Math.random();
+      setEchoIdleMood(r < 0.55 ? "calm" : r < 0.75 ? "curious" : r < 0.92 ? "listening" : "sleepy");
+      moodTimer = setTimeout(rotate, 12e3 + Math.random() * 16e3);
+    };
+    const micro = () => {
+      if (!alive) return;
+      const r = Math.random();
+      fireEchoAction(r < 0.4 ? "tilt" : r < 0.75 ? "peek" : "nod");
+      actionTimer = setTimeout(micro, 18e3 + Math.random() * 26e3);
+    };
+    moodTimer = setTimeout(rotate, 8e3);
+    actionTimer = setTimeout(micro, 9e3 + Math.random() * 8e3);
+    return () => {
+      alive = false;
+      clearTimeout(moodTimer);
+      clearTimeout(actionTimer);
+      setEchoIdleMood("calm");
+    };
+  }, [echoMode, status, fireEchoAction]);
+  // 状态转场：完成→跳一下庆祝再转 fond；来任务→点头应声；睡醒→wake 过渡；
+  // 拖拽落地→回弹小跳
+  reactExports.useEffect(() => {
+    if (!echoMode) return;
+    const prev = echoPrevStatus.current;
+    echoPrevStatus.current = status;
+    if (prev === status) return;
+    if (status === "complete") {
+      fireEchoAction("hop");
+      overrideEcho({ mood: "happy" }, 5e3);
+    } else if (status === "attention") {
+      fireEchoAction("shake");
+    } else if (status === "running" && (prev === "idle" || prev === "sleep" || prev === "complete")) {
+      fireEchoAction("nod");
+    } else if (prev === "sleep" && status === "idle") {
+      overrideEcho({ mood: "wake" }, 1800);
+    } else if (prev === "drag") {
+      fireEchoAction("hop");
+    }
+  }, [echoMode, status, fireEchoAction, overrideEcho]);
+  // 待处理状态每隔一阵摇头呼唤，直到被处理
+  reactExports.useEffect(() => {
+    if (!echoMode || status !== "attention") return;
+    const timer = setInterval(() => fireEchoAction("shake"), 9e3);
+    return () => clearInterval(timer);
+  }, [echoMode, status, fireEchoAction]);
+  // 视线跟随鼠标（rAF 节流；睡着时不跟）。鼠标离开窗口即回落到情绪默认视线
+  reactExports.useEffect(() => {
+    if (!echoMode) return;
+    let raf = 0;
+    const onMove = (e) => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        const nx = (e.clientX / window.innerWidth) * 2 - 1;
+        const ny = (e.clientY / window.innerHeight) * 2 - 1;
+        setEchoGaze([
+          Math.max(-1, Math.min(1, nx)),
+          Math.max(-1, Math.min(1, ny * 0.7))
+        ]);
+      });
+    };
+    const onLeave = () => setEchoGaze(null);
+    window.addEventListener("mousemove", onMove);
+    document.documentElement.addEventListener("mouseleave", onLeave);
+    return () => {
+      window.removeEventListener("mousemove", onMove);
+      document.documentElement.removeEventListener("mouseleave", onLeave);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, [echoMode]);
   const drawFrame = reactExports.useCallback((frame) => {
     const canvas = canvasRef.current;
     const sheet = sheetRef.current;
@@ -289,6 +402,13 @@ function PetApp() {
       clickCountRef.current = 1;
     }
     lastClickTs.current = now;
+    if (echoModeRef.current) {
+      if (clickCountRef.current === 1) fireEchoAction("nod");
+      else if (clickCountRef.current === 2) {
+        fireEchoAction("hop");
+        overrideEcho({ mood: "happy" }, 2500);
+      }
+    }
     if (clickCountRef.current >= 3) {
       clickCountRef.current = 0;
       // 先播一段告别动作再切回灵动岛。
@@ -378,8 +498,14 @@ function PetApp() {
               // 桌宠七态 → Echo 情绪/动作。echoFrame 仅用于触发重渲染，
               // 组件内部经 __setFrame 读全局帧号。
               key: echoFrame >= 0 ? "echo" : "echo",
-              mood: { idle: "calm", play: "happy", sleep: "doze", running: "focused", attention: "surprised", complete: "happy", drag: "calm" }[status] ?? "calm",
-              loop: status === "play" ? "hop" : status === "drag" ? "stumble" : void 0,
+              // play → fond + hop 循环 = 素材库的招牌「好感小跳」组合；
+              // complete 基础态用 fond（庆祝转场后的陪伴感），idle 由轮换给出
+              mood: echoOverride && Date.now() < echoOverride.until
+                ? echoOverride.mood
+                : { idle: echoIdleMood, play: "fond", sleep: "doze", running: "focused", attention: "surprised", complete: "fond", drag: "calm" }[status] ?? "calm",
+              loop: status === "play" ? "hop" : status === "drag" ? "stumble" : echoOverride && Date.now() < echoOverride.until ? echoOverride.loop : void 0,
+              action: echoAction ?? void 0,
+              gaze: status === "sleep" ? void 0 : echoGaze ?? void 0,
               width: petSize,
               shadow: false
             })


### PR DESCRIPTION
## 动机

`little-echo.js` 里已经实现了 12 种情绪（calm / curious / focused / listening / happy / fond / moved / sad / surprised / sleepy / doze / wake）、6 种动作（nod / shake / hop / tilt / peek / stumble）和一个 `gaze` 向量。

但桌宠只用一张静态映射表把七个状态各钉死在一种情绪上：

```js
mood: { idle: "calm", play: "happy", sleep: "doze", running: "focused",
        attention: "surprised", complete: "happy", drag: "calm" }[status]
```

素材库里大部分表达力没被用上，空闲时永远是同一个 calm，观感很死板。

## 改动

在 `PetApp` 里加一层导演，**只在 `echo:little` 模式下运行**（其他雪碧图形象完全不受影响）：

- **空闲情绪轮换** —— 按权重在 calm / curious / listening / sleepy 之间切换（12–28s），并每隔 18–44s 来一个小动作（歪头 / 探头 / 点头）。间隔带随机量，不会显得像定时器。
- **状态转场动作** —— 完成 → 跳一下庆祝再转 fond；来新任务 → 点头应声；睡醒 → wake 过渡；拖拽落地 → 回弹小跳。待处理状态每隔 9s 摇头呼唤，直到被处理。
- **点击分级反馈** —— 一击点头，二击跳一下并短暂转 happy（三击回灵动岛的行为不变）。
- **视线跟随鼠标** —— rAF 节流；睡着时不跟；鼠标离开窗口即回落到当前情绪的默认视线。

## 一个坑

整块必须放在 `const status = ...` **之后**：里面的 effect 依赖 `status`，提前声明会在求值时撞上 TDZ，让整个宠物渲染失败 —— 表现为「宠物召唤不出来」，而不是报错，很难查。代码里留了注释。

## 验证

`npm run check` 全绿。隔离环境实测（CDP 采样 DOM 内联 transform）：动画在推进、视线随鼠标改变渲染、点击后不崩。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
