### PR TITLE
fix(island): gate toolbox icon drag behind pointer threshold to restore stable clicks

### DIFF
--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -333,6 +333,28 @@ function AgentUsageRow({
     window.islandBridge?.deleteSessions(visibleSessionIds);
   };
   const dragSourceIdRef = reactExports.useRef(null);
+  // 工具图标默认 draggable=false：常开 HTML5 拖拽会把轻微抖动误判为拖拽启动，
+  // 吞掉点击并残留拖拽态（issue #69 的「点不动 / 误触发」）。按下后位移超过
+  // 阈值才启用 draggable，下一次 pointermove 由浏览器接管拖拽。
+  const [dragEnabledId, setDragEnabledId] = reactExports.useState(null);
+  const handleUtilityPointerDown = (id, event) => {
+    if (event.button !== 0) return;
+    const startX = event.clientX;
+    const startY = event.clientY;
+    const cleanup = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+    };
+    const onMove = (moveEvent) => {
+      if (Math.hypot(moveEvent.clientX - startX, moveEvent.clientY - startY) > 6) {
+        setDragEnabledId(id);
+        cleanup();
+      }
+    };
+    const onUp = () => cleanup();
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
   const utilityModuleDefs = [
     ["shelf", "文件架", ShelfToolIcon],
     ["clipboard", "剪贴板", ClipboardToolIcon],
@@ -357,8 +379,20 @@ function AgentUsageRow({
     title: label,
     "aria-label": label,
     "aria-pressed": activeToolboxModule === id,
-    draggable: true,
-    onDragStart: () => handleUtilityDragStart(id),
+    draggable: dragEnabledId === id,
+    onPointerDown: (event) => handleUtilityPointerDown(id, event),
+    onDragStart: (event) => {
+      // Chromium：dragstart 未写入 dataTransfer 时拖拽可能在部分平台立即取消（issue #69「拖不动」）
+      try {
+        event.dataTransfer.setData("text/plain", id);
+        event.dataTransfer.effectAllowed = "move";
+      } catch { /* dataTransfer 不可用时放弃本次拖拽 */ }
+      handleUtilityDragStart(id);
+    },
+    onDragEnd: () => {
+      setDragEnabledId(null);
+      dragSourceIdRef.current = null;
+    },
     onDragOver: (event) => event.preventDefault(),
     onDrop: (event) => { event.preventDefault(); handleUtilityDrop(id); },
     onClick: () => onToolboxModuleChange?.(activeToolboxModule === id ? "agent" : id)


### PR DESCRIPTION
验收标准:顶部工具条图标（文件架/剪贴板/终端/用量）单击稳定触发对应模块,按住移动 6px 以上才进入拖拽重排,拖拽取消后不再派发误点击;需实机回归确认 issue #69 的三个症状消失。

针对 #69 的三个症状各对应一处根因修复:
- 「点不动」:工具图标此前 `draggable: true` 常开,Chromium 在按下后轻微抖动即进入拖拽 pending 并吞掉 click。现在默认 `draggable: false`,pointer 位移超过 6px 才启用 draggable（React 生态标准 workaround）,点击 100% 可靠。
- 「拖不动」:原 onDragStart 未向 dataTransfer 写入数据,未 setData 的拖拽在部分平台立即取消。现在补 `setData('text/plain', id)` + `effectAllowed = 'move'`。
- 「误触发其它界面」:拖拽启动后被取消时 Chromium 会向按钮派发 click,造成「我在拖动却切换了模块/触发了别的入口」。现在 drag 结束（含取消）统一清理 dragSourceIdRef 与 dragEnabledId,拖拽态零残留;配合阈值门控,拖拽意图不再泄漏为点击。

改动仅限 usage-row 工具图标按钮,不触碰窗口拖动区与其它 panel-btn。npm run check 全绿。需实机回归（岛展开态逐图标点击 + 拖拽重排）,建议随 v1.3.0-beta.2 验证后关闭 #69。

Ref: issue #69