### PR TITLE
feat(settings): in-app complaint box with prefilled GitHub issue link

### DIFF
--- a/src/renderer/settings-app.css
+++ b/src/renderer/settings-app.css
@@ -112,3 +112,12 @@ input[type=range] { flex:1; accent-color:var(--accent); }
 .toast.error { background:rgba(190,35,35,.94); }
 @media (max-width:680px) { .window { grid-template-columns:170px 1fr; } .content { padding:30px 20px 48px; } .setting-row { align-items:flex-start; flex-direction:column; gap:10px; } .feature-settings-card > .setting-row { flex-direction:row; align-items:center; } .feature-settings-actions { gap:7px; } .feature-settings-disclosure.button { min-width:70px; padding-inline:9px; } .feature-settings-detail .setting-row { flex-direction:column; align-items:flex-start; } .inline-controls { width:100%; } .inline-controls select { flex:1; min-width:0; } .text-input { width:100%; } .saved-command-control { width:100%; } .saved-command-list { justify-content:flex-start; } .terminal-command-editor { width:100%; grid-template-columns:1fr; } .terminal-directory-control { width:100%; justify-content:flex-start; } .mcp-example-list { grid-template-columns:1fr; } }
 @media (prefers-color-scheme:dark) { :root { --text:#f5f5f7; --muted:#a1a1a6; --line:rgba(255,255,255,.12); --sidebar:rgba(31,31,34,.88); --content:rgba(38,38,41,.94); --card:rgba(255,255,255,.055); } select,.button,.text-input { background:rgba(255,255,255,.075); } }
+
+.complaint-overlay { position: fixed; inset: 0; z-index: 400; display: flex; align-items: center; justify-content: center; background: rgba(0,0,0,.42); }
+.complaint-card { width: min(520px, calc(100vw - 48px)); display: grid; gap: 12px; padding: 20px; background: var(--content); border: 1px solid var(--line); border-radius: 14px; box-shadow: 0 18px 56px rgba(0,0,0,.45); }
+.complaint-title { margin: 0; font-size: 16px; color: var(--text); }
+.complaint-hint { margin: 0; font-size: 12px; color: var(--muted); line-height: 1.6; }
+.complaint-input { width: 100%; box-sizing: border-box; resize: vertical; min-height: 120px; padding: 10px 12px; border: 1px solid var(--line); border-radius: 10px; background: var(--card); color: var(--text); font: inherit; }
+.complaint-status { margin: 0; min-height: 1em; font-size: 12px; color: var(--muted); }
+.complaint-actions { display: flex; gap: 8px; justify-content: flex-end; }
+.setting-actions-group { display: flex; gap: 8px; }

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -6,6 +6,9 @@ const DEFAULT_PET_SPRITE = "codex:qianxue";
 const FEEDBACK_URL = "https://workisland.yanglaishe.cn/#feedback";
 const COMMUNITY_URL = "https://workisland.yanglaishe.cn/#community";
 const USER_GUIDE_URL = "https://workisland.yanglaishe.cn/guide/";
+const GITHUB_ISSUE_NEW_URL = "https://github.com/qianzhu18/workisland/issues/new";
+const GITHUB_ISSUE_TEMPLATE = "bug_report.yml";
+const COMPLAINT_BODY_LIMIT = 1500;
 const WORKISLAND_ICON_URL = "../assets/workisland-icon.png";
 const DEFAULT_AGENT_ICON_URL = "../assets/brands/agent.svg";
 const AGENT_STATUS_REFRESH_INTERVAL_MS = 3000;
@@ -499,6 +502,83 @@ function doctorSummaryLine(summary) {
   return parts.join(" · ");
 }
 
+function buildComplaintDiagnostics(appVersion) {
+  const platform = navigator.userAgentData?.platform || navigator.platform || "unknown";
+  const lines = [
+    "---",
+    "由 WorkIsland 设置页「一键吐槽」自动生成",
+    `WorkIsland: ${appVersion || "unknown"} (${platform})`
+  ];
+  try {
+    const agents = [...state.statuses.values()].map(report => `${report.agentId}:${report?.diagnosis?.status || "unknown"}`);
+    if (agents.length) lines.push(`Agents: ${agents.join(", ")}`);
+    const doctor = doctorSummaryLine(state.doctorSummary);
+    if (doctor) lines.push(`Doctor: ${doctor}`);
+  } catch { /* 诊断摘要失败不阻塞提交 */ }
+  return lines.join("\n");
+}
+
+function openComplaintBox() {
+  if (document.querySelector(".complaint-overlay")) return;
+  const overlay = el("div", "complaint-overlay");
+  const card = el("div", "complaint-card");
+  card.append(
+    el("h2", "complaint-title", "一键吐槽"),
+    el("p", "complaint-hint", "像跟朋友吐槽一样写就行：哪里不对、想要什么，一句话也可以。截图在打开的 GitHub 页面直接粘贴即可；版本与 Agent 状态会自动附带，不用你填。"),
+    el("p", "complaint-hint", "内容只用于反馈，不会自动上传任何会话数据。")
+  );
+  const textarea = document.createElement("textarea");
+  textarea.className = "complaint-input";
+  textarea.rows = 6;
+  textarea.placeholder = "例如：点了右上角的终端图标没反应，还弹出了别的东西。";
+  const statusLine = el("p", "complaint-status", "");
+  const sendButton = button("送去 GitHub", async () => {
+    const text = textarea.value.trim();
+    if (!text) {
+      statusLine.textContent = "先写一句吐槽再发送。";
+      return;
+    }
+    sendButton.disabled = true;
+    try {
+      const appVersion = await api.getAppVersion().catch(() => "");
+      const fullBody = `${text}\n${buildComplaintDiagnostics(appVersion)}`;
+      try { await navigator.clipboard.writeText(fullBody); } catch { /* 剪贴板失败不影响打开 */ }
+      const params = new URLSearchParams({
+        template: GITHUB_ISSUE_TEMPLATE,
+        title: text.split("\n")[0].slice(0, 60) || "用户反馈",
+        version: `${appVersion || "unknown"} (${navigator.userAgentData?.platform || navigator.platform || "unknown"})`,
+        area: "Other",
+        reproduction: text.slice(0, COMPLAINT_BODY_LIMIT),
+        expected: "按用户描述正常工作。",
+        actual: fullBody.slice(0, COMPLAINT_BODY_LIMIT + 600),
+        frequency: "未填写（应用内一键吐槽提交）"
+      });
+      api.openExternal(`${GITHUB_ISSUE_NEW_URL}?${params}`);
+      statusLine.textContent = "已在浏览器打开预填好的 issue，点一次 Submit 即可；内容较长时请把剪贴板里的原文粘贴进正文。";
+      setTimeout(() => overlay.remove(), 8000);
+    } finally {
+      sendButton.disabled = false;
+    }
+  }, "primary");
+  const copyButton = button("复制诊断信息", async () => {
+    const appVersion = await api.getAppVersion().catch(() => "");
+    try {
+      await navigator.clipboard.writeText(buildComplaintDiagnostics(appVersion));
+      statusLine.textContent = "诊断信息已复制，可直接粘贴给开发者。";
+    } catch {
+      statusLine.textContent = "复制失败，请手动截图本页 Agent 状态。";
+    }
+  });
+  const cancelButton = button("取消", () => overlay.remove());
+  const actions = el("div", "complaint-actions");
+  actions.append(copyButton, cancelButton, sendButton);
+  card.append(textarea, statusLine, actions);
+  overlay.append(card);
+  overlay.addEventListener("keydown", event => { if (event.key === "Escape") overlay.remove(); });
+  document.body.append(overlay);
+  textarea.focus();
+}
+
 async function refreshAgents() {
   const reports = await api.getHookStatus();
   state.statuses = new Map((reports || []).map(report => [report.agentId, report]));
@@ -969,7 +1049,7 @@ function aboutPage() {
   const support = section("帮助与社区", "操作手册、反馈渠道与社区信息由 WorkIsland 官网统一维护，无需重新安装即可更新。");
   support.append(
     row("产品手册", "查看安装、首次任务、状态理解、隐私与反馈说明。", button("打开手册", () => api.openExternal(USER_GUIDE_URL), "primary")),
-    row("提交反馈", "报告问题、提出建议或补充复现信息。", button("打开反馈入口", () => api.openExternal(FEEDBACK_URL), "primary")),
+    row("提交反馈", "像日常吐槽一样一句话反馈，会自动附带版本与 Agent 状态。", (() => { const group = el("div", "setting-actions-group"); group.append(button("一键吐槽", () => openComplaintBox(), "primary"), button("打开反馈入口", () => api.openExternal(FEEDBACK_URL))); return group; })()),
     row("加入社区", "查看最新 WorkIsland 微信社区二维码。", button("查看群码", () => api.openExternal(COMMUNITY_URL)))
   );
   const updates = section("更新", "仅请求官方版本信息与官方安装包，不上传会话内容或使用数据。");


### PR DESCRIPTION
验收标准:设置页「帮助与社区 → 提交反馈 → 一键吐槽」弹出应用内浮层,输入一句话后浏览器打开的 GitHub issue(bug_report.yml)标题/版本/正文全部预填完成,用户只需点一次 Submit;「复制诊断信息」可把版本与 Agent 状态摘要复制到剪贴板。

- 应用内吐槽浮层:一个文本框,提交后自动拼接 `issues/new?template=bug_report.yml&…` 预填链接,正文自动附带 WorkIsland 版本、平台、已接入 Agent 状态与 Doctor 摘要(复用 Agent Doctor 数据),用户不需要填任何技术字段。
- 纯渲染层实现,零新增 IPC 通道(契约守卫仍为 161,npm run check 457 测试全绿)。
- 超长内容自动截断,全文同时复制到剪贴板兜底 GitHub URL 长度限制;截图走 GitHub issue 编辑器原生粘贴,浮层文案已引导。
- 原有「打开反馈入口」「加入社区」入口保留不动。

Ref: 公测收口-反馈通道(应用内吐槽 → GitHub Issues,不接邮件、不搭服务)