### PR TITLE
feat(island): session recaps summarize what happened while the island was collapsed

### DIFF
--- a/src/renderer/island/app.css
+++ b/src/renderer/island/app.css
@@ -1095,3 +1095,15 @@ body {
   font-size: 10px;
   color: rgba(255, 255, 255, 0.45);
 }
+
+.session-recap {
+  margin: 0 0 6px;
+  padding: 4px 10px;
+  display: inline-block;
+  align-self: flex-start;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.85);
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 7px;
+}

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -197,6 +197,40 @@ function IslandApp() {
   const performanceAlertTimerRef = reactExports.useRef(null);
   const [tokenBurnTotal, setTokenBurnTotal] = reactExports.useState(0);
   const [agentSetupReports, setAgentSetupReports] = reactExports.useState(null);
+  // B-6 Session Recaps：岛收起期间按会话累计 phase 迁移，展开时冻结展示。
+  const sessionRecapsRef = reactExports.useRef(new Map());
+  const prevPhasesRef = reactExports.useRef(new Map());
+  const [sessionRecaps, setSessionRecaps] = reactExports.useState(() => new Map());
+  reactExports.useEffect(() => {
+    if (notchStatus === "opened") {
+      setSessionRecaps(new Map(sessionRecapsRef.current));
+    } else {
+      // 开始新的离开周期：清零后重新累计；存量 phase 基线避免启动误计。
+      sessionRecapsRef.current = new Map();
+      prevPhasesRef.current = new Map(useSessionStore.getState().sessions.map((s) => [s.id, s.phase]));
+      setSessionRecaps(new Map());
+    }
+  }, [notchStatus]);
+  reactExports.useEffect(() => {
+    if (notchStatus === "opened") {
+      prevPhasesRef.current = new Map(sessions.map((s) => [s.id, s.phase]));
+      return;
+    }
+    const prev = prevPhasesRef.current;
+    for (const session of sessions) {
+      const before = prev.get(session.id);
+      if (before === undefined || before === session.phase) continue;
+      let recap = sessionRecapsRef.current.get(session.id);
+      if (!recap) {
+        recap = { approval: 0, completed: 0, failed: 0 };
+        sessionRecapsRef.current.set(session.id, recap);
+      }
+      if (session.phase === "waitingForApproval" || session.phase === "waitingForAnswer") recap.approval += 1;
+      else if (session.phase === "completed") recap.completed += 1;
+      else if (session.phase === "failed") recap.failed += 1;
+      prev.set(session.id, session.phase);
+    }
+  }, [sessions, notchStatus]);
   reactExports.useEffect(() => {
     let disposed = false;
     const refreshAgentSetup = () => {
@@ -950,6 +984,7 @@ function IslandApp() {
           {
             sessions,
             hasConnectedAgent: agentSetupReports ? agentSetupReports.some((report) => report?.diagnosis?.status === "ok") : null,
+            sessionRecaps,
             surface,
             notchHeight: notchH,
             panelMaxHeightPx,

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -1459,6 +1459,7 @@ function SessionEmptyOnboarding({ onOpenSettings }) {
 function IslandPanel({
   sessions,
   hasConnectedAgent = null,
+  sessionRecaps = null,
   surface,
   notchHeight,
   panelMaxHeightPx,


### PR DESCRIPTION
验收标准:岛收起期间某会话出现审批/完成/失败迁移,展开时该会话卡顶部显示「离开期间：N 等审批 · N 完成 · N 失败」,用户回来 10 秒内看懂发生了什么;岛展开期间或无变化时不显示。

- 纯渲染层实现(零新 IPC):监听 sessions 推送,仅在岛收起(notchStatus !== opened)时按 phase 迁移计数,存量会话以基线保护避免启动误计;展开瞬间冻结快照展示,再次收起自动开新周期。
- 会话卡新增 session-recap 徽条;展开期间持续推送不重复计数(仅迁移触发)。
- build:renderer + 契约测试 + 457 单测本地全绿。

Ref: B-6(Session Recaps,对标 Vibe Island v1.0.45)