### PR TITLE
fix(win): make the app reliably quittable on Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,12 @@ jobs:
           exe="$(ls release/*Portable*x64.exe 2>/dev/null | head -1)"
           if [ -z "$exe" ]; then echo "portable exe not found"; ls release; exit 1; fi
           node scripts/smoke-win-packaged.mjs "$exe" 90000
+      - name: Verify packaged build can quit on its own
+        # 退出回归（issue #56）：应用必须能自行退出，僵尸化即失败
+        shell: bash
+        run: |
+          exe="$(ls release/*Portable*x64.exe 2>/dev/null | head -1)"
+          node scripts/smoke-win-packaged.mjs "$exe" 90000 --expect-self-quit
       - name: Collect logs on failure
         if: failure()
         shell: bash

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -38,6 +38,10 @@ jobs:
       - name: Launch packaged app and verify ready state
         shell: bash
         run: node scripts/smoke-win-packaged.mjs "$SMOKE_EXE" 90000
+      - name: Verify the packaged app can quit on its own
+        # 退出回归（issue #56）：应用必须能自行退出，僵尸化即失败
+        shell: bash
+        run: node scripts/smoke-win-packaged.mjs "$SMOKE_EXE" 90000 --expect-self-quit
       - name: Collect logs on failure
         if: failure()
         shell: bash

--- a/scripts/smoke-win-packaged.mjs
+++ b/scripts/smoke-win-packaged.mjs
@@ -58,6 +58,40 @@ const FAIL_MARKERS = [
   "A JavaScript error occurred in the main process"
 ];
 
