### PR TITLE
fix(performance): restore responsive hover process details

### DIFF
--- a/docs/superpowers/plans/2026-08-31-performance-hover-details.md
+++ b/docs/superpowers/plans/2026-08-31-performance-hover-details.md
@@ -1,0 +1,78 @@
+# Performance Hover Details Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore reliable process details in the system performance popover by showing explicit loading/empty feedback, immediately reusing the latest successful process sample, and making pointer transfer forgiving.
+
+**Architecture:** Extend `PerformanceService` with an in-memory last-successful process cache and explicit process-detail status fields. Keep hidden sampling lightweight, publish cached data synchronously when details open, then refresh on demand. Let the existing renderer choose between loading, list, and empty/unavailable rows from those fields, while preserving all existing sorting and process actions.
+
+**Tech Stack:** Electron, Node.js CommonJS service, React renderer, Node test runner, CSS.
+
+---
+
+## Task 1: Specify cached process-detail behavior with failing tests
+
+**Files:**
+- Modify: `tests/performance-service.test.mjs`
+
+- [ ] Add a test that completes one successful macOS process sample, hides details, reopens them with the next `/bin/ps` call deferred, and asserts that `getSnapshot()` immediately contains the cached list with `processesLoading: true`.
+- [ ] Add a test that completes one successful process sample, makes the next `/bin/ps` call fail, and asserts that the cached list remains available after refresh while loading ends.
+- [ ] Run `node --test tests/performance-service.test.mjs` and confirm both new tests fail for the missing cache/status behavior.
+- [ ] Commit the failing behavioral specification together with its eventual implementation in Task 2.
+
+## Task 2: Implement service cache and status transitions
+
+**Files:**
+- Modify: `src/main/performance-service.cjs`
+- Test: `tests/performance-service.test.mjs`
+
+- [ ] Initialize a last-successful process cache and process-detail state flags without enabling hidden process sampling.
+- [ ] When details become visible, synchronously publish cached processes and a loading state, then start the existing on-demand sample.
+- [ ] On a successful `/bin/ps` or PowerShell process sample, replace the cache and publish `processesLoaded: true`, `processesLoading: false`, and `processesUnavailable: false`.
+- [ ] On a failed process refresh, preserve the cache, end loading, and publish an unavailable state only when there is no usable cached list.
+- [ ] When details are hidden, continue publishing an empty active process list and do not execute process-detail commands.
+- [ ] Run `node --test tests/performance-service.test.mjs` and confirm all service tests pass.
+- [ ] Commit with message `fix(performance): preserve process details across hover`.
+
+## Task 3: Specify and implement renderer feedback and hover grace
+
+**Files:**
+- Modify: `tests/workstation-ipc.test.mjs`
+- Modify: `src/renderer/island/components/PerformancePopover.js`
+- Modify: `src/renderer/island/app.css`
+
+- [ ] Add renderer contract assertions for an explicit process status row, loading copy, empty/unavailable copy, and a 350 ms close delay.
+- [ ] Run `node --test tests/workstation-ipc.test.mjs` and confirm the new assertions fail.
+- [ ] Change the close grace period from 140 ms to 350 ms.
+- [ ] Render a compact `role="status"` row when no process records exist: loading during the first sample, unavailable after a failed first sample, and empty after a successful zero-row sample.
+- [ ] Add restrained styling for the status row without changing the existing process list, sorting, pinning, or action controls.
+- [ ] Run `node --test tests/workstation-ipc.test.mjs tests/renderer-syntax.test.mjs` and confirm both pass.
+- [ ] Commit with message `fix(performance): show process loading feedback`.
+
+## Task 4: Regression and build verification
+
+**Files:**
+- Verify only; no planned source edits.
+
+- [ ] Run the focused performance and IPC tests.
+- [ ] Run the full project test command from `package.json`.
+- [ ] Run the production build/package command used by the repository and confirm the artifact is produced successfully.
+- [ ] Inspect `git diff --check`, `git status --short`, and the branch diff to confirm only the intended plan, service, renderer, CSS, and test files are committed; preserve unrelated user changes.
+
+## Task 5: Deliver through PR and close Issue #67
+
+**Files:**
+- No local source edits planned.
+
+- [ ] Push `codex/fix-performance-hover-details` to origin.
+- [ ] Open a pull request whose body includes `Closes #67`, summarizes the cached-first/loading behavior, and lists exact verification evidence.
+- [ ] Wait for required CI checks and address any failures within scope.
+- [ ] Merge the pull request.
+- [ ] Fetch `origin --prune` and verify the feature commits are ancestors of `origin/main`.
+- [ ] Verify GitHub Issue #67 is closed and report the PR, merged commit, tests, build artifact, and any remaining local-only verification gate.
+
+## Plan self-review
+
+- [ ] Confirm every approved design requirement is represented: first-open loading, cached reopen, failed-refresh preservation, explicit empty/unavailable feedback, 350 ms hover grace, no hidden process scanning, and unchanged process controls.
+- [ ] Scan changed files for placeholders such as `TODO`, `FIXME`, mock-only branches, or skipped assertions.
+- [ ] Confirm service state fields use consistent boolean semantics across macOS, Windows, IPC snapshots, and renderer conditions.

