### PR TITLE
feat(island): render plan confirmation as collapsible markdown

### DIFF
--- a/src/renderer/island/app.css
+++ b/src/renderer/island/app.css
@@ -1107,3 +1107,34 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.12);
   border-radius: 7px;
 }
+
+.plan-confirmation-plan.is-collapsed {
+  max-height: 180px;
+  overflow: hidden;
+  position: relative;
+}
+
+.plan-confirmation-plan.is-collapsed::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 0 0;
+  height: 48px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(10, 10, 12, 0.85));
+  pointer-events: none;
+}
+
+.plan-confirmation-expand {
+  margin-top: 6px;
+  padding: 4px 12px;
+  font-size: 11px;
+  color: #fff;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.plan-confirmation-expand:hover {
+  background: rgba(255, 255, 255, 0.2);
+}
+}

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -1170,6 +1170,7 @@ function PlanConfirmationCard({
   session
 }) {
   const [selectedChoice, setSelectedChoice] = reactExports.useState(null);
+  const [planExpanded, setPlanExpanded] = reactExports.useState(false);
   const planConfirmation = session.planConfirmation;
   if (!planConfirmation) return null;
   function handleSubmit() {
@@ -1180,7 +1181,10 @@ function PlanConfirmationCard({
   function jumpToTerminal() {
     window.islandBridge?.jumpToSession(session.id);
   }
-  return /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-card" }, /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-container" }, /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-header" }, /* @__PURE__ */ React.createElement("span", { className: "plan-confirmation-header-title" }, i18n.k3476981328({}, "等待确认计划"))), /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-content" }, /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-plan" }, planConfirmation.plan), /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-choices" }, /* @__PURE__ */ React.createElement(
+  return /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-card" }, /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-container" }, /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-header" }, /* @__PURE__ */ React.createElement("span", { className: "plan-confirmation-header-title" }, i18n.k3476981328({}, "等待确认计划"))), /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-content" }, /* @__PURE__ */ React.createElement("div", { className: `plan-confirmation-plan island-markdown${planExpanded ? "" : " is-collapsed"}` }, /* @__PURE__ */ React.createElement(Markdown, { remarkPlugins: [remarkGfm], components: { a: ({ href, children }) => /* @__PURE__ */ React.createElement("a", { href, onClick: (e) => {
+    e.preventDefault();
+    if (href) window.islandBridge?.openExternal?.(href);
+  } }, children) } }, planConfirmation.plan || ""), !planExpanded && /* @__PURE__ */ React.createElement("button", { className: "plan-confirmation-expand", type: "button", onClick: () => setPlanExpanded(true) }, i18n.k3476981328({}, "展开完整计划"))), /* @__PURE__ */ React.createElement("div", { className: "plan-confirmation-choices" }, /* @__PURE__ */ React.createElement(
     "label",
     {
       className: `plan-confirmation-choice ${selectedChoice === "AGENT" ? "is-selected" : ""}`


### PR DESCRIPTION
验收标准:Plan 确认卡中的计划文本按 Markdown 渲染(标题/列表/代码块,复用岛上既有 island-markdown 样式与 GFM),链接点击走系统浏览器;默认折叠至 180px 高(渐隐遮罩),点「展开完整计划」查看全文,可一键回终端跳转不变。

- 复用 vendor/markdown.js(CompletionCard 已有先例),不新增依赖、不新增 IPC。
- npm run build:renderer + 契约测试 + 全量单测本地全绿。

Ref: B-7(Plan Review Markdown,对标 Vibe Island)