### PR TITLE
fix(win): jump to the Codex session's real window instead of a bare cmd

### DIFF
--- a/src/main/windows-navigation.cjs
+++ b/src/main/windows-navigation.cjs
@@ -3,25 +3,29 @@
 const childProcess = require("node:child_process");
 const util = require("node:util");
 
+// executable 为 null 的条目永不主动启动：终端宿主（wt/pwsh/cmd）拉起只会得到
+// 一个落在默认 profile 的空控制台（issue #57 的「跳到裸 cmd」），codex 在
+// Windows 上是 CLI、不存在 Codex.exe 桌面客户端。对这些目标只聚焦已有窗口。
+// launchable 的 GUI 客户端在窗口全关时才允许启动兜底。
 const WINDOWS_APPS = Object.freeze({
-  "windows terminal": { title: "Windows Terminal", executable: "wt.exe" },
-  terminal: { title: "Windows Terminal", executable: "wt.exe" },
-  powershell: { title: "PowerShell", executable: "powershell.exe" },
-  pwsh: { title: "PowerShell", executable: "pwsh.exe" },
-  "command prompt": { title: "Command Prompt", executable: "cmd.exe" },
-  cmd: { title: "Command Prompt", executable: "cmd.exe" },
-  cursor: { title: "Cursor", executable: "Cursor.exe" },
-  "visual studio code": { title: "Visual Studio Code", executable: "code.cmd" },
-  "vs code": { title: "Visual Studio Code", executable: "code.cmd" },
-  vscode: { title: "Visual Studio Code", executable: "code.cmd" },
-  code: { title: "Visual Studio Code", executable: "code.cmd" },
-  windsurf: { title: "Windsurf", executable: "Windsurf.exe" },
-  trae: { title: "TRAE", executable: "Trae.exe" },
-  codex: { title: "Codex", executable: "Codex.exe" },
-  claude: { title: "Claude", executable: "Claude.exe" },
-  opencode: { title: "OpenCode", executable: "opencode.exe" },
-  wezterm: { title: "WezTerm", executable: "wezterm-gui.exe" },
-  alacritty: { title: "Alacritty", executable: "alacritty.exe" }
+  "windows terminal": { title: "Windows Terminal", executable: null },
+  terminal: { title: "Windows Terminal", executable: null },
+  powershell: { title: "PowerShell", executable: null },
+  pwsh: { title: "PowerShell", executable: null },
+  "command prompt": { title: "Command Prompt", executable: null },
+  cmd: { title: "Command Prompt", executable: null },
+  cursor: { title: "Cursor", executable: "Cursor.exe", launchable: true },
+  "visual studio code": { title: "Visual Studio Code", executable: "code.cmd", launchable: true },
+  "vs code": { title: "Visual Studio Code", executable: "code.cmd", launchable: true },
+  vscode: { title: "Visual Studio Code", executable: "code.cmd", launchable: true },
+  code: { title: "Visual Studio Code", executable: "code.cmd", launchable: true },
+  windsurf: { title: "Windsurf", executable: "Windsurf.exe", launchable: true },
+  trae: { title: "TRAE", executable: "Trae.exe", launchable: true },
+  codex: { title: "Codex", executable: null },
+  claude: { title: "Claude", executable: "Claude.exe", launchable: true },
+  opencode: { title: "OpenCode", executable: null },
+  wezterm: { title: "WezTerm", executable: "wezterm-gui.exe", launchable: true },
+  alacritty: { title: "Alacritty", executable: "alacritty.exe", launchable: true }
 });
 
 function resolveWindowsApp(app) {
@@ -36,16 +40,41 @@ function createWindowsNavigation({ execFile = childProcess.execFile, logger = co
   async function jumpToTarget(target) {
     const app = resolveWindowsApp(target?.app);
     if (!app) return false;
-    // AppActivate 按窗口标题前缀匹配，同名窗口（如多个 PowerShell）可能激活到
-    // 另一个；Windows Terminal 尚无按 WT_SESSION 精确定位的公开接口，先接受这个
-    // 近似。激活失败时回退到启动可执行文件，并把结果写回 stdout 供调用方判断。
+    // 激活优先级（issue #57）：
+    // 1) 按会话 pid 激活（AppActivate 接受 PID，GUI 客户端会话直接命中）；
+    // 2) 沿父进程链找 WindowsTerminal/conhost 等终端宿主，按宿主 PID 激活
+    //    （WT 窗口标题随活动标签变化，标题匹配几乎必然失败；标签级精确定位
+    //    尚无公开接口，只能聚焦到宿主窗口）；
+    // 3) 按标题激活兜底；
+    // 4) 仅对 launchable 的 GUI 客户端允许 Start-Process 兜底——codex/终端类
+    //    目标任何情况下都不再凭空弹出新窗口。
     const script = [
       "$title = [Environment]::GetEnvironmentVariable('WORKISLAND_APP_TITLE')",
       "$executable = [Environment]::GetEnvironmentVariable('WORKISLAND_APP_EXECUTABLE')",
+      "$launchable = [Environment]::GetEnvironmentVariable('WORKISLAND_APP_LAUNCHABLE') -eq '1'",
+      "$targetPid = 0",
+      "[void][int]::TryParse([Environment]::GetEnvironmentVariable('WORKISLAND_APP_PID'), [ref]$targetPid)",
       "$shell = New-Object -ComObject WScript.Shell",
-      "$activated = $shell.AppActivate($title)",
-      "if (-not $activated -and $executable) { Start-Process -FilePath $executable; Write-Output 'RESULT:launched'; exit 0 }",
-      "if ($activated) { Write-Output 'RESULT:activated' } else { Write-Output 'RESULT:failed' }"
+      "$activated = $false",
+      "if ($targetPid -gt 0) {",
+      "  $activated = $shell.AppActivate($targetPid)",
+      "  if (-not $activated) {",
+      "    $termHost = $null",
+      "    $hostNames = @('windowsterminal.exe','conhost.exe','openconsole.exe','wezterm-gui.exe','alacritty.exe')",
+      "    $p = Get-CimInstance Win32_Process -Filter \"ProcessId=$targetPid\"",
+      "    for ($i = 0; $i -lt 8 -and $p; $i++) {",
+      "      $n = $p.Name.ToLowerInvariant()",
+      "      if ($hostNames -contains $n) { $termHost = $p; break }",
+      "      if ($n -eq 'explorer.exe') { break }",
+      "      $p = Get-CimInstance Win32_Process -Filter \"ProcessId=$($p.ParentProcessId)\"",
+      "    }",
+      "    if ($termHost) { $activated = $shell.AppActivate([int]$termHost.ProcessId) }",
+      "  }",
+      "}",
+      "if (-not $activated -and $title) { $activated = $shell.AppActivate($title) }",
+      "if ($activated) { Write-Output 'RESULT:activated'; exit 0 }",
+      "if ($launchable -and $executable) { Start-Process -FilePath $executable; Write-Output 'RESULT:launched'; exit 0 }",
+      "Write-Output 'RESULT:failed'"
     ].join("; ");
     try {
       // promisify(execFile) 对多返回值的实现是数组（真实 child_process 为 {stdout}）
@@ -57,12 +86,14 @@ function createWindowsNavigation({ execFile = childProcess.execFile, logger = co
         "-Command",
         script
       ], {
-        timeout: 5e3,
+        timeout: 8e3,
         windowsHide: true,
         env: {
           ...process.env,
           WORKISLAND_APP_TITLE: app.title,
-          WORKISLAND_APP_EXECUTABLE: app.executable || ""
+          WORKISLAND_APP_EXECUTABLE: app.executable || "",
+          WORKISLAND_APP_LAUNCHABLE: app.launchable ? "1" : "0",
+          WORKISLAND_APP_PID: String(Number(target?.pid) || 0)
         }
       });
       const stdout = typeof result === "string"

--- a/tests/windows-platform.test.mjs
+++ b/tests/windows-platform.test.mjs
@@ -37,7 +37,7 @@ test("Windows Terminal hook context preserves WT_SESSION", () => {
   assert.equal(payload.terminal_session_id, "{pane-guid}");
 });
 
-test("Windows navigation activates an existing app before launching a fallback", async () => {
+test("Windows navigation activates existing windows and never spawns a bare terminal", async () => {
   const calls = [];
   const navigation = createWindowsNavigation({
     execFile: (command, args, options, callback) => {
@@ -45,12 +45,32 @@ test("Windows navigation activates an existing app before launching a fallback",
       callback(null, "RESULT:activated", "");
     }
   });
-  assert.deepEqual(resolveWindowsApp("Windows Terminal"), { title: "Windows Terminal", executable: "wt.exe" });
+  assert.deepEqual(resolveWindowsApp("Windows Terminal"), { title: "Windows Terminal", executable: null });
   assert.equal(await navigation.jumpToTarget({ app: "Windows Terminal" }), true);
   assert.equal(calls[0].command, "powershell.exe");
   assert.equal(calls[0].options.windowsHide, true);
   assert.equal(calls[0].options.env.WORKISLAND_APP_TITLE, "Windows Terminal");
-  assert.equal(calls[0].options.env.WORKISLAND_APP_EXECUTABLE, "wt.exe");
+  assert.equal(calls[0].options.env.WORKISLAND_APP_EXECUTABLE, "");
+  assert.equal(calls[0].options.env.WORKISLAND_APP_LAUNCHABLE, "0");
+  assert.equal(calls[0].options.env.WORKISLAND_APP_PID, "0");
+
+  // codex 在 Windows 上是 CLI：跳转只允许聚焦（按 pid/标题），绝不 Start-Process。
+  const codexApp = resolveWindowsApp("codex");
+  assert.deepEqual(codexApp, { title: "Codex", executable: null });
+  assert.equal(await navigation.jumpToTarget({ app: "codex", pid: 4242 }), true);
+  assert.equal(calls[1].options.env.WORKISLAND_APP_TITLE, "Codex");
+  assert.equal(calls[1].options.env.WORKISLAND_APP_EXECUTABLE, "");
+  assert.equal(calls[1].options.env.WORKISLAND_APP_LAUNCHABLE, "0");
+  assert.equal(calls[1].options.env.WORKISLAND_APP_PID, "4242");
+  assert.ok(!calls[1].args.join(" ").includes("Start-Process wt"), "must not blindly launch Windows Terminal");
+  const codexScript = calls[1].args[calls[1].args.length - 1];
+  assert.match(codexScript, /AppActivate\(\$targetPid\)/);
+  assert.match(codexScript, /windowsterminal\.exe/);
+
+  // GUI 客户端保留启动兜底（窗口全关时）。
+  assert.deepEqual(resolveWindowsApp("cursor"), { title: "Cursor", executable: "Cursor.exe", launchable: true });
+  assert.equal(await navigation.jumpToTarget({ app: "cursor" }), true);
+  assert.equal(calls[2].options.env.WORKISLAND_APP_LAUNCHABLE, "1");
 
   const failedNavigation = createWindowsNavigation({
     execFile: (command, args, options, callback) => callback(null, "RESULT:failed", "")


### PR DESCRIPTION
Fixes the Codex-jump half of the Windows alpha blocker.

## What
- activate by session pid first (`AppActivate` accepts pids), then walk the parent chain to the WindowsTerminal/conhost host window and activate that — WT window titles track the active tab, which is why the old title match nearly always failed
- title-prefix match stays as a tertiary fallback
- never `Start-Process` for terminal hosts or codex: spawning `wt.exe` lands in a default-profile empty console (the reported bare-cmd jump), and there is no `Codex.exe` desktop client on Windows
- launch fallback kept only for real GUI clients (cursor/trae/claude/windsurf/wezterm/alacritty/vscode)
- unit tests pin the new contract (codex target carries no launchable executable; pid reaches the PowerShell layer)

Closes #57 (auto-close won't fire on a non-default base; will close manually)