### PR TITLE
fix(tests): 修复 Windows CI 上 3 个既有单测失败

### DIFF
--- a/tests/template-github.test.mjs
+++ b/tests/template-github.test.mjs
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { createRequire } from "node:module";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 
 const require = createRequire(import.meta.url);
 const { sha256Buffer } = require("../src/shared/template-manifest.cjs");
@@ -164,7 +164,7 @@ test("publishTemplate requires --confirm, gh auth, and refuses duplicates", asyn
     assert.equal(published.catalogEntry.id, "author.remote");
     assert.equal(
       published.catalogEntry.zipUrl,
-      `https://github.com/example/repo/releases/download/templates-author.remote-v1.0.0/${keepZip.split("/").at(-1)}`
+      `https://github.com/example/repo/releases/download/templates-author.remote-v1.0.0/${encodeURIComponent(basename(keepZip))}`
     );
     assert.match(published.catalogEntry.zipSha256, /^[0-9a-f]{64}$/);
     assert.ok(published.nextStep.includes("catalog.json"));

--- a/tests/workisland-cli.test.mjs
+++ b/tests/workisland-cli.test.mjs
@@ -109,7 +109,10 @@ test("readManual prefers WORKISLAND_MANUAL_PATH and falls back to embedded text"
 });
 
 test("sendBridgeCommand completes the hello → command → response round trip", async () => {
-  const socketPath = join(tmpdir(), `wi-cli-test-${process.pid}.sock`);
+  // Windows 无法在任意文件系统路径上监听 Unix socket，改用命名管道命名空间。
+  const socketPath = process.platform === "win32"
+    ? `\\\\.\\pipe\\wi-cli-test-${process.pid}`
+    : join(tmpdir(), `wi-cli-test-${process.pid}.sock`);
   const server = net.createServer((socket) => {
     socket.write(`${JSON.stringify({ type: "hello", hello: { protocolVersion: 1, serverLabel: "test" } })}\n`);
     socket.on("data", (chunk) => {
@@ -131,12 +134,14 @@ test("sendBridgeCommand completes the hello → command → response round trip"
     assert.deepEqual(response, { type: "result", data: { echo: "getAppearance" } });
   } finally {
     server.close();
-    rmSync(socketPath, { force: true });
+    if (process.platform !== "win32") rmSync(socketPath, { force: true });
   }
 });
 
 test("sendBridgeCommand times out when the bridge never answers", async () => {
-  const socketPath = join(tmpdir(), `wi-cli-silent-${process.pid}.sock`);
+  const socketPath = process.platform === "win32"
+    ? `\\\\.\\pipe\\wi-cli-silent-${process.pid}`
+    : join(tmpdir(), `wi-cli-silent-${process.pid}.sock`);
   // Greets but never answers commands.
   const server = net.createServer((socket) => {
     socket.write(`${JSON.stringify({ type: "hello", hello: { protocolVersion: 1 } })}\n`);
@@ -149,7 +154,7 @@ test("sendBridgeCommand times out when the bridge never answers", async () => {
     );
   } finally {
     server.close();
-    rmSync(socketPath, { force: true });
+    if (process.platform !== "win32") rmSync(socketPath, { force: true });
   }
 });
 


### PR DESCRIPTION
## 问题

main 分支的 windows-x64 检查目前固定红（如 [#79 合并后的 check 运行](https://github.com/qianzhu18/workisland/actions/runs/33525727883)），失败 3 项，全部为测试侧平台假设，与产品代码无关：

1. `sendBridgeCommand completes the hello → command → response round trip` 与 `sendBridgeCommand times out when the bridge never answers`：Windows 无法在 TEMP 下的任意文件路径监听 Unix socket（`listen EACCES`）。改为 win32 上使用 `\\.\pipe\` 命名空间，并为管道路径跳过 `rmSync`。
2. `publishTemplate requires --confirm, gh auth, and refuses duplicates`：测试用 ``keepZip.split("/").at(-1)`` 拼期望 URL，Windows 反斜杠路径整段被拼进 URL。改为与生产实现一致的 `encodeURIComponent(path.basename(...))`。

## 验证

- 本地 macOS `npm run test:unit` 372/372 通过
- 这 3 个用例在 Windows CI 上的失败根因均已消除，预期 windows-x64 恢复绿色

## 动机

让 windows-x64 检查恢复可信，为 #81（项目级 Hook 修复）的全绿合并扫清既有噪音。