### PR TITLE
fix(audio): play task sounds from Codex transcript events

### DIFF
--- a/src/main/agent-sound-policy.cjs
+++ b/src/main/agent-sound-policy.cjs
@@ -1,0 +1,47 @@
+"use strict";
+
+const SOUND_DEDUP_WINDOW_MS = 5000;
+const SOUND_DEDUP_CAPACITY = 512;
+
+/**
+ * Translate events synthesized from a Codex transcript into the same sound
+ * vocabulary used by hook adapters. Replayed startup state and user-initiated
+ * interruptions deliberately stay quiet.
+ */
+function resolveCodexTranscriptSoundEvent(event = {}) {
+  if (event.detectionSource !== "codex-transcript" || event.replayed) return null;
+  if (event.type === "turnStarted") return "sessionStart";
+  if (event.type !== "sessionCompleted" || event.isInterrupt) return null;
+  return event.error ? "taskError" : "taskComplete";
+}
+
+/**
+ * Hooks and the transcript watcher can describe the same lifecycle edge a
+ * moment apart. Keep audio idempotent without suppressing another session.
+ */
+function createAgentSoundDeduplicator({
+  now = Date.now,
+  windowMs = SOUND_DEDUP_WINDOW_MS,
+  capacity = SOUND_DEDUP_CAPACITY
+} = {}) {
+  const recent = new Map();
+
+  function shouldPlay(eventId, sessionId, timestamp) {
+    const occurredAt = Number.isFinite(timestamp) ? timestamp : now();
+    const key = `${sessionId || "unknown"}:${eventId}`;
+    const previous = recent.get(key);
+    if (previous !== undefined && occurredAt - previous < windowMs) return false;
+
+    recent.set(key, occurredAt);
+    if (recent.size > capacity) recent.delete(recent.keys().next().value);
+    return true;
+  }
+
+  return { shouldPlay };
+}
+
+module.exports = {
+  SOUND_DEDUP_WINDOW_MS,
+  createAgentSoundDeduplicator,
+  resolveCodexTranscriptSoundEvent
+};

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -21,6 +21,7 @@ const { HermesHookManager, AidenHookManager, TraexCliHookManager } = require("./
 const { PluginHookManager, DeepSeekHarnessHookManager } = require("./hooks-custom.cjs");
 const { ZCodeHookManager, WorkBuddyHookManager, CodeBuddyHookManager } = require("./hooks-work-agents.cjs");
 const { initSoundDirs, playSoundEvent } = require("./sound-service.cjs");
+const { createAgentSoundDeduplicator, resolveCodexTranscriptSoundEvent } = require("./agent-sound-policy.cjs");
 const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens } = require("./adapters-extended.cjs");
 const { getAgentDescriptor, validateAgentWiring } = require("../shared/agent-catalog.cjs");
 const { createPresentationRequest } = require("./presentation-policy.cjs");
