### PR TITLE
feat(toolbox): 插件图标拖放排序 + 溢出滚动收纳（研发分拣第 4 项）

### DIFF
--- a/src/main/hook-shared.cjs
+++ b/src/main/hook-shared.cjs
@@ -18,8 +18,8 @@ function saveSessions(sessions) {
   } catch {
   }
 }
-function shellQuote(p) {
-  if (process.platform === "win32") return `"${String(p).replaceAll('"', '\\"')}"`;
+function shellQuote(p, platform = process.platform) {
+  if (platform === "win32") return `"${String(p).replaceAll('"', '\\"')}"`;
   return `'${p}'`;
 }
 function buildDevHooksCliCommand(source) {
@@ -35,10 +35,10 @@ function wrapWithInstallCheck(guardPath, command, { platform = process.platform,
     const sourceMatch = String(command).match(/--source\s+(?:"([^"]+)"|'([^']+)'|(\S+))/);
     const source = sourceMatch?.[1] || sourceMatch?.[2] || sourceMatch?.[3];
     if (portableExecutable && source) {
-      return `if not exist ${shellQuote(portableExecutable)} exit /b 0 & ${shellQuote(portableExecutable)} --workisland-hook-source=${source}`;
+      return `if not exist ${shellQuote(portableExecutable, platform)} exit /b 0 & ${shellQuote(portableExecutable, platform)} --workisland-hook-source=${source}`;
     }
     const normalized = command.replace(/^ELECTRON_RUN_AS_NODE=1\s+/, 'set "ELECTRON_RUN_AS_NODE=1"&& ');
-    return `if not exist ${shellQuote(guardPath)} exit /b 0 & ${normalized}`;
+    return `if not exist ${shellQuote(guardPath, platform)} exit /b 0 & ${normalized}`;
   }
   return `[ -e ${shellQuote(guardPath)} ] || exit 0; ${command}`;
 }

--- a/src/preload/island.js
+++ b/src/preload/island.js
@@ -201,6 +201,9 @@ electron.contextBridge.exposeInMainWorld("islandBridge", {
   getSettings() {
     return electron.ipcRenderer.invoke(ipc.IPC.SETTINGS_GET);
   },
+  setSettings(partial) {
+    return electron.ipcRenderer.invoke(ipc.IPC.SETTINGS_SET, partial);
+  },
   getPetSpritePath() {
     return electron.ipcRenderer.invoke(ipc.IPC.PET_GET_SPRITE_PATH);
   },

--- a/src/renderer/island/components/IslandPanel.css
+++ b/src/renderer/island/components/IslandPanel.css
@@ -69,6 +69,23 @@
   align-items: center;
   gap: 12px;
   flex-shrink: 0;
+  max-width: 60%;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+
+.usage-row-actions::-webkit-scrollbar {
+  display: none;
+}
+
+/* Draggable utility modules: hint affordance without changing hit targets. */
+.toolbox-icon-button[draggable="true"] {
+  -webkit-user-drag: element;
+  touch-action: none;
+}
+
+.toolbox-icon-button[draggable="true"]:active {
+  cursor: grabbing;
 }
 
 .update-tag {

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -9,7 +9,7 @@ import { PerformancePopover } from "./PerformancePopover.js";
 import { ShelfPanel } from "./ShelfPanel.js";
 import { ClipboardPanel } from "./ClipboardPanel.js";
 import { TerminalPanel } from "./TerminalPanel.js";
-import { enabledToolboxModules, selectToolboxModule } from "./productivity-toolbox-model.mjs";
+import { enabledToolboxModules, orderToolboxModules, reorderToolboxModules, selectToolboxModule } from "./productivity-toolbox-model.mjs";
 const defaultIcon = new URL("../assets/status/idle.svg", import.meta.url).href;
 const runningIcon = new URL("../assets/status/running.svg", import.meta.url).href;
 const approvalIcon = new URL("../assets/status/approval.svg", import.meta.url).href;
@@ -259,6 +259,8 @@ function AgentUsageRow({
   enabledToolboxModules = [],
   activeToolboxModule = "agent",
   onToolboxModuleChange,
+  toolboxModuleOrder = [],
+  onToolboxModuleReorder,
   onOpenSettings,
   onOpenAbout,
   onOpenPet
@@ -278,11 +280,20 @@ function AgentUsageRow({
   const handleClearSessions = () => {
     window.islandBridge?.deleteSessions(visibleSessionIds);
   };
-  const utilityModules = [
+  const dragSourceIdRef = reactExports.useRef(null);
+  const utilityModules = orderToolboxModules([
     ["shelf", "文件架", ShelfToolIcon],
     ["clipboard", "剪贴板", ClipboardToolIcon],
     ["terminal", "终端", TerminalToolIcon]
-  ].filter(([id]) => enabledToolboxModules.includes(id));
+  ].filter(([id]) => enabledToolboxModules.includes(id)).map(([id]) => id), toolboxModuleOrder)
+    .map((id) => [["shelf", "文件架", ShelfToolIcon], ["clipboard", "剪贴板", ClipboardToolIcon], ["terminal", "终端", TerminalToolIcon]].find(([moduleId]) => moduleId === id));
+  const handleUtilityDragStart = (id) => { dragSourceIdRef.current = id; };
+  const handleUtilityDrop = (id) => {
+    const sourceId = dragSourceIdRef.current;
+    dragSourceIdRef.current = null;
+    if (!sourceId || sourceId === id) return;
+    onToolboxModuleReorder?.(sourceId, id);
+  };
   const utilityButtons = utilityModules.map(([id, label, Icon]) => React.createElement("button", {
     key: id,
     type: "button",
@@ -290,6 +301,10 @@ function AgentUsageRow({
     title: label,
     "aria-label": label,
     "aria-pressed": activeToolboxModule === id,
+    draggable: true,
+    onDragStart: () => handleUtilityDragStart(id),
+    onDragOver: (event) => event.preventDefault(),
+    onDrop: (event) => { event.preventDefault(); handleUtilityDrop(id); },
     onClick: () => onToolboxModuleChange?.(activeToolboxModule === id ? "agent" : id)
   }, React.createElement(Icon)));
   const agentHomeButton = activeToolboxModule !== "agent" && React.createElement("button", {
@@ -1367,7 +1382,26 @@ function IslandPanel({
 }) {
   const [followUpSessionId, setFollowUpSessionId] = React.useState(null);
   const [activeModule, setActiveModule] = React.useState("agent");
+  const [moduleOrder, setModuleOrder] = React.useState([]);
+  React.useEffect(() => {
+    let disposed = false;
+    window.islandBridge?.getSettings?.().then((settings) => {
+      if (!disposed) setModuleOrder(Array.isArray(settings?.toolboxModuleOrder) ? settings.toolboxModuleOrder : []);
+    }).catch(() => {});
+    const unsubscribe = window.islandBridge?.onSettingsChanged?.((settings) => {
+      setModuleOrder(Array.isArray(settings?.toolboxModuleOrder) ? settings.toolboxModuleOrder : []);
+    });
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, []);
   const enabledModules = enabledToolboxModules({ fileShelfEnabled, clipboardHistoryEnabled, terminalEnabled });
+  const handleToolboxModuleReorder = (sourceId, targetId) => {
+    const nextOrder = reorderToolboxModules(["shelf", "clipboard", "terminal"], sourceId, targetId);
+    setModuleOrder(nextOrder);
+    window.islandBridge?.setSettings?.({ toolboxModuleOrder: nextOrder });
+  };
   const agentAttention = Boolean(surface?.actionableSessionId) || sessions.some((session) => ["waitingForApproval", "waitingForAnswer", "failed"].includes(session.phase));
   React.useEffect(() => {
     setActiveModule((current) => selectToolboxModule({ current, attention: agentAttention, enabled: enabledModules }));
@@ -1436,6 +1470,8 @@ function IslandPanel({
       enabledToolboxModules: enabledModules,
       activeToolboxModule: activeModule,
       onToolboxModuleChange: setActiveModule,
+      toolboxModuleOrder: moduleOrder,
+      onToolboxModuleReorder: handleToolboxModuleReorder,
       onOpenSettings,
       onOpenAbout,
       onOpenPet

--- a/src/renderer/island/components/productivity-toolbox-model.mjs
+++ b/src/renderer/island/components/productivity-toolbox-model.mjs
@@ -1,5 +1,29 @@
 const TOOLBOX_MODULES = Object.freeze(["agent", "shelf", "clipboard", "terminal"]);
 
+// Sort known utility modules by the user-dragged order; modules missing from
+// the order (including newly introduced ones) keep their default position
+// after the ordered ones.
+function orderToolboxModules(modules = [], order = []) {
+  const rank = new Map(order.map((id, index) => [id, index]));
+  return [...modules].sort((a, b) => {
+    const ra = rank.has(a) ? rank.get(a) : order.length;
+    const rb = rank.has(b) ? rank.get(b) : order.length;
+    return ra === rb ? modules.indexOf(a) - modules.indexOf(b) : ra - rb;
+  });
+}
+
+// Reorder for a drag-and-drop move: move `sourceId` to the position of
+// `targetId` within `modules`. Returns a new ordered array of all modules
+// (enabled or not) so the persisted order stays stable when modules toggle.
+function reorderToolboxModules(modules = [], sourceId, targetId) {
+  if (!modules.includes(sourceId) || !modules.includes(targetId) || sourceId === targetId) return modules;
+  const next = modules.filter((id) => id !== sourceId);
+  next.splice(modules.indexOf(targetId) > modules.indexOf(sourceId)
+    ? next.indexOf(targetId) + 1
+    : next.indexOf(targetId), 0, sourceId);
+  return next;
+}
+
 function enabledToolboxModules(settings = {}) {
   const enabled = ["agent"];
   if (settings.fileShelfEnabled !== false) enabled.push("shelf");
@@ -34,7 +58,9 @@ function reduceToolboxState(state, event) {
 export {
   TOOLBOX_MODULES,
   enabledToolboxModules,
+  orderToolboxModules,
   reduceToolboxState,
+  reorderToolboxModules,
   resolveToolboxReopenModule,
   selectToolboxModule
 };

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -124,6 +124,10 @@ const DEFAULT_SETTINGS = {
   terminalCustomDirectory: "",
   terminalSavedCommands: [],
   toolboxReopenMode: "agent",
+  // User-dragged order of utility modules (shelf/clipboard/terminal). Empty
+  // array means the built-in default order; unknown ids are dropped on merge
+  // and newly introduced modules append after the ordered ones.
+  toolboxModuleOrder: [],
   showUsageQuota: true,
   usageDisplayValue: "used",
   disableClaudeTerminalTitle: true,
@@ -292,6 +296,13 @@ function mergeSettings(parsed = {}) {
   merged.toolboxReopenMode = ["agent", "last"].includes(parsed.toolboxReopenMode)
     ? parsed.toolboxReopenMode
     : DEFAULT_SETTINGS.toolboxReopenMode;
+  {
+    const known = ["shelf", "clipboard", "terminal"];
+    const order = Array.isArray(parsed.toolboxModuleOrder)
+      ? parsed.toolboxModuleOrder.filter((id) => known.includes(id))
+      : [];
+    merged.toolboxModuleOrder = Array.from(new Set(order));
+  }
 
   return merged;
 }

--- a/tests/toolbox-module-order.test.mjs
+++ b/tests/toolbox-module-order.test.mjs
@@ -1,0 +1,52 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const {
+  orderToolboxModules,
+  reorderToolboxModules
+} = await import("../src/renderer/island/components/productivity-toolbox-model.mjs");
+const { mergeSettings, DEFAULT_SETTINGS } = require("../src/shared/settings.cjs");
+
+test("orderToolboxModules keeps default order when preference is empty", () => {
+  assert.deepEqual(
+    orderToolboxModules(["shelf", "clipboard", "terminal"], []),
+    ["shelf", "clipboard", "terminal"]
+  );
+});
+
+test("orderToolboxModules applies user order and appends unknown modules after", () => {
+  assert.deepEqual(
+    orderToolboxModules(["shelf", "clipboard", "terminal"], ["terminal", "clipboard"]),
+    ["terminal", "clipboard", "shelf"]
+  );
+});
+
+test("orderToolboxModules ignores ids not present among modules", () => {
+  assert.deepEqual(
+    orderToolboxModules(["clipboard", "terminal"], ["terminal", "shelf", "clipboard"]),
+    ["terminal", "clipboard"]
+  );
+});
+
+test("reorderToolboxModules moves a module left and right", () => {
+  const modules = ["shelf", "clipboard", "terminal"];
+  assert.deepEqual(reorderToolboxModules(modules, "terminal", "shelf"), ["terminal", "shelf", "clipboard"]);
+  assert.deepEqual(reorderToolboxModules(modules, "shelf", "terminal"), ["clipboard", "terminal", "shelf"]);
+});
+
+test("reorderToolboxModules is a no-op for unknown or identical ids", () => {
+  const modules = ["shelf", "clipboard", "terminal"];
+  assert.equal(reorderToolboxModules(modules, "shelf", "shelf"), modules);
+  assert.equal(reorderToolboxModules(modules, "nope", "shelf"), modules);
+});
+
+test("settings merge sanitizes toolboxModuleOrder", () => {
+  const merged = mergeSettings({
+    toolboxModuleOrder: ["terminal", "bogus", "terminal", "clipboard", 7, null]
+  });
+  assert.deepEqual(merged.toolboxModuleOrder, ["terminal", "clipboard"]);
+  assert.deepEqual(DEFAULT_SETTINGS.toolboxModuleOrder, []);
+  assert.deepEqual(mergeSettings({}).toolboxModuleOrder, []);
+});


### PR DESCRIPTION
## 内容

对标 Chrome 扩展栏的交互，落地「插件区可自定义布局」的第一步：

- **拖放换位**：文件架 / 剪贴板 / 终端图标支持 HTML5 拖放重排（主工作台顶部操作行）。
- **顺序持久化**：新增 `settings.toolboxModuleOrder`；merge 时过滤未知 id 并去重；新增模块自动排在有序项之后，禁用的模块不丢顺序。
- **溢出滚动**：操作行 `max-width: 60%` + 横向滚动（隐藏滚动条），为后续插件增多预留收纳空间。
- **island preload 补 `setSettings`**：原先只有 getSettings，看板类功能写设置无通道。

## 实现

- `productivity-toolbox-model.mjs`：新增 `orderToolboxModules` / `reorderToolboxModules` 纯函数（默认顺序兜底、左移/右移语义）。
- `IslandPanel.js`：拖放事件 + 模块顺序状态（初始读 settings，监听 SETTINGS_DID_CHANGE），变更经 `islandBridge.setSettings` 持久化。
- `IslandPanel.css`：滚动收纳与拖拽 affordance。

## 顺带修复

- cherry-pick 了 #64 分支上的 shellQuote 平台注入修复（#62 引入，main 上 `windows-platform` 测试必挂）。

## 验证

- [x] 新增 6 项单测（顺序排序/重排/设置 merge 清洗）
- [x] 本地 `npm run check`：265/265 通过
- [ ] CI 绿
- [ ] 实机拖放体验待人工验证（自动化覆盖模型层，DOM 拖放行为需实机）

## 关联

[MASTER_TODO 研发分拣](../docs/09-todo/MASTER_TODO.md) 第 4 项；第 5 项「对标 macOS 菜单栏打磨」将在此分支合入后按插件拆小 PR。