+// 退出回归模式（issue #56）：--expect-self-quit 时带 --smoke-quit-after=<ms>
+// 启动打包应用，不发送 taskkill，断言进程能自行退出且退出码为 0。
+// 应用僵尸化（拒绝退出/窗口隐藏后常驻）会让本模式超时失败。
+if (process.argv.includes("--expect-self-quit")) {
+  const QUIT_DELAY_MS = 4000;
+  const quitChild = spawn(exe, [`--smoke-quit-after=${QUIT_DELAY_MS}`], {
+    stdio: ["ignore", "pipe", "pipe"]
+  });
+  let quitOutput = "";
+  quitChild.stdout.on("data", (d) => { quitOutput += d; });
+  quitChild.stderr.on("data", (d) => { quitOutput += d; });
+  console.log(`[smoke] self-quit scenario: launched pid=${quitChild.pid} with --smoke-quit-after=${QUIT_DELAY_MS}`);
+  const quitResult = await new Promise((resolve) => {
+    const timer = setTimeout(() => resolve({ status: "timeout" }), timeoutMs);
+    quitChild.on("exit", (code) => {
+      clearTimeout(timer);
+      resolve({ status: "exited", code });
+    });
+  });
+  try { quitChild.kill(); } catch {}
+  console.log(`[smoke] self-quit result: ${quitResult.status}${quitResult.code !== undefined ? ` (exit ${quitResult.code})` : ""}`);
+  if (quitResult.status !== "exited" || quitResult.code !== 0) {
+    console.error("[smoke] app failed to exit on its own — quit regression");
+    const logTail = findLogFiles().map((f) => {
+      try { return readFileSync(f, "utf8"); } catch { return ""; }
+    }).join("\n");
+    if (logTail) console.error("[smoke] log tail:\n" + logTail.split(/\r?\n/).slice(-40).join("\n"));
+    if (quitOutput.trim()) console.error("[smoke] process output:\n" + quitOutput.split(/\r?\n/).slice(-40).join("\n"));
+    process.exit(1);
+  }
+  console.log("[smoke] OK: app exited cleanly on its own");
+  process.exit(0);
+}
+
 let output = "";
 const child = spawn(exe, [], {
   stdio: ["ignore", "pipe", "pipe"]

--- a/src/main/bridge-server.cjs
+++ b/src/main/bridge-server.cjs
@@ -102,6 +102,11 @@ function createBridgeServerClass({
           const probe = net.createConnection({ path: this.socketPath }, () => {
             probe.end();
             log.error("[BridgeServer]", "another instance is already listening — giving up");
+            try {
+              require("electron").app.quit();
+            } catch {
+              // 非 Electron 环境（单元测试）无需处理
+            }
           });
           probe.on("error", () => {
             try {

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -680,6 +680,11 @@ function flushLogSync() {
   }
 }
 async function runIslandApp() {
+  if (!electron.app.requestSingleInstanceLock()) {
+    log.warn("[main] another WorkIsland instance already holds the lock — exiting this duplicate");
+    electron.app.quit();
+    return;
+  }
   const { resolveRuntimeMode } = require("./runtime-mode.cjs");
   const runtimeMode = resolveRuntimeMode(process.env);
   const developmentMode = runtimeMode.isDevelopment;
@@ -694,7 +699,18 @@ async function runIslandApp() {
   log.info("[main] process starting, electron version:", process.versions.electron);
   log.info("[main] pid:", process.pid);
   electron.app.on("window-all-closed", () => {
+    if (process.platform !== "darwin") {
+      log.info("[main] all windows closed — quitting");
+      electron.app.quit();
+    }
   });
+  if (process.platform === "win32") {
+    // Windows 注销/关机时不一定走优雅退出路径，直接结束避免残留进程。
+    electron.app.on("session-end", () => {
+      log.info("[main] session-end — forcing exit");
+      electron.app.exit(0);
+    });
+  }
   await electron.app.whenReady();
   log.info("[main] app.whenReady() fired");
   const sentinelPath = getCrashSentinelPath();
@@ -715,6 +731,10 @@ async function runIslandApp() {
   } catch {
   }
   const coordinator = new AppCoordinator();
+  electron.app.on("second-instance", () => {
+    log.info("[main] second-instance launch — surfacing settings window");
+    coordinator.openSettingsWindow();
+  });
   updateService = createUpdateService({
     app: electron.app,
     shell: electron.shell,
@@ -761,8 +781,14 @@ async function runIslandApp() {
         log.warn("[main] quit watchdog: all windows destroyed, awaiting will-quit");
         return;
       }
-      log.warn("[main] quit timed out with windows still alive — treating as cancelled, restoring isQuitting=false");
-      setQuitting(false);
+      log.warn("[main] quit timed out with windows still alive — destroying windows and forcing exit");
+      for (const win of aliveWindows) {
+        try {
+          win.destroy();
+        } catch {
+        }
+      }
+      electron.app.exit(0);
     }, QUIT_WATCHDOG_MS);
   });
   electron.app.on("will-quit", () => {
@@ -781,6 +807,11 @@ async function runIslandApp() {
       fs.unlinkSync(sentinelPath);
     } catch {
     }
+    // 硬退出兜底：优雅清理超时（如钩子子进程未退出）时强制结束，避免僵尸实例占用管道。
+    setTimeout(() => {
+      log.warn("[main] will-quit did not complete in time — forcing exit");
+      electron.app.exit(0);
+    }, 3000).unref();
   });
   electron.app.setName("WorkIsland");
   utils.electronApp.setAppUserModelId("app.workisland.desktop");
@@ -827,6 +858,7 @@ async function runIslandApp() {
     }
   };
   let islandWindow;
+  let statusTray = null;
   let rendererCrashCount = 0;
   const MAX_RENDERER_RETRIES = 2;
   function createIslandWindow() {
@@ -950,6 +982,39 @@ async function runIslandApp() {
     });
   }
 
+  // Windows/Linux 没有 Dock，托盘是常驻可见的显示/退出入口（issue #56）。
+  function createStatusTray() {
+    if (process.platform === "darwin" || statusTray) return;
+    try {
+      const icon = electron.nativeImage.createFromPath(path.join(__dirname, "../../resources/icon.png"));
+      if (icon.isEmpty()) {
+        log.warn("[main] tray icon not found — skipping tray creation");
+        return;
+      }
+      statusTray = new electron.Tray(icon.resize({ width: 16, height: 16 }));
+      statusTray.setToolTip("WorkIsland");
+      const zh = (coordinator.getSettings().locale || "zh") !== "en";
+      const menu = electron.Menu.buildFromTemplate([
+        { label: zh ? "显示灵动岛" : "Show Island", click: () => {
+          islandWindow?.revealForHover();
+        } },
+        { label: zh ? "设置…" : "Settings…", click: () => {
+          coordinator.openSettingsWindow();
+        } },
+        { type: "separator" },
+        { label: zh ? "退出 WorkIsland" : "Quit WorkIsland", click: () => {
+          electron.app.quit();
+        } }
+      ]);
+      statusTray.setContextMenu(menu);
+      statusTray.on("click", () => {
+        islandWindow?.revealForHover();
+      });
+    } catch (err) {
+      log.warn("[main] failed to create status tray:", err?.message || err);
+    }
+  }
+
   if (needsOnboarding) {
     log.info("[main] first launch — showing WelcomeWindow");
     if (!coordinator.getSettings().firstLaunchAt) {
@@ -958,9 +1023,11 @@ async function runIslandApp() {
     showWelcomeWindow({ afterComplete: () => {
       coordinator.updateSettings({ hasCompletedOnboarding: true });
       startIsland({ expandAfterOnboarding: true });
+      createStatusTray();
     } });
   } else {
     startIsland();
+    createStatusTray();
   }
   coordinator.setPetWindowFactory((x, y) => {
     const petWindow = new PetWindow(x, y, coordinator.getSettings().petScale);

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -713,6 +713,19 @@ async function runIslandApp() {
   }
   await electron.app.whenReady();
   log.info("[main] app.whenReady() fired");
+  // CI 退出回归（issue #56）：--smoke-quit-after=<ms> 在就绪后自动退出，
+  // 供打包 smoke 验证应用不会僵尸化（不再依赖 taskkill 强杀）。
+  const smokeQuitArg = process.argv.find((arg) => arg.startsWith("--smoke-quit-after="));
+  if (smokeQuitArg) {
+    const smokeQuitDelay = Number(smokeQuitArg.split("=")[1]) || 0;
+    if (smokeQuitDelay > 0) {
+      log.info(`[main] smoke-quit-after=${smokeQuitDelay}ms armed`);
+      setTimeout(() => {
+        log.info("[main] smoke-quit-after elapsed — calling app.quit()");
+        electron.app.quit();
+      }, smokeQuitDelay);
+    }
+  }
   const sentinelPath = getCrashSentinelPath();
   if (fs.existsSync(sentinelPath)) {
     log.warn("[main] crash sentinel detected — previous process did not exit cleanly");


### PR DESCRIPTION
Fixes the quit half of the Windows alpha blocker.

## What
- single-instance lock: duplicate instances exit instead of half-running beside the pipe owner; a second launch surfaces the settings window
- status tray (island / settings / quit) on non-darwin platforms — the first always-visible quit entry on Windows
- `window-all-closed` now quits outside darwin instead of lingering windowless
- quit watchdog escalates: destroy stuck windows + `app.exit(0)` instead of cancelling the quit and reverting `isQuitting` (previously one stalled quit made the app permanently unquittable)
- `will-quit` hard-exit fallback (3s) and win32 `session-end` force exit
- bridge server asks the duplicate instance to quit when the named pipe is held
- CI regression: `--smoke-quit-after` flag + `smoke-win-packaged.mjs --expect-self-quit` scenario wired into windows-smoke and release workflows

Closes #56 (auto-close won't fire on a non-default base; will close manually)