@@ -128,6 +129,10 @@ function createAppCoordinatorClass({
     // edge idempotent within a short window without suppressing a later,
     // identical prompt.
     submissionNotificationBySession = /* @__PURE__ */ new Map();
+    // Hook adapters and the Codex transcript watcher can report the same
+    // lifecycle transition independently. Audio needs a separate per-session
+    // guard because hook adapters request sounds before event dedup runs.
+    agentSoundDedup = createAgentSoundDeduplicator();
     /**
      * Codex 会话元数据（transcript_path + 当前 turn_id），由 hookProcessed 事件维护，
      * 供 sweepInterruptedCodexSessions 读 transcript 末尾的 turn_aborted/interrupted 用。
@@ -295,6 +300,10 @@ function createAppCoordinatorClass({
           );
           return;
         }
+        const transcriptSoundEvent = resolveCodexTranscriptSoundEvent(event);
+        if (transcriptSoundEvent) {
+          this.playAgentSound(transcriptSoundEvent, event.sessionId, event.timestamp);
+        }
         log.info(
           "[AppCoordinator] agentEvent: type=%s session=%s tool=%s source=%s",
           event.type,
@@ -378,8 +387,8 @@ function createAppCoordinatorClass({
           reportTokenUsage(info.tool, info.sessionId, info.tokenUsage);
         }
       );
-      this.bridge.setSoundEventHandler((eventId) => {
-        playSoundEvent(eventId, this.settings);
+      this.bridge.setSoundEventHandler((eventId, context) => {
+        this.playAgentSound(eventId, context?.sessionId, context?.timestamp);
       });
       this.bridge.start();
       this.quotaService.start();
@@ -413,6 +422,10 @@ function createAppCoordinatorClass({
       this.startFullscreenCheck();
       this.autoReInstallHooks();
       playSoundEvent("appLaunch", this.settings);
+    }
+    playAgentSound(eventId, sessionId, timestamp) {
+      if (!this.agentSoundDedup.shouldPlay(eventId, sessionId, timestamp)) return false;
+      return playSoundEvent(eventId, this.settings);
     }
     /**
      * 启动 Codex transcript watcher（独立于 hook 的完成检测通道）。

--- a/src/main/bridge-server.cjs
+++ b/src/main/bridge-server.cjs
@@ -401,7 +401,10 @@ function createBridgeServerClass({
           });
         },
         playSoundEvent: (eventId) => {
-          this.soundEventHandler?.(eventId);
+          this.soundEventHandler?.(eventId, {
+            sessionId: hookPayload.session_id ?? hookPayload.conversation_id,
+            timestamp: Date.now()
+          });
         },
         getApprovalMode: (tool) => {
           return this.approvalModeProvider?.(tool) ?? "terminalNative";

--- a/src/main/codex-transcript-watcher.cjs
+++ b/src/main/codex-transcript-watcher.cjs
@@ -403,10 +403,20 @@ class CodexTranscriptWatcher extends EventEmitter {
           file.lastPrompt = message.slice(0, MAX_SUMMARY_LEN);
           // Codex Desktop 可能在 task_started 之前先写 user_message，把它当作
           // 新 turn 的起点（与 stow 行为一致）
-          if (!file.turnRunning || file.lastTurnCompleted) {
+          const isNewTurn = !file.turnRunning || file.lastTurnCompleted;
+          if (isNewTurn) {
             file.turnRunning = true;
             file.activeTurnId = undefined;
             file.lastTurnCompleted = false;
+            // `turnStarted` is the single audio edge for transcript-backed
+            // submissions. `sessionStarted` can be emitted more than once to
+            // enrich prompt metadata, so it must remain display-only.
+            emit(
+              this.buildEvent(file, "turnStarted", {
+                ts,
+                title: file.title
+              })
+            );
           }
           // 总是补发 sessionStarted 携带最新 prompt：即使 task_started 已经先发过，
           // 这里更新 prompt 让灵动岛 session 可见（isVisibleInIsland 需要 latestUserPrompt）。

--- a/tests/agent-sound-policy.test.mjs
+++ b/tests/agent-sound-policy.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
+const {
+  createAgentSoundDeduplicator,
+  resolveCodexTranscriptSoundEvent
+} = require("../src/main/agent-sound-policy.cjs");
+const { CodexTranscriptWatcher } = require("../src/main/codex-transcript-watcher.cjs");
+
+test("Codex transcript lifecycle events map to start, complete, and error sounds", () => {
+  assert.equal(resolveCodexTranscriptSoundEvent({ detectionSource: "codex-transcript", type: "turnStarted" }), "sessionStart");
+  assert.equal(resolveCodexTranscriptSoundEvent({ detectionSource: "codex-transcript", type: "sessionCompleted" }), "taskComplete");
+  assert.equal(resolveCodexTranscriptSoundEvent({ detectionSource: "codex-transcript", type: "sessionCompleted", error: "failed" }), "taskError");
+  assert.equal(resolveCodexTranscriptSoundEvent({ detectionSource: "codex-transcript", type: "sessionCompleted", isInterrupt: true }), null);
+  assert.equal(resolveCodexTranscriptSoundEvent({ detectionSource: "codex-transcript", type: "turnStarted", replayed: true }), null);
+});
+
+test("sound dedup keeps one lifecycle sound per session without muting another session", () => {
+  const dedup = createAgentSoundDeduplicator({ now: () => 1000 });
+  assert.equal(dedup.shouldPlay("taskComplete", "one", 1000), true);
+  assert.equal(dedup.shouldPlay("taskComplete", "one", 2000), false);
+  assert.equal(dedup.shouldPlay("taskComplete", "two", 2000), true);
+  assert.equal(dedup.shouldPlay("taskComplete", "one", 6000), true);
+});
+
+test("a Codex user message creates one turn-start edge for sound playback", () => {
+  const watcher = new CodexTranscriptWatcher();
+  const events = [];
+  watcher.on("event", (event) => events.push(event));
+  const file = {
+    sessionId: "sound-regression-session",
+    startedAt: 0,
+    lastReadSize: 0,
+    lastEventAt: 0,
+    title: "Codex 会话",
+    turnRunning: false,
+    lastTurnCompleted: false
+  };
+
+  watcher.processLine(file, JSON.stringify({
+    timestamp: "2026-08-26T00:00:00.000Z",
+    payload: { type: "user_message", message: "请完成声音回归测试" }
+  }));
+
+  assert.equal(events.filter((event) => event.type === "turnStarted").length, 1);
+  assert.equal(events.find((event) => event.type === "turnStarted")?.detectionSource, "codex-transcript");
+});


### PR DESCRIPTION
## Summary
- play a start sound for a newly observed Codex transcript turn
- play completion or error sounds for transcript-derived terminal events
- deduplicate hook and transcript signals per session to avoid double audio

## Validation
- `npm run check`
- `npm run package:mac`

Fixes #50