### PR TITLE
fix(zcode): 项目级 Hook 适配 ZCode 3.10+，修复检测始终失败 (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 这里记录 WorkIsland 对用户有意义的版本变化。每个版本的安装包与完整说明以 [GitHub Releases](https://github.com/qianzhu18/workisland/releases) 为准；也可以查看[官网更新日志](https://workisland.yanglaishe.cn/changelog/)。
 
+## [Unreleased]
+
+### Fixed
+
+- 修复 ZCode（≥3.10）始终无法连接的问题：新版 ZCode 只执行项目级 Hook，不再读取用户级 `~/.zcode/cli/config.json`。Hook 现在会同步写入最近活跃会话所在项目（git 根目录）的 `.zcode/config.json`（与项目内 MCP 等既有配置合并、互不覆盖），卸载时一并清理；用户级配置仍保留以兼容旧版 ZCode。
+
 ## [3.2.0] - 2026-09-01
 
 ### Added

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -779,6 +779,7 @@ function createAppCoordinatorClass({
           } catch {
           }
           const options = { statusLineEnabled: this.resolveClaudeStatusLineEnabled(agentId) };
+          if (agentId === "zcode") options.workspacePaths = this.collectRecentSessionCwds();
           log.info(`[AppCoordinator] auto-reinstalling hook for ${agentId}`);
           await manager.install(options);
         } catch (err) {
@@ -1455,6 +1456,7 @@ function createAppCoordinatorClass({
       const manager = this.hookManagers.get(agentId);
       if (!manager) return { success: false, error: `${i18n.k2159120351({ placeholder1: agentId }, "未知的 agent: {placeholder1}")}`, errorCode: "NOT_FOUND" };
       const options = { statusLineEnabled: this.resolveClaudeStatusLineEnabled(agentId) };
+      if (agentId === "zcode") options.workspacePaths = this.collectRecentSessionCwds();
       try {
         await manager.install(options);
         log.info(`[AppCoordinator] installHook(${agentId}) success`);
@@ -1473,6 +1475,22 @@ function createAppCoordinatorClass({
     async uninstallHook(agentId) {
       const manager = this.hookManagers.get(agentId);
       if (manager) await manager.uninstall();
+    }
+    // ZCode ≥3.10 只执行项目级 hooks：取最近活跃会话的项目目录（cwd），去重后交给
+    // ZCodeHookManager 解析 git 根并写入 .zcode/config.json。
+    collectRecentSessionCwds() {
+      const sessions = [...this.state.sessions.values()]
+        .filter((session) => typeof session?.cwd === "string" && path.isAbsolute(session.cwd) && fs.existsSync(session.cwd))
+        .sort((left, right) => Number(right.updatedAt || 0) - Number(left.updatedAt || 0));
+      const seen = new Set();
+      const cwds = [];
+      for (const session of sessions) {
+        if (seen.has(session.cwd)) continue;
+        seen.add(session.cwd);
+        cwds.push(session.cwd);
+        if (cwds.length >= 20) break;
+      }
+      return cwds;
     }
     // 移除所有已安装的 hook 配置，并将 hookToggles 全部置为 false
     async uninstallAllHooks() {

--- a/src/main/hooks-work-agents.cjs
+++ b/src/main/hooks-work-agents.cjs
@@ -80,8 +80,14 @@ async function writeJsonAtomic(filePath, value) {
 
 function isWorkIslandCommand(command, source) {
   if (typeof command !== "string") return false;
-  const hasWorkIslandBinary = command.includes("flux-hooks") || command.includes("hooks-cli/index.");
-  const hasSource = command.includes(`--source '${source}'`) || command.includes(`--source ${source}`);
+  // Windows 写入的命令是反斜杠路径 + 双引号参数（win32 shellQuote），POSIX 是正斜杠 +
+  // 单引号。统一成 / 再匹配，否则 merge/uninstall 在 Windows 上认不出自家 hook，
+  // 重连时重复堆积、卸载时残留。
+  const normalized = command.replaceAll("\\", "/");
+  const hasWorkIslandBinary = normalized.includes("flux-hooks") || normalized.includes("hooks-cli/index.");
+  const hasSource = normalized.includes(`--source '${source}'`)
+    || normalized.includes(`--source "${source}"`)
+    || normalized.includes(`--source ${source}`);
   return hasWorkIslandBinary && hasSource;
 }
 

--- a/src/main/hooks-work-agents.cjs
+++ b/src/main/hooks-work-agents.cjs
@@ -147,6 +147,22 @@ function getZCodeConfigPath(homeDir = os.homedir()) {
   return path.join(homeDir, ".zcode", "cli", "config.json");
 }
 
+function getZCodeWorkspaceConfigPath(workspacePath) {
+  return path.join(workspacePath, ".zcode", "config.json");
+}
+
+// ZCode ≥3.10 只执行项目级 hooks：从会话目录向上找到最近的 .git（worktree 为 .git 文件），
+// 读取其中 zcode.json / .zcode/config.json；用户级 ~/.zcode/cli/config.json 中的 hooks 不再被执行。
+function findZCodeProjectRoot(startPath, pathExists = (candidate) => fs.existsSync(candidate)) {
+  let current = path.resolve(startPath);
+  for (;;) {
+    if (pathExists(path.join(current, ".git"))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
 function getManifestPath(agentId, homeDir = os.homedir()) {
   return path.join(homeDir, ".flux", "hooks", `${agentId}-manifest.json`);
 }
@@ -180,9 +196,9 @@ function isCodeBuddyInstalled(homeDir = os.homedir()) {
 class ZCodeHookManager {
   agentId = "zcode";
 
-  async install() {
-    const configPath = getZCodeConfigPath();
-    const manifestPath = getManifestPath(this.agentId);
+  async install({ homeDir = os.homedir(), workspacePaths = [] } = {}) {
+    const configPath = getZCodeConfigPath(homeDir);
+    const manifestPath = getManifestPath(this.agentId, homeDir);
     const current = await readJson(configPath, { strict: true }) ?? {};
     const previousManifest = await readJson(manifestPath);
     const hadHooksSection = previousManifest?.hadHooksSection ?? Object.hasOwn(current, "hooks");
@@ -193,21 +209,61 @@ class ZCodeHookManager {
     hookConfig.events = mergeHookGroups(hookConfig.events, ZCODE_EVENTS, command, this.agentId);
     current.hooks = hookConfig;
     await writeJsonAtomic(configPath, current);
+    const workspaceConfigs = await this.installWorkspaceHooks(workspacePaths, previousManifest);
     await writeJsonAtomic(manifestPath, {
       configPath,
       events: ZCODE_EVENTS.map(({ event }) => event),
       hadHooksSection,
       previousEnabled,
+      workspaceConfigs,
       installedAt: previousManifest?.installedAt ?? new Date().toISOString(),
       updatedAt: new Date().toISOString()
     });
-    log.info("[ZCodeHookManager] installed hooks to %s", configPath);
+    log.info(
+      "[ZCodeHookManager] installed hooks to %s (%d project configs)",
+      configPath,
+      workspaceConfigs.length
+    );
   }
 
-  async uninstall() {
-    const manifestPath = getManifestPath(this.agentId);
+  // 用户级配置仅为旧版 ZCode 保留；ZCode ≥3.10 需要 `.zcode/config.json` 写在每个项目的 git 根目录。
+  // `.zcode/config.json` 同时承载 ZCode 工作区级 MCP 等配置，因此只合并 hooks 字段、不动其余内容。
+  async installWorkspaceHooks(workspacePaths, previousManifest) {
+    const command = buildHookCommand(this.agentId);
+    const tracked = new Map(
+      (previousManifest?.workspaceConfigs ?? []).map((entry) => [entry.configPath, entry])
+    );
+    const seen = new Set();
+    for (const workspacePath of workspacePaths) {
+      if (typeof workspacePath !== "string" || !path.isAbsolute(workspacePath)) continue;
+      const root = findZCodeProjectRoot(workspacePath) ?? path.resolve(workspacePath);
+      const configPath = getZCodeWorkspaceConfigPath(root);
+      if (seen.has(configPath)) continue;
+      seen.add(configPath);
+      try {
+        const current = await readJson(configPath, { strict: true }) ?? {};
+        const hadHooksSection = tracked.get(configPath)?.hadHooksSection ?? Object.hasOwn(current, "hooks");
+        const hooks = current.hooks && typeof current.hooks === "object" ? { ...current.hooks } : {};
+        hooks.enabled = true;
+        hooks.events = mergeHookGroups(hooks.events, ZCODE_EVENTS, command, this.agentId);
+        current.hooks = hooks;
+        await writeJsonAtomic(configPath, current);
+        tracked.set(configPath, { configPath, hadHooksSection });
+      } catch (error) {
+        log.warn(
+          "[ZCodeHookManager] failed to install project hooks to %s: %s",
+          configPath,
+          error?.message ?? error
+        );
+      }
+    }
+    return [...tracked.values()];
+  }
+
+  async uninstall({ homeDir = os.homedir() } = {}) {
+    const manifestPath = getManifestPath(this.agentId, homeDir);
     const manifest = await readJson(manifestPath);
-    const configPath = manifest?.configPath ?? getZCodeConfigPath();
+    const configPath = manifest?.configPath ?? getZCodeConfigPath(homeDir);
     const current = await readJson(configPath, { strict: true });
     if (current?.hooks && typeof current.hooks === "object") {
       const events = removeHookGroups(current.hooks.events, this.agentId);
@@ -220,26 +276,54 @@ class ZCodeHookManager {
       }
       await writeJsonAtomic(configPath, current);
     }
+    for (const entry of manifest?.workspaceConfigs ?? []) {
+      const projectConfig = await readJson(entry.configPath, { strict: true });
+      if (!projectConfig?.hooks || typeof projectConfig.hooks !== "object") continue;
+      const events = removeHookGroups(projectConfig.hooks.events, this.agentId);
+      if (Object.keys(events).length) projectConfig.hooks.events = events;
+      else delete projectConfig.hooks.events;
+      if (entry.hadHooksSection === false && Object.keys(projectConfig.hooks).length === 0) {
+        delete projectConfig.hooks;
+      }
+      await writeJsonAtomic(entry.configPath, projectConfig);
+    }
     await promises.rm(manifestPath, { force: true });
   }
 
-  async checkHealth() {
+  async checkHealth({ homeDir = os.homedir() } = {}) {
     const issues = [];
-    const configPath = getZCodeConfigPath();
-    const available = isZCodeInstalled();
+    const configPath = getZCodeConfigPath(homeDir);
+    const manifestPath = getManifestPath(this.agentId, homeDir);
+    const available = isZCodeInstalled(homeDir);
     const current = await readJson(configPath);
     if (!current) issues.push("ZCode Hook 尚未连接");
     else {
       if (current.hooks?.enabled !== true) issues.push("ZCode hooks.enabled 未启用");
       issues.push(...verifyHookGroups(current.hooks?.events, ZCODE_EVENTS, buildHookCommand(this.agentId), this.agentId));
     }
+    const manifest = await readJson(manifestPath);
+    const workspaceConfigs = manifest?.workspaceConfigs ?? [];
+    for (const { configPath: projectConfigPath } of workspaceConfigs) {
+      const projectConfig = await readJson(projectConfigPath);
+      if (!projectConfig) {
+        issues.push(`ZCode 项目 Hook 尚未连接：${projectConfigPath}`);
+        continue;
+      }
+      const projectIssues = verifyHookGroups(
+        projectConfig.hooks?.events,
+        ZCODE_EVENTS,
+        buildHookCommand(this.agentId),
+        this.agentId
+      );
+      issues.push(...projectIssues.map((issue) => `${issue}（${projectConfigPath}）`));
+    }
     return {
       agentId: this.agentId,
       available,
       installed: issues.length === 0,
       issues,
-      manifestPath: getManifestPath(this.agentId),
-      configPaths: [configPath]
+      manifestPath,
+      configPaths: [configPath, ...workspaceConfigs.map(({ configPath }) => configPath)]
     };
   }
 }
@@ -346,6 +430,8 @@ module.exports = {
   WorkBuddyHookManager,
   CodeBuddyHookManager,
   getZCodeConfigPath,
+  getZCodeWorkspaceConfigPath,
+  findZCodeProjectRoot,
   getWorkBuddyConfigPath,
   getCodeBuddyConfigPath,
   mergeHookGroups,

--- a/src/shared/agent-catalog.cjs
+++ b/src/shared/agent-catalog.cjs
@@ -16,7 +16,7 @@ const CORE_AGENT_DESCRIPTORS = Object.freeze([
   descriptor("trae", "TraeCode", "#5967E9", "支持 TraeCode v3.5.66+。连接后还需在 TraeCode 设置 → Hooks 中启用“已配置的 Hooks”，并将运行方式设为“本地自动运行”；收到真实任务事件后才显示已验证。", {
     completion: "native", approval: "observe", question: "observe", jump: "workspace"
   }),
-  descriptor("zcode", "ZCode", "#635BFF", "ZCode 原生配置 Hook，支持实时状态、完成提醒和 Island 审批。", {
+  descriptor("zcode", "ZCode", "#635BFF", "ZCode 原生配置 Hook，支持实时状态、完成提醒和 Island 审批。ZCode 3.10+ 仅加载项目级 Hook（写入使用过的项目的 .zcode/config.json），新项目请先在 ZCode 中打开会话后重新连接。", {
     completion: "native", approval: "bridge", question: "nativeOnly", jump: "app"
   }),
   descriptor("workbuddy", "WorkBuddy", "#2F80ED", "WorkBuddy Claude-compatible Hook，支持完整会话生命周期、Island 审批和应用跳转。", {

--- a/tests/zcode-project-hooks.test.mjs
+++ b/tests/zcode-project-hooks.test.mjs
@@ -15,11 +15,13 @@ Module._load = function(request, parent, isMain) {
   return originalLoad.call(this, request, parent, isMain);
 };
 const {
+  ZCODE_EVENTS,
   ZCodeHookManager,
   findZCodeProjectRoot,
   getZCodeConfigPath,
   getZCodeWorkspaceConfigPath,
-  isWorkIslandHookGroup
+  isWorkIslandHookGroup,
+  mergeHookGroups
 } = require("../src/main/hooks-work-agents.cjs");
 Module._load = originalLoad;
 
@@ -51,6 +53,26 @@ test("findZCodeProjectRoot walks up to the nearest .git and returns null without
   const plain = makeTempDir("zcode-plain-");
   fs.mkdirSync(path.join(plain, "deep"), { recursive: true });
   assert.equal(findZCodeProjectRoot(path.join(plain, "deep")), null);
+});
+
+test("hook detection accepts Windows backslash paths and double-quoted --source", () => {
+  // win32 dev 命令（buildDevHooksCliCommand + win32 shellQuote）
+  const windowsDevCommand = 'set "ELECTRON_RUN_AS_NODE=1"&& "C:\\Program Files\\nodejs\\node.exe" "D:\\work\\island\\src\\island\\hooks-cli\\index.cjs" --source "zcode"';
+  // win32 打包态命令（wrapWithInstallCheck + flux-hooks 二进制）
+  const windowsPackagedCommand = 'if not exist "C:\\Apps\\WorkIsland.exe" exit /b 0 & set "ELECTRON_RUN_AS_NODE=1"&& "C:\\Apps\\WorkIsland.exe" "C:\\Apps\\resources\\bin\\flux-hooks" --source "zcode"';
+  assert.equal(isWorkIslandHookGroup({ hooks: [{ type: "command", command: windowsDevCommand }] }, "zcode"), true);
+  assert.equal(isWorkIslandHookGroup({ hooks: [{ type: "command", command: windowsPackagedCommand }] }, "zcode"), true);
+  assert.equal(isWorkIslandHookGroup({ hooks: [{ type: "command", command: "node hooks-cli/index.cjs --source 'zcode'" }] }, "zcode"), true);
+  assert.equal(isWorkIslandHookGroup({ hooks: [{ type: "command", command: 'node hooks-cli/index.cjs --source "other"' }] }, "zcode"), false);
+
+  // 若不识别 Windows 形状的既有组，merge 会重复堆积而不是替换 —— 在任何平台钉住幂等契约。
+  const merged = mergeHookGroups(
+    { Stop: [{ hooks: [{ type: "command", command: windowsDevCommand }] }] },
+    ZCODE_EVENTS.filter(({ event }) => event === "Stop"),
+    windowsDevCommand,
+    "zcode"
+  );
+  assert.equal(merged.Stop.length, 1);
 });
 
 test("install writes project-level hooks while preserving other project config", async () => {

--- a/tests/zcode-project-hooks.test.mjs
+++ b/tests/zcode-project-hooks.test.mjs
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const Module = require("node:module");
+const originalLoad = Module._load;
+Module._load = function(request, parent, isMain) {
+  if (request === "electron") {
+    return { app: { isPackaged: false, getAppPath: () => process.cwd() } };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+const {
+  ZCodeHookManager,
+  findZCodeProjectRoot,
+  getZCodeConfigPath,
+  getZCodeWorkspaceConfigPath,
+  isWorkIslandHookGroup
+} = require("../src/main/hooks-work-agents.cjs");
+Module._load = originalLoad;
+
+function getManifestPath(homeDir) {
+  return path.join(homeDir, ".flux", "hooks", "zcode-manifest.json");
+}
+
+function makeTempDir(prefix) {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf-8"));
+}
+
+function workIslandEventNames(config) {
+  return Object.entries(config.hooks?.events ?? {})
+    .filter(([, groups]) => groups.some((group) => isWorkIslandHookGroup(group, "zcode")))
+    .map(([event]) => event)
+    .sort();
+}
+
+test("findZCodeProjectRoot walks up to the nearest .git and returns null without one", () => {
+  const root = makeTempDir("zcode-root-");
+  fs.mkdirSync(path.join(root, ".git"));
+  const nested = path.join(root, "a", "b");
+  fs.mkdirSync(nested, { recursive: true });
+  assert.equal(findZCodeProjectRoot(nested), root);
+  const plain = makeTempDir("zcode-plain-");
+  fs.mkdirSync(path.join(plain, "deep"), { recursive: true });
+  assert.equal(findZCodeProjectRoot(path.join(plain, "deep")), null);
+});
+
+test("install writes project-level hooks while preserving other project config", async () => {
+  const home = makeTempDir("zcode-home-");
+  const project = makeTempDir("zcode-proj-");
+  fs.mkdirSync(path.join(project, ".git"));
+  fs.mkdirSync(path.join(project, "src"), { recursive: true });
+  const projectConfigPath = getZCodeWorkspaceConfigPath(project);
+  fs.mkdirSync(path.dirname(projectConfigPath), { recursive: true });
+  fs.writeFileSync(projectConfigPath, JSON.stringify({ mcp: { servers: { demo: {} } } }), "utf-8");
+
+  const manager = new ZCodeHookManager();
+  await manager.install({ homeDir: home, workspacePaths: [path.join(project, "src")] });
+
+  const projectConfig = readJson(projectConfigPath);
+  assert.deepEqual(Object.keys(projectConfig).sort(), ["hooks", "mcp"]);
+  assert.deepEqual(projectConfig.mcp, { servers: { demo: {} } });
+  assert.equal(projectConfig.hooks.enabled, true);
+  assert.deepEqual(
+    workIslandEventNames(projectConfig),
+    ["PermissionRequest", "PostToolUse", "PostToolUseFailure", "PreToolUse", "SessionStart", "Stop", "UserPromptSubmit"]
+  );
+
+  const manifest = readJson(getManifestPath(home));
+  assert.deepEqual(manifest.workspaceConfigs, [{ configPath: projectConfigPath, hadHooksSection: false }]);
+  assert.ok(fs.existsSync(getZCodeConfigPath(home)), "user-level config is still written for older ZCode");
+});
+
+test("checkHealth reports missing project config and uninstall cleans both scopes", async () => {
+  const home = makeTempDir("zcode-home-");
+  const project = makeTempDir("zcode-proj-");
+  fs.mkdirSync(path.join(project, ".git"));
+
+  const manager = new ZCodeHookManager();
+  await manager.install({ homeDir: home, workspacePaths: [project] });
+
+  const projectConfigPath = getZCodeWorkspaceConfigPath(project);
+  fs.rmSync(projectConfigPath);
+  const health = await manager.checkHealth({ homeDir: home });
+  assert.equal(health.installed, false);
+  assert.ok(health.issues.some((issue) => issue.includes(projectConfigPath)));
+  assert.ok(health.configPaths.includes(projectConfigPath));
+
+  await manager.uninstall({ homeDir: home });
+  assert.equal(fs.existsSync(projectConfigPath), false, "deleted project config must not be recreated by uninstall");
+  const userConfig = readJson(getZCodeConfigPath(home));
+  assert.equal(userConfig.hooks, undefined);
+  assert.equal(fs.existsSync(getManifestPath(home)), false);
+});
+
+test("install keeps a healthy project config idempotent and deduplicates workspaces", async () => {
+  const home = makeTempDir("zcode-home-");
+  const project = makeTempDir("zcode-proj-");
+  fs.mkdirSync(path.join(project, ".git"));
+  fs.mkdirSync(path.join(project, "src"), { recursive: true });
+
+  const manager = new ZCodeHookManager();
+  await manager.install({ homeDir: home, workspacePaths: [project, path.join(project, "src")] });
+  const first = readJson(getZCodeWorkspaceConfigPath(project));
+  await manager.install({ homeDir: home, workspacePaths: [project] });
+  const second = readJson(getZCodeWorkspaceConfigPath(project));
+  assert.deepEqual(second, first);
+  const manifest = readJson(getManifestPath(home));
+  assert.equal(manifest.workspaceConfigs.length, 1);
+  const health = await manager.checkHealth({ homeDir: home });
+  assert.equal(health.installed, true);
+});


### PR DESCRIPTION
Closes #80

## 问题

ZCode 3.10+ 的 Hook 运行时只加载**项目级**配置：从会话工作目录向上查到最近的 `.git` 根，读取其中的 `zcode.json` / `.zcode/config.json`；用户级 `~/.zcode/cli/config.json` 中的 `hooks` 不再被执行（作为对比，MCP 配置仍保留用户级读取）。而 WorkIsland 3.2.0-rc.1 只把 Hook 写入用户级文件，导致 ZCode 从未触发 `flux-hooks`，检测始终失败（日志中 `flux-hooks` 执行次数为 0）。

## 修复方案

保留用户级写入（兼容旧版 ZCode，对新版无害），并新增项目级安装通道：

- **`ZCodeHookManager.install()`** 接受 `workspacePaths`，对每个工作区向上解析 git 根（worktree 的 `.git` 文件也识别），把 Hook 写入 `<git-root>/.zcode/config.json`。该文件同时承载 ZCode 工作区级 MCP 等配置，因此只合并 `hooks` 字段、不改动其余内容。
- **工作区来源**：`app-coordinator` 的 `installHook()` 与启动时的自动修复（`autoReInstallHooks()`）会把最近活跃会话的 `cwd`（去重、最多 20 个）作为 `workspacePaths` 传入。
- **manifest 跟踪**：所有写入过的项目配置记录在 `~/.flux/hooks/zcode-manifest.json` 的 `workspaceConfigs` 中（含 `hadHooksSection`），`uninstall()` 一并清理、`checkHealth()` 逐一校验（缺失或命令过期会给出带路径的 issue）。
- **文案**：ZCode 的设置页描述改为说明项目级 Hook 行为——新项目需先在 ZCode 中打开会话后重新连接。

### 已知边界（与 #80 讨论一致）

- ZCode 的新项目存在先有鸡还是先有蛋的问题：Hook 未写入前 ZCode 不会发事件，因此新项目需要用户在 ZCode 中打开过一次会话、再点一次「连接」。设置页文案已说明。
- ZCode 对项目级 Hook 还有信任门控（`workspace_hooks_policy_requires_pretrust`），首次运行时可能需要用户在 ZCode 侧确认。

## 测试

- 新增 `tests/zcode-project-hooks.test.mjs`（4 个用例）：git 根解析、项目级写入且不破坏既有 MCP 配置、health 检出缺失的项目配置 + 双层卸载清理、重复安装幂等且工作区去重。
- `npm run check` 全绿（renderer 构建 + source contract + 376 个单测）。
- 真机验证建议：合并后在本机连接 ZCode，确认 `~/<某个已用 ZCode 的项目>/.zcode/config.json` 出现 Hook，且 ZCode 日志出现 `flux-hooks` 执行记录。
