### PR TITLE
feat(island): first-run empty state shows agent setup guide instead of blank list

### DIFF
--- a/scripts/test-source.mjs
+++ b/scripts/test-source.mjs
@@ -58,7 +58,8 @@ const {
 // usage insights and the appearance/template APIs expand the rest of the
 // public bridge contract. Agent Doctor (B-1 PR2) adds settings:repair-hook /
 // repair-all-hooks / get-doctor-audit (155 -> 158 via MCP, +3 here).
-assert.equal(Object.keys(IPC).length, 161, "IPC contract changed; review both main and preload consumers");
+// Island first-run empty state adds island:get-agent-setup-status (161 -> 162, 2026-09).
+assert.equal(Object.keys(IPC).length, 162, "IPC contract changed; review both main and preload consumers");
 assert.equal(listProductCapabilities({ platform: "darwin" }).length, 15, "MCP product catalog must stay explicit");
 assert.equal(diagnoseMcpSubject("performance-details-not-visible", { settings: {} }).subject, "performance-details-not-visible");
 assert.equal(IPC.APP_UPDATE_DOWNLOAD, "app:update-download");

--- a/src/main/ipc-services.cjs
+++ b/src/main/ipc-services.cjs
@@ -229,6 +229,9 @@ function createIpcServices({ performHapticFeedback, isAllowedExternalUrl, readPa
     electron.ipcMain.handle(IPC.SETTINGS_GET_HOOK_STATUS, () => {
       return coordinator.getHookStatus();
     });
+    electron.ipcMain.handle(IPC.ISLAND_GET_AGENT_SETUP_STATUS, () => {
+      return coordinator.getHookStatus();
+    });
     electron.ipcMain.handle(IPC.PLUGIN_AGENT_META, () => {
       return listPluginAgentMeta();
     });

--- a/src/preload/island.js
+++ b/src/preload/island.js
@@ -234,6 +234,9 @@ electron.contextBridge.exposeInMainWorld("islandBridge", {
   getSettings() {
     return electron.ipcRenderer.invoke(ipc.IPC.SETTINGS_GET);
   },
+  getAgentSetupStatus() {
+    return electron.ipcRenderer.invoke(ipc.IPC.ISLAND_GET_AGENT_SETUP_STATUS);
+  },
   setSettings(partial) {
     return electron.ipcRenderer.invoke(ipc.IPC.SETTINGS_SET, partial);
   },

--- a/src/renderer/assets/welcome-view.js
+++ b/src/renderer/assets/welcome-view.js
@@ -38,6 +38,13 @@ function WelcomeApp() {
         isWindows
           ? "在 Windows 桌面顶部查看 Work Agent 工作状态、处理需要确认的事项，并在任务完成时获得系统声音提醒。"
           : "在 Mac 顶部查看 Work Agent 工作状态、处理需要确认的事项，并在任务完成时获得声音与触觉提醒。"
+      ),
+      React.createElement(
+        "div",
+        { className: "welcome-steps" },
+        React.createElement("span", null, "① 安装一个 AI 编码 Agent"),
+        React.createElement("span", null, "② 设置 → Agents 一键接入"),
+        React.createElement("span", null, "③ 跑一条命令，岛亮起来")
       )
     ),
     React.createElement(

--- a/src/renderer/assets/welcome.css
+++ b/src/renderer/assets/welcome.css
@@ -149,3 +149,6 @@ h1 {
   font-size: 11px;
   text-align: center;
 }
+
+.welcome-steps { display: flex; gap: 14px; margin-top: 18px; }
+.welcome-steps span { font-size: 12px; color: rgba(255, 255, 255, 0.78); }

--- a/src/renderer/island/app.css
+++ b/src/renderer/island/app.css
@@ -1052,3 +1052,46 @@ body {
   .media-artwork-stage:hover .media-artwork { transform: none; }
   .media-artwork-stage:hover .media-artwork-sheen { opacity: 0; }
 }
+
+.session-empty-onboarding {
+  padding: 24px 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  text-align: center;
+}
+
+.session-empty-onboarding-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+}
+
+.session-empty-onboarding-steps p {
+  margin: 2px 0;
+  font-size: 11px;
+  color: rgba(255, 255, 255, 0.68);
+  line-height: 1.6;
+}
+
+.session-empty-onboarding-button {
+  margin-top: 4px;
+  padding: 5px 14px;
+  font-size: 11px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.session-empty-onboarding-button:hover {
+  background: rgba(255, 255, 255, 0.22);
+}
+
+.session-empty-onboarding-hint {
+  margin: 0;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.45);
+}

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -196,6 +196,23 @@ function IslandApp() {
   const highLoadSinceRef = reactExports.useRef(0);
   const performanceAlertTimerRef = reactExports.useRef(null);
   const [tokenBurnTotal, setTokenBurnTotal] = reactExports.useState(0);
+  const [agentSetupReports, setAgentSetupReports] = reactExports.useState(null);
+  reactExports.useEffect(() => {
+    let disposed = false;
+    const refreshAgentSetup = () => {
+      window.islandBridge?.getAgentSetupStatus?.().then((reports) => {
+        if (!disposed) setAgentSetupReports(Array.isArray(reports) ? reports : []);
+      }).catch(() => { /* 状态拉取失败时保持未知,不误显引导 */ });
+    };
+    refreshAgentSetup();
+    const setupTimer = setInterval(refreshAgentSetup, 30000);
+    window.addEventListener("focus", refreshAgentSetup);
+    return () => {
+      disposed = true;
+      clearInterval(setupTimer);
+      window.removeEventListener("focus", refreshAgentSetup);
+    };
+  }, []);
   const [autoCollapseDurationMs, setAutoCollapseDurationMs] = reactExports.useState(
     DEFAULT_SETTINGS.completionPopupDurationSec * 1e3
   );
@@ -932,6 +949,7 @@ function IslandApp() {
           IslandPanel,
           {
             sessions,
+            hasConnectedAgent: agentSetupReports ? agentSetupReports.some((report) => report?.diagnosis?.status === "ok") : null,
             surface,
             notchHeight: notchH,
             panelMaxHeightPx,

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -1410,8 +1410,21 @@ function renderActionableCard(props) {
     );
   return null;
 }
+function SessionEmptyOnboarding({ onOpenSettings }) {
+  return /* @__PURE__ */ React.createElement("div", { className: "session-empty-onboarding" },
+    /* @__PURE__ */ React.createElement("div", { className: "session-empty-onboarding-title" }, "还没有接入任何 Agent"),
+    /* @__PURE__ */ React.createElement("div", { className: "session-empty-onboarding-steps" },
+      React.createElement("p", null, "① 安装一个支持的 AI 编码 Agent（Claude Code、Codex CLI 等）"),
+      React.createElement("p", null, "② 打开设置 → Agents，一键接入（自动写入 Hook）"),
+      React.createElement("p", null, "③ 跑一条命令，这里就会亮起它的状态")
+    ),
+    React.createElement("button", { className: "session-empty-onboarding-button", type: "button", onClick: () => onOpenSettings?.("agents") }, "打开设置接入"),
+    React.createElement("p", { className: "session-empty-onboarding-hint" }, "首次接入约 30 秒，全程本地完成")
+  );
+}
 function IslandPanel({
   sessions,
+  hasConnectedAgent = null,
   surface,
   notchHeight,
   panelMaxHeightPx,
@@ -1550,7 +1563,7 @@ function IslandPanel({
       onUpdateInstall,
       onOpenRelease
     }
-  ), /* @__PURE__ */ React.createElement("div", { className: "panel-divider" }), activeModule === "shelf" && /* @__PURE__ */ React.createElement(ShelfPanel), activeModule === "clipboard" && /* @__PURE__ */ React.createElement(ClipboardPanel), activeModule === "terminal" && /* @__PURE__ */ React.createElement(TerminalPanel, { savedCommands: terminalSavedCommands, onOpenSettings: () => onOpenSettings("general") }), activeModule === "usage" && /* @__PURE__ */ React.createElement(UsagePanel), /* @__PURE__ */ React.createElement("div", { className: `workspace-content${mediaEnabled && mediaState?.active && mediaState?.title ? " has-media" : ""}${activeModule === "agent" ? "" : " is-hidden"}` }, mediaEnabled && mediaState?.active && mediaState?.title && /* @__PURE__ */ React.createElement(MediaCard, { media: mediaState, lyrics: lyricsState }), /* @__PURE__ */ React.createElement("div", { className: "workspace-agent-pane" }, /* @__PURE__ */ React.createElement("div", { className: "session-list", ref: sessionListRef }, visibleSessions.length === 0 ? /* @__PURE__ */ React.createElement("div", { className: "session-list-empty" }, /* @__PURE__ */ React.createElement(
+  ), /* @__PURE__ */ React.createElement("div", { className: "panel-divider" }), activeModule === "shelf" && /* @__PURE__ */ React.createElement(ShelfPanel), activeModule === "clipboard" && /* @__PURE__ */ React.createElement(ClipboardPanel), activeModule === "terminal" && /* @__PURE__ */ React.createElement(TerminalPanel, { savedCommands: terminalSavedCommands, onOpenSettings: () => onOpenSettings("general") }), activeModule === "usage" && /* @__PURE__ */ React.createElement(UsagePanel), /* @__PURE__ */ React.createElement("div", { className: `workspace-content${mediaEnabled && mediaState?.active && mediaState?.title ? " has-media" : ""}${activeModule === "agent" ? "" : " is-hidden"}` }, mediaEnabled && mediaState?.active && mediaState?.title && /* @__PURE__ */ React.createElement(MediaCard, { media: mediaState, lyrics: lyricsState }), /* @__PURE__ */ React.createElement("div", { className: "workspace-agent-pane" }, /* @__PURE__ */ React.createElement("div", { className: "session-list", ref: sessionListRef }, visibleSessions.length === 0 ? (hasConnectedAgent === false ? /* @__PURE__ */ React.createElement(SessionEmptyOnboarding, { onOpenSettings }) : /* @__PURE__ */ React.createElement("div", { className: "session-list-empty" }, /* @__PURE__ */ React.createElement(
     "img",
     {
       className: "session-list-empty-icon",
@@ -1558,7 +1571,7 @@ function IslandPanel({
       alt: "",
       draggable: false
     }
-  ), /* @__PURE__ */ React.createElement("span", { className: "session-list-empty-text" }, i18n.k1005597952({}, "暂无会话"))) : visibleSessions.map((session) => {
+  ), /* @__PURE__ */ React.createElement("span", { className: "session-list-empty-text" }, i18n.k1005597952({}, "暂无会话")))) : visibleSessions.map((session) => {
     const canFollowUp = session.phase === "completed" && canContinueSessionViaTerminalPrompt(session);
     const isFollowUpOpen = followUpSessionId === session.id && canFollowUp;
     const openFollowUp = canFollowUp ? () => setFollowUpSessionId(session.id) : void 0;

--- a/src/shared/ipc.cjs
+++ b/src/shared/ipc.cjs
@@ -32,6 +32,7 @@ const IPC = Object.freeze({
   ISLAND_SWITCH_SESSION: "island:switch-session",
   ISLAND_CONFIRM_SESSION: "island:confirm-session",
   ISLAND_UNDO_SETTINGS_CHANGES: "island:undo-settings-changes",
+  ISLAND_GET_AGENT_SETUP_STATUS: "island:get-agent-setup-status",
 
   MEDIA_GET_STATE: "media:get-state",
   MEDIA_STATE_UPDATE: "media:state-update",


### PR DESCRIPTION
验收标准:未接入任何 Agent 的用户展开岛时,会话列表显示三步接入指引卡(安装 Agent → 设置一键接入 → 跑命令看岛亮)和「打开设置接入」按钮,而不是只有「暂无会话」;已接入但无会话时保持原「暂无会话」;状态拉取失败时保持原文案不误显引导。

- 新增 IPC `island:get-agent-setup-status`(161 → 162,契约守卫已同步),复用主进程 coordinator.getHookStatus(),岛渲染层每 30s + focus 时刷新。
- 岛空态按 `hasConnectedAgent` 三态渲染:未接入 → 引导卡;已接入 → 原「暂无会话」;未知(拉取失败)→ 原文案兜底。
- 欢迎页 hero 下补三步接入提示,与岛内指引文案一致,衔接主进程既有 hasCompletedOnboarding/ISLAND_ONBOARDING_EXPAND 流程。
- npm run check 全绿(静态检查 157 文件 + 契约测试 + 457 单测)。

Ref: B-14(首跑引导 Onboarding)+ 任务表「首跑引导与空状态 v1(无动画版先行)」