--- a/docs/superpowers/specs/2026-08-31-performance-hover-details-design.md
+++ b/docs/superpowers/specs/2026-08-31-performance-hover-details-design.md
@@ -1,0 +1,59 @@
+# Performance Hover Details Design
+
+Issue: [#67](https://github.com/qianzhu18/workisland/issues/67)
+
+## Problem
+
+The performance popover begins process sampling only after it becomes visible. On the first hover, the renderer therefore receives an empty `processes` array and renders only CPU and memory. The process list appears several seconds later without any loading feedback. A 140 ms delayed close also makes it easy to lose the popover while moving the pointer from the trigger to the floating layer.
+
+The process sampler and process-management actions still work. This change addresses the presentation gap without introducing continuous background process scanning.
+
+## Desired experience
+
+- Opening the performance popover always gives immediate feedback.
+- The first open shows a clear process-loading state until the first on-demand sample completes.
+- Later opens show the most recent successful process list immediately while requesting a fresh sample.
+- Moving the pointer between the performance button and popover does not close the popover under normal movement.
+- Clicking the button still pins and unpins the popover.
+- CPU/memory sorting, process selection, and terminate/force actions remain unchanged.
+
+## Design
+
+### Service state
+
+`PerformanceService` will keep the most recent successful process sample in a dedicated in-memory cache. Hiding the details will continue to publish an empty active `processes` array so normal background updates remain lightweight, but opening the details will publish the cached list immediately before starting a fresh sample.
+
+The cache is process-local, is never persisted, and contains only the same bounded process records already exposed by the service. No additional background timer or filesystem storage is introduced.
+
+### Renderer state
+
+The popover will distinguish three process states:
+
+1. `loading`: details are visible and no process sample has completed yet.
+2. `ready`: at least one process record is available, including a cached record set while refresh is in flight.
+3. `empty`: sampling completed successfully but produced no visible processes.
+
+The renderer will show a compact loading row for the first state and an explicit empty row for the third. Existing process list rendering remains the ready state.
+
+### Hover behavior
+
+The close grace period will increase from 140 ms to 350 ms. Entering either the trigger or floating layer cancels the timer. Pinning remains independent of hover and continues to keep the layer open.
+
+## Error handling
+
+If process sampling fails, CPU and memory remain available. The process area exits the indefinite loading state and shows an unavailable/empty message. A failed refresh does not erase a previously successful cached list.
+
+## Testing
+
+- Service test: reopening details emits the previous successful process list before the fresh sample completes.
+- Service test: a failed refresh preserves the last successful cache.
+- Renderer contract test: the popover has explicit loading/empty feedback and uses the longer close delay.
+- Existing process action, IPC, syntax, and full project checks must remain green.
+- macOS manual verification: first open shows loading feedback; subsequent open shows cached processes immediately; pointer transfer remains stable.
+
+## Non-goals
+
+- Continuous process sampling while the popover is hidden.
+- Changes to process termination permissions or protected-process rules.
+- Redesigning the performance visuals or toolbox drag-and-drop interaction.
+- Persisting process information across application restarts.

--- a/src/main/performance-service.cjs
+++ b/src/main/performance-service.cjs
@@ -143,13 +143,17 @@ class PerformanceService extends EventEmitter {
     this.killProcess = killProcess;
     this.enabled = true;
     this.detailsVisible = false;
+    this.detailsRequestId = 0;
     this.timer = null;
     this.previousCpus = osApi.cpus();
     this.previousWindowsProcesses = new Map();
     this.lastWindowsSampleAt = 0;
+    this.lastSuccessfulProcesses = [];
+    this.hasSuccessfulProcessSample = false;
     this.state = {
       cpuPct: 0, memoryUsedBytes: 0, memoryTotalBytes: osApi.totalmem(), memoryPct: 0,
-      memoryPressure: "unknown", processes: [], updatedAt: 0
+      memoryPressure: "unknown", processes: [], processesLoading: false,
+      processesLoaded: false, processesUnavailable: false, updatedAt: 0
     };
   }
 
@@ -172,7 +176,17 @@ class PerformanceService extends EventEmitter {
   }
 
   setDetailsVisible(visible) {
-    this.detailsVisible = Boolean(visible);
+    const nextVisible = Boolean(visible);
+    if (nextVisible !== this.detailsVisible) this.detailsRequestId += 1;
+    this.detailsVisible = nextVisible;
+    this.state = {
+      ...this.state,
+      processes: this.detailsVisible ? this.lastSuccessfulProcesses : [],
+      processesLoading: this.detailsVisible,
+      processesLoaded: this.hasSuccessfulProcessSample,
+      processesUnavailable: false
+    };
+    this.emit("update", this.state);
     if (this.detailsVisible) void this.sample();
   }
 
@@ -231,13 +245,16 @@ class PerformanceService extends EventEmitter {
   }
 
   async sample() {
+    const shouldSampleDetails = this.detailsVisible;
+    const detailsRequestId = this.detailsRequestId;
     const cpus = this.osApi.cpus();
     const cpuPct = calculateCpuUsage(this.previousCpus, cpus);
     this.previousCpus = cpus;
     const memoryTotalBytes = this.osApi.totalmem();
     let memoryUsedBytes = Math.max(0, memoryTotalBytes - this.osApi.freemem());
     let memoryPressure = this.state.memoryPressure;
-    let processes = this.detailsVisible ? this.state.processes : [];
+    let processes = shouldSampleDetails ? this.lastSuccessfulProcesses : [];
+    let processSampleFailed = false;
     if (this.platform !== "win32") try {
       const pressure = await this.execFile("/usr/bin/memory_pressure", []);
       memoryPressure = parseMemoryPressure(pressure.stdout);
@@ -246,7 +263,7 @@ class PerformanceService extends EventEmitter {
       const vm = await this.execFile("/usr/bin/vm_stat", []);
       memoryUsedBytes = parseVmStat(vm.stdout, memoryTotalBytes) ?? memoryUsedBytes;
     } catch {}
-    if (this.detailsVisible) {
+    if (shouldSampleDetails) {
       try {
         if (this.platform === "win32") {
           const now = Date.now();
@@ -269,15 +286,35 @@ class PerformanceService extends EventEmitter {
           const result = await this.execFile("/bin/ps", ["-axo", "pid=,uid=,%cpu=,%mem=,rss=,command="]);
           processes = parseProcessRows(result.stdout, { currentUid: this.currentUid });
         }
-      } catch {}
+        this.lastSuccessfulProcesses = processes;
+        this.hasSuccessfulProcessSample = true;
+      } catch {
+        processSampleFailed = true;
+        processes = this.lastSuccessfulProcesses;
+      }
     }
+    const detailsStillVisible = this.detailsVisible;
+    const canPublishProcessDetails = shouldSampleDetails
+      && detailsStillVisible
+      && detailsRequestId === this.detailsRequestId;
     this.state = {
       cpuPct,
       memoryUsedBytes,
       memoryTotalBytes,
       memoryPct: memoryTotalBytes ? Math.round(memoryUsedBytes / memoryTotalBytes * 1e3) / 10 : 0,
       memoryPressure,
-      processes,
+      processes: detailsStillVisible
+        ? canPublishProcessDetails ? processes : this.state.processes
+        : [],
+      processesLoading: detailsStillVisible && !canPublishProcessDetails
+        ? this.state.processesLoading
+        : false,
+      processesLoaded: detailsStillVisible && !canPublishProcessDetails
+        ? this.state.processesLoaded
+        : this.hasSuccessfulProcessSample,
+      processesUnavailable: canPublishProcessDetails
+        ? processSampleFailed && !this.hasSuccessfulProcessSample
+        : detailsStillVisible && this.state.processesUnavailable,
       updatedAt: Date.now()
     };
     this.emit("update", this.state);

--- a/src/renderer/island/app.css
+++ b/src/renderer/island/app.css
@@ -1014,6 +1014,7 @@ body {
 .performance-metric i::after { content: ""; display: block; width: var(--value); height: 100%; border-radius: inherit; background: linear-gradient(90deg,#65cfa0,#9ce5c2); }
 .performance-memory { margin: 9px 2px 3px; color: rgba(255,255,255,.4); font-size: 9px; font-variant-numeric: tabular-nums; }
 .performance-processes { margin-top: 10px; padding-top: 10px; border-top: 1px solid rgba(255,255,255,.08); }
+.performance-process-status { margin-top: 10px; padding: 10px; border-top: 1px solid rgba(255,255,255,.08); color: rgba(255,255,255,.46); font-size: 9px; text-align: center; }
 .performance-process-title { display: flex; justify-content: space-between; gap: 8px; margin-bottom: 6px; color: rgba(255,255,255,.42); font-size: 9px; letter-spacing: .2px; }
 .performance-process-title span:last-child { color: rgba(255,255,255,.28); }
 .performance-process-list { overflow-y: auto; overscroll-behavior: contain; scrollbar-width: thin; }

--- a/src/renderer/island/components/PerformancePopover.js
+++ b/src/renderer/island/components/PerformancePopover.js
@@ -27,7 +27,7 @@ export function PerformancePopover({ state }) {
   const open = () => { cancelClose(); setHovered(true); };
   const closeSoon = () => {
     cancelClose();
-    closeTimer.current = window.setTimeout(() => setHovered(false), 140);
+    closeTimer.current = window.setTimeout(() => setHovered(false), 350);
   };
   React.useLayoutEffect(() => {
     if (!visible || !triggerRef.current) return undefined;
@@ -49,6 +49,13 @@ export function PerformancePopover({ state }) {
   const metric = selectedMetric || preferredProcessMetric(state);
   const orderedProcesses = sortProcessesByMetric(state?.processes, metric);
   const visibleProcesses = showAllProcesses ? orderedProcesses : orderedProcesses.slice(0, 5);
+  const processStatus = state?.processesLoading
+    ? "正在读取进程…"
+    : state?.processesUnavailable
+      ? "暂时无法读取进程"
+      : state?.processesLoaded
+        ? "没有可显示的进程"
+        : "正在读取进程…";
   const level = cpu >= 85 || memory >= 90 ? "critical" : cpu >= 65 || memory >= 75 ? "warning" : "normal";
   const actOnProcess = async (action) => {
     if (!selectedProcess || pendingAction) return;
@@ -71,6 +78,7 @@ export function PerformancePopover({ state }) {
       React.createElement("button", { type: "button", className: `performance-metric${metric === "memory" ? " is-active" : ""}`, onClick: () => setSelectedMetric("memory"), "aria-pressed": metric === "memory", title: "按内存占用排序" }, React.createElement("span", null, "内存"), React.createElement("strong", null, `${memory}%`), React.createElement("i", { style: { "--value": `${memory}%` } }))
     ),
     React.createElement("div", { className: "performance-memory" }, `${bytes(state?.memoryUsedBytes)} / ${bytes(state?.memoryTotalBytes)}`),
+    orderedProcesses.length === 0 && React.createElement("div", { className: "performance-process-status", role: "status" }, processStatus),
     state?.processes?.length > 0 && React.createElement("div", { className: "performance-processes" },
       React.createElement("div", { className: "performance-process-title" }, React.createElement("span", null, metric === "memory" ? "按内存占用排序" : "按 CPU 占用排序"), React.createElement("span", null, `${orderedProcesses.length} 个可见进程`)),
       React.createElement("div", { className: `performance-process-list${showAllProcesses ? " is-expanded" : ""}` },

--- a/tests/performance-service.test.mjs
+++ b/tests/performance-service.test.mjs
@@ -95,6 +95,109 @@ test("performance service only samples process details while visible", async () 
   assert.ok(detailCalls >= 1);
 });
 
+test("performance service republishes cached process details before refresh completes", async () => {
+  let processSample = 0;
+  let resolveRefresh;
+  const refreshPending = new Promise((resolve) => { resolveRefresh = resolve; });
+  const service = new PerformanceService({
+    platform: "darwin",
+    currentUid: 501,
+    osApi: {
+      cpus: () => [{ times: { user: 10, nice: 0, sys: 10, idle: 80, irq: 0 } }],
+      totalmem: () => 100,
+      freemem: () => 40
+    },
+    execFile: async (file) => {
+      if (file !== "/bin/ps") return { stdout: "" };
+      processSample += 1;
+      if (processSample === 1) {
+        return { stdout: "321 501 12.0 4.0 4096 /Applications/Safari.app/Contents/MacOS/Safari" };
+      }
+      await refreshPending;
+      return { stdout: "654 501 8.0 3.0 2048 /Applications/Mail.app/Contents/MacOS/Mail" };
+    }
+  });
+
+  service.detailsVisible = true;
+  await service.sample();
+  service.setDetailsVisible(false);
+  await service.sample();
+  assert.deepEqual(service.getSnapshot().processes, []);
+
+  service.setDetailsVisible(true);
+  assert.deepEqual(service.getSnapshot().processes.map((process) => process.pid), [321]);
+  assert.equal(service.getSnapshot().processesLoading, true);
+
+  resolveRefresh();
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
+test("performance service preserves cached process details when refresh fails", async () => {
+  let failProcessRefresh = false;
+  const service = new PerformanceService({
+    platform: "darwin",
+    currentUid: 501,
+    osApi: {
+      cpus: () => [{ times: { user: 10, nice: 0, sys: 10, idle: 80, irq: 0 } }],
+      totalmem: () => 100,
+      freemem: () => 40
+    },
+    execFile: async (file) => {
+      if (file !== "/bin/ps") return { stdout: "" };
+      if (failProcessRefresh) throw new Error("ps failed");
+      return { stdout: "321 501 12.0 4.0 4096 /Applications/Safari.app/Contents/MacOS/Safari" };
+    }
+  });
+
+  service.detailsVisible = true;
+  await service.sample();
+  failProcessRefresh = true;
+  await service.sample();
+
+  assert.deepEqual(service.getSnapshot().processes.map((process) => process.pid), [321]);
+  assert.equal(service.getSnapshot().processesLoading, false);
+});
+
+test("a hidden sample finishing late does not cancel a newly opened detail load", async () => {
+  let pressureCall = 0;
+  let resolveHiddenPressure;
+  let resolveVisibleProcesses;
+  const hiddenPressurePending = new Promise((resolve) => { resolveHiddenPressure = resolve; });
+  const visibleProcessesPending = new Promise((resolve) => { resolveVisibleProcesses = resolve; });
+  const service = new PerformanceService({
+    platform: "darwin",
+    currentUid: 501,
+    osApi: {
+      cpus: () => [{ times: { user: 10, nice: 0, sys: 10, idle: 80, irq: 0 } }],
+      totalmem: () => 100,
+      freemem: () => 40
+    },
+    execFile: async (file) => {
+      if (file === "/usr/bin/memory_pressure") {
+        pressureCall += 1;
+        if (pressureCall === 1) await hiddenPressurePending;
+        return { stdout: "" };
+      }
+      if (file === "/bin/ps") {
+        await visibleProcessesPending;
+        return { stdout: "321 501 12.0 4.0 4096 /Applications/Safari.app/Contents/MacOS/Safari" };
+      }
+      return { stdout: "" };
+    }
+  });
+
+  const hiddenSample = service.sample();
+  service.setDetailsVisible(true);
+  assert.equal(service.getSnapshot().processesLoading, true);
+
+  resolveHiddenPressure();
+  await hiddenSample;
+  assert.equal(service.getSnapshot().processesLoading, true);
+
+  resolveVisibleProcesses();
+  await new Promise((resolve) => setImmediate(resolve));
+});
+
 test("Windows process rows calculate CPU deltas and protect WorkIsland", () => {
   const firstJson = JSON.stringify([
     { pid: 321, name: "Player", cpuSeconds: 10, memoryBytes: 1_000, path: "C:\\Player.exe", startedAt: "2026-01-01T00:00:00.000Z" },

--- a/tests/workstation-ipc.test.mjs
+++ b/tests/workstation-ipc.test.mjs
@@ -26,6 +26,11 @@ test("Island preload exposes narrow media and performance contracts", () => {
   assert.match(popover, /formatProcessMemory/);
   assert.match(popover, /performance-process-list/);
   assert.match(popover, /process\.protected/);
+  assert.match(popover, /performance-process-status/);
+  assert.match(popover, /正在读取进程…/);
+  assert.match(popover, /暂时无法读取进程/);
+  assert.match(popover, /没有可显示的进程/);
+  assert.match(popover, /window\.setTimeout\(\(\) => setHovered\(false\), 350\)/);
   const pill = readFileSync(new URL("../src/renderer/island/components/IslandPill.js", import.meta.url), "utf8");
   assert.match(pill, /media-wave-bar/);
   assert.match(pill, /getNotchMediaLayout/);
@@ -49,4 +54,5 @@ test("Island preload exposes narrow media and performance contracts", () => {
   assert.match(css, /\.media-rail\s*\{[^}]*grid-template-rows:\s*auto minmax\(0,\s*1fr\)/s);
   assert.match(css, /\.lyrics-panel\s*\{[^}]*position:\s*absolute[^}]*bottom:/s);
   assert.match(css, /performance-process-list[^}]*overflow-y:\s*auto/s);
+  assert.match(css, /\.performance-process-status\s*\{/);
 });


### PR DESCRIPTION
## Summary

- show explicit process loading and empty/unavailable feedback on first hover
- reuse the latest successful process sample immediately while refreshing on demand
- preserve cached details after refresh failures and protect new loads from stale hidden samples
- increase pointer-transfer grace from 140 ms to 350 ms

## Verification

- npm run check (294 tests passed)
- npm run package:mac
- DMG SHA-256: d7cd3198cd61022fc6de94a5d2b9a777b0f4b3ba9345c8cff2fa4b4481fe63dd

Closes #67