### PR TITLE
feat(push): Bark mobile push for approval, question, completed and failed events

### DIFF
--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -24,6 +24,7 @@ const { PluginHookManager, DeepSeekHarnessHookManager } = require("./hooks-custo
 const { ZCodeHookManager, WorkBuddyHookManager, CodeBuddyHookManager } = require("./hooks-work-agents.cjs");
 const { initSoundDirs, playSoundEvent } = require("./sound-service.cjs");
 const { createAgentSoundDeduplicator, resolveCodexTranscriptSoundEvent } = require("./agent-sound-policy.cjs");
+const { pushBarkNotification } = require("./bark-push.cjs");
 const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens, collectAndReportTokens } = require("./adapters-extended.cjs");
 const { getAgentDescriptor, validateAgentWiring } = require("../shared/agent-catalog.cjs");
 const { diagnoseReport } = require("../shared/agent-doctor.cjs");
@@ -551,6 +552,10 @@ function createAppCoordinatorClass({
     }
     playAgentSound(eventId, sessionId, timestamp) {
       if (!this.agentSoundDedup.shouldPlay(eventId, sessionId, timestamp)) return false;
+      // B-8 Bark 推送与本地声音共享同一去重闸门；推送失败不影响声音播放。
+      const session = sessionId ? this.getSessions().find((item) => item.id === sessionId) : null;
+      const agentName = session?.tool || session?.agent || "";
+      void pushBarkNotification(this.settings, eventId, agentName);
       return playSoundEvent(eventId, this.settings);
     }
     /**

--- a/src/main/bark-push.cjs
+++ b/src/main/bark-push.cjs
@@ -1,0 +1,53 @@
+"use strict";
+
+/**
+ * B-8 Bark 手机推送（对标 Vibe Island v1.0.44 的四类事件推送）。
+ *
+ * 边界约束：
+ * - 默认关闭，只在用户填写自己的 Bark 端点（官方或自托管）后生效；
+ * - 只推送事件类型与 Agent 展示名，不带 prompt / transcript / 路径 / 审批内容；
+ * - 请求失败只记日志，绝不影响本地声音与岛的行为。
+ */
+
+const log = require("electron-log");
+
+const EVENT_TITLES = {
+  approval: "等待审批",
+  question: "等待你的回答",
+  completed: "任务完成",
+  failed: "任务失败"
+};
+
+function describeEvent(eventId) {
+  return EVENT_TITLES[eventId] || "WorkIsland 更新";
+}
+
+function buildBarkUrl(barkSettings, eventId, agentName = "") {
+  const base = String(barkSettings?.url || "").trim().replace(/\/+$/, "");
+  if (!base) return "";
+  const title = describeEvent(eventId);
+  const body = agentName ? `${agentName} 有新动态` : "WorkIsland";
+  return `${base}/${encodeURIComponent(title)}/${encodeURIComponent(body)}?group=WorkIsland`;
+}
+
+async function pushBarkNotification(settings, eventId, agentName = "") {
+  const bark = settings?.barkPush;
+  if (!bark?.enabled) return false;
+  // 事件白名单：只有用户开启的事件类型才离开本机（appLaunch 默认不推）。
+  if (!bark.events?.[eventId]) return false;
+  const url = buildBarkUrl(bark, eventId, agentName);
+  if (!url) return false;
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
+    if (!response.ok) {
+      log.warn("[bark-push] endpoint responded with", response.status);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    log.warn("[bark-push] request failed:", err?.message ?? String(err));
+    return false;
+  }
+}
+
+module.exports = { EVENT_TITLES, describeEvent, buildBarkUrl, pushBarkNotification };

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -1031,7 +1031,19 @@ function soundPage() {
     row("音量", "统一调整所有提示音。", volumeControl),
     row("自定义声音", "在本地目录中添加或替换提示音文件。", button("打开目录", () => api.openSoundsDir()))
   );
-  root.append(main);
+  const bark = state.settings.barkPush || { enabled: false, url: "", events: {} };
+  const barkSection = section("手机推送（Bark）", "Agent 等待审批、提问或完成、失败时推送到 iPhone。默认关闭；只推送事件类型与 Agent 名，不含会话内容。");
+  const barkUrl = document.createElement("input");
+  barkUrl.className = "text-input";
+  barkUrl.placeholder = "https://api.day.app/你的设备Key";
+  barkUrl.value = bark.url || "";
+  barkUrl.setAttribute("aria-label", "Bark 推送地址");
+  barkUrl.addEventListener("change", () => save({ barkPush: { ...bark, url: barkUrl.value.trim() } }));
+  barkSection.append(
+    row("启用推送", "仅向你配置的 Bark 端点发请求，自托管同样支持。", toggle(bark.enabled, v => save({ barkPush: { ...bark, enabled: v } }), "启用 Bark 推送")),
+    row("推送地址", "iOS 安装 Bark App 后复制推送 URL 粘贴到这里。", barkUrl)
+  );
+  root.append(main, barkSection);
   return root;
 }
 

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -109,6 +109,14 @@ const DEFAULT_SETTINGS = {
   // hideWhenNoActiveSessions) are one-time migration sources only — see
   // migrateIslandDisplayMode().
   islandDisplayMode: "persistent",
+  // B-8 Bark push (2026-09): user-owned endpoint, off by default. The payload
+  // carries only the event type and agent display name — never prompts,
+  // transcripts or paths. See src/main/bark-push.cjs.
+  barkPush: {
+    enabled: false,
+    url: "",
+    events: { approval: true, question: true, completed: true, failed: true }
+  },
   // Bumps when the display-mode default must migrate existing installations.
   islandDisplayModeVersion: 1,
   autoCollapseOnMouseLeave: true,

--- a/tests/bark-push.test.mjs
+++ b/tests/bark-push.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import { test } from "node:test";
+import { buildBarkUrl, pushBarkNotification } from "../src/main/bark-push.cjs";
+
+test("buildBarkUrl appends encoded title, body and group", () => {
+  const url = buildBarkUrl({ url: "https://api.day.app/abc/" }, "approval", "claude");
+  assert.ok(url.startsWith("https://api.day.app/abc/"), "should keep the configured base");
+  assert.ok(url.includes(encodeURIComponent("等待审批")), "title should be URL-encoded");
+  assert.ok(url.includes("group=WorkIsland"), "group tag should be appended");
+});
+
+test("buildBarkUrl returns empty without a configured endpoint", () => {
+  assert.equal(buildBarkUrl({ url: "" }, "approval"), "");
+  assert.equal(buildBarkUrl(undefined, "approval"), "");
+});
+
+test("pushBarkNotification skips disabled and non-whitelisted events", async () => {
+  const disabled = { barkPush: { enabled: false, url: "https://api.day.app/x", events: { approval: true } } };
+  assert.equal(await pushBarkNotification(disabled, "approval"), false);
+  const missingEvent = { barkPush: { enabled: true, url: "https://api.day.app/x", events: { approval: true } } };
+  assert.equal(await pushBarkNotification(missingEvent, "appLaunch"), false);
+  const missingUrl = { barkPush: { enabled: true, url: "", events: { approval: true } } };
+  assert.equal(await pushBarkNotification(missingUrl, "approval"), false);
+});
+
+test("pushBarkNotification hits the configured endpoint", async () => {
+  const seen = [];
+  const server = http.createServer((req, res) => {
+    seen.push(req.url);
+    res.end('{"code":200}');
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  try {
+    const ok = await pushBarkNotification(
+      { barkPush: { enabled: true, url: `http://127.0.0.1:${port}`, events: { approval: true } } },
+      "approval",
+      "codex"
+    );
+    assert.equal(ok, true);
+    assert.equal(seen.length, 1);
+    assert.ok(seen[0].startsWith(`/${encodeURIComponent("等待审批")}/`), "path should carry the encoded event title");
+    assert.ok(seen[0].includes("group=WorkIsland"));
+  } finally {
+    server.close();
+  }
+});
+
+test("pushBarkNotification returns false on unreachable endpoint", async () => {
+  const ok = await pushBarkNotification(
+    { barkPush: { enabled: true, url: "http://127.0.0.1:9", events: { approval: true } } },
+    "approval"
+  );
+  assert.equal(ok, false);
+});


### PR DESCRIPTION
验收标准:用户在「设置 → 声音 → 手机推送(Bark)」开启并填入自己的 Bark 端点后,审批/提问/完成/失败四类事件会推送到 iPhone;默认关闭;推送内容只有事件类型与 Agent 名,不含 prompt、路径或会话内容。

- 主进程新增 bark-push.cjs:Bark GET 推送协议(官方 api.day.app 与自托管均支持),5s 超时、失败仅记日志、绝不影响本地声音与岛行为。
- 挂载点与本地声音共用同一去重闸门(playAgentSound),重复事件不会重复轰炸手机。
- 设置页新增「手机推送(Bark)」section:启用开关 + 端点 URL;事件白名单默认四类,appLaunch 不推送。
- 新增 5 个单测(URL 构造/默认关闭/白名单/端点命中/失败降级),npm run check 全绿。

Ref: B-8