### PR TITLE
feat(api): read-only local developer status endpoint with opt-in bearer auth

### DIFF
--- a/docs/DEVELOPER_API.md
+++ b/docs/DEVELOPER_API.md
@@ -1,0 +1,46 @@
+# Developer API（B-9）
+
+WorkIsland 提供一个**只读**的本地 HTTP 状态端点，供脚本、菜单栏工具、面板等第三方集成使用。
+对标 Notchy 的 `127.0.0.1:9999` 开发者接口。
+
+## 开关
+
+设置 → 关于 WorkIsland → **开发者 API**：
+
+- 默认**关闭**；开启后仅监听 `127.0.0.1`（loopback），外部机器无法访问。
+- 可选配置**访问令牌**：填写后，请求必须携带 `Authorization: Bearer <token>` 头（或 `?token=<token>` 查询参数），否则返回 `401`。
+- 端口默认 `9938`。
+
+## 端点
+
+### `GET /api/status`
+
+```json
+{
+  "ok": true,
+  "app": "WorkIsland",
+  "version": "1.3.0-beta.1",
+  "platform": "darwin",
+  "sessions": [
+    {
+      "id": "sess_01J8...",
+      "agent": "claude",
+      "phase": "running",
+      "startedAt": 1725300000000,
+      "updatedAt": 1725300123456
+    }
+  ],
+  "generatedAt": "2026-09-03T04:40:00.000Z"
+}
+```
+
+`phase` 取值与岛内会话状态一致：`running / waitingForApproval / waitingForAnswer / completed / failed` 等。
+
+### 隐私边界
+
+响应**只包含会话状态元数据**（会话 id、Agent 名、阶段、时间戳），不包含 prompt、
+transcript、文件路径、审批内容或用量明细。时间戳为 Unix 毫秒。
+
+### 其它路径
+
+一律返回 `404 {"ok":false,"error":"not_found"}`。

--- a/src/main/developer-api.cjs
+++ b/src/main/developer-api.cjs
@@ -1,0 +1,91 @@
+"use strict";
+
+/**
+ * B-9 Developer API（对标 Notchy 127.0.0.1:9999）。
+ *
+ * 边界约束：
+ * - loopback-only（127.0.0.1）只读状态端点，默认关闭，需在设置中显式开启；
+ * - 配置了访问令牌时，请求必须携带 Bearer 令牌（或 ?token=），否则 401；
+ * - 响应只包含会话状态元数据（id / Agent / phase / 时间），绝不包含
+ *   prompt、transcript、文件路径或审批内容。
+ */
+
+const http = require("node:http");
+const log = require("electron-log");
+
+const DEFAULT_PORT = 9938;
+
+let serverState = null; // { server, port }
+
+function buildStatusPayload(coordinator) {
+  const sessions = (coordinator.getSessions?.() || []).map((session) => ({
+    id: session.id ?? null,
+    agent: session.tool || session.agent || null,
+    phase: session.phase ?? null,
+    startedAt: session.startedAt ?? null,
+    updatedAt: session.updatedAt ?? null
+  }));
+  return {
+    ok: true,
+    app: "WorkIsland",
+    version: coordinator.getAppVersion?.() || null,
+    platform: process.platform,
+    sessions,
+    generatedAt: new Date().toISOString()
+  };
+}
+
+function handleDeveloperApiRequest(coordinator, apiSettings, req, res) {
+  if (req.url.split("?")[0] !== "/api/status") {
+    res.writeHead(404, { "content-type": "application/json" });
+    res.end(JSON.stringify({ ok: false, error: "not_found" }));
+    return;
+  }
+  const token = String(apiSettings?.token || "").trim();
+  if (token) {
+    const header = String(req.headers.authorization || "");
+    const urlToken = new URL(req.url, "http://127.0.0.1").searchParams.get("token") || "";
+    const provided = header.startsWith("Bearer ") ? header.slice(7) : urlToken;
+    if (provided !== token) {
+      res.writeHead(401, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: false, error: "unauthorized" }));
+      return;
+    }
+  }
+  res.writeHead(200, { "content-type": "application/json" });
+  res.end(JSON.stringify(buildStatusPayload(coordinator)));
+}
+
+function stopDeveloperApi() {
+  if (!serverState) return false;
+  const { server } = serverState;
+  serverState = null;
+  try {
+    server.close();
+  } catch (err) {
+    log.warn("[developer-api] close failed:", err?.message ?? String(err));
+  }
+  return true;
+}
+
+function syncDeveloperApi(coordinator) {
+  const api = coordinator.getSettings?.()?.developerApi;
+  const wantRunning = !!api?.enabled;
+  if (!wantRunning) return stopDeveloperApi();
+  const port = Number(api.port) > 0 ? Number(api.port) : DEFAULT_PORT;
+  if (serverState && serverState.port === port) return true;
+  stopDeveloperApi();
+  const server = http.createServer((req, res) => handleDeveloperApiRequest(coordinator, api, req, res));
+  server.on("error", (err) => {
+    log.warn("[developer-api] server error:", err?.message ?? String(err));
+    if (serverState?.server === server) serverState = null;
+  });
+  server.listen(port, "127.0.0.1", () => {
+    serverState = { server, port };
+    log.info(`[developer-api] listening on 127.0.0.1:${port}`);
+  });
+  serverState = { server, port };
+  return true;
+}
+
+module.exports = { DEFAULT_PORT, buildStatusPayload, handleDeveloperApiRequest, syncDeveloperApi, stopDeveloperApi };

--- a/src/main/ipc-services.cjs
+++ b/src/main/ipc-services.cjs
@@ -8,6 +8,7 @@ const promises = require("node:fs/promises");
 const { IPC } = require("../shared/ipc.cjs");
 const { listPluginAgentMeta } = require("./agent-registry.cjs");
 const { previewSound, getUserSoundsDir } = require("./sound-service.cjs");
+const { syncDeveloperApi } = require("./developer-api.cjs");
 const {
   DEFAULT_SPRITE,
   BUILT_IN_CODEX_PETS,
@@ -208,6 +209,8 @@ function createIpcServices({ performHapticFeedback, isAllowedExternalUrl, readPa
         resolveSpriteSelection(partial.petSprite);
       }
       coordinator.updateSettings(partial, "settings");
+      // B-9：注册时与设置变化后各同步一次，覆盖「上次开着重启」与开关切换。
+      syncDeveloperApi(coordinator);
     });
     electron.ipcMain.handle(IPC.SETTINGS_SELECT_DIRECTORY, (event) => {
       return selectDirectory(electron.BrowserWindow.fromWebContents(event.sender) ?? void 0);

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -1169,7 +1169,19 @@ function aboutPage() {
     ),
     row("本机发送状态", "仅显示本机队列与 PostHog 批量接口最近一次 HTTP 2xx 确认，不展示或上传任何额外内容。", el("div", "setting-description", statusText))
   );
-  root.append(about, support, privacy, updates, diagnostics);
+  const devApi = state.settings.developerApi || { enabled: false, port: 9938, token: "" };
+  const devSection = section("开发者 API", "在本机回环地址提供只读的会话状态 JSON 端点，供脚本与工具集成。默认关闭；响应不含会话内容。");
+  const devToken = document.createElement("input");
+  devToken.className = "text-input";
+  devToken.placeholder = "可选访问令牌（留空不鉴权）";
+  devToken.value = devApi.token || "";
+  devToken.setAttribute("aria-label", "开发者 API 访问令牌");
+  devToken.addEventListener("change", () => save({ developerApi: { ...devApi, token: devToken.value.trim() } }));
+  devSection.append(
+    row("启用本地状态端点", `开启后 GET http://127.0.0.1:${devApi.port || 9938}/api/status 返回会话状态与版本信息。`, toggle(devApi.enabled, v => save({ developerApi: { ...devApi, enabled: v } }), "启用开发者 API")),
+    row("访问令牌", "填写后请求需携带 Bearer 令牌（或 ?token= 查询参数）；仅本机可访问。", devToken)
+  );
+  root.append(about, support, privacy, updates, devSection, diagnostics);
   return root;
 }
 

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -117,6 +117,11 @@ const DEFAULT_SETTINGS = {
     url: "",
     events: { approval: true, question: true, completed: true, failed: true }
   },
+  // B-9 Developer API (2026-09): read-only status JSON on loopback, off by
+  // default. Optional shared token enables bearer auth. Response carries only
+  // session status metadata. See src/main/developer-api.cjs and
+  // docs/DEVELOPER_API.md.
+  developerApi: { enabled: false, port: 9938, token: "" },
   // Bumps when the display-mode default must migrate existing installations.
   islandDisplayModeVersion: 1,
   autoCollapseOnMouseLeave: true,

--- a/tests/developer-api.test.mjs
+++ b/tests/developer-api.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
+const { buildStatusPayload, handleDeveloperApiRequest, syncDeveloperApi, stopDeveloperApi } = require("../src/main/developer-api.cjs");
+
+function mockResponse() {
+  const res = { statusCode: 0, body: "", headers: {} };
+  return {
+    res,
+    writeHead(code, headers) {
+      res.statusCode = code;
+      res.headers = headers || {};
+      return this;
+    },
+    end(payload) {
+      res.body = payload ?? "";
+    }
+  };
+}
+
+function mockCoordinator() {
+  return {
+    getSessions: () => [
+      { id: "s1", tool: "claude", phase: "running", startedAt: 1, updatedAt: 2, latestUserPrompt: "SECRET PROMPT" }
+    ],
+    getAppVersion: () => "1.3.0-test"
+  };
+}
+
+test("buildStatusPayload exposes status metadata but never prompts", () => {
+  const payload = buildStatusPayload(mockCoordinator());
+  assert.equal(payload.ok, true);
+  assert.equal(payload.version, "1.3.0-test");
+  assert.equal(payload.sessions.length, 1);
+  assert.deepEqual(Object.keys(payload.sessions[0]).sort(), ["agent", "id", "phase", "startedAt", "updatedAt"]);
+  assert.equal(JSON.stringify(payload).includes("SECRET PROMPT"), false);
+});
+
+test("handleDeveloperApiRequest serves status and rejects other paths", () => {
+  const coordinator = mockCoordinator();
+  const ok = mockResponse();
+  handleDeveloperApiRequest(coordinator, {}, { url: "/api/status", headers: {} }, ok);
+  assert.equal(ok.res.statusCode, 200);
+  const missing = mockResponse();
+  handleDeveloperApiRequest(coordinator, {}, { url: "/api/other", headers: {} }, missing);
+  assert.equal(missing.res.statusCode, 404);
+});
+
+test("handleDeveloperApiRequest enforces the optional bearer token", () => {
+  const coordinator = mockCoordinator();
+  const apiSettings = { token: "s3cret" };
+  const denied = mockResponse();
+  handleDeveloperApiRequest(coordinator, apiSettings, { url: "/api/status", headers: {} }, denied);
+  assert.equal(denied.res.statusCode, 401);
+  const allowed = mockResponse();
+  handleDeveloperApiRequest(coordinator, apiSettings, { url: "/api/status", headers: { authorization: "Bearer s3cret" } }, allowed);
+  assert.equal(allowed.res.statusCode, 200);
+});
+
+test("syncDeveloperApi starts on loopback only when enabled and stops when disabled", async () => {
+  const coordinator = {
+    getSettings: () => ({ developerApi: { enabled: true, port: 9938, token: "" } }),
+    getSessions: () => [],
+    getAppVersion: () => "test"
+  };
+  assert.equal(syncDeveloperApi(coordinator), true);
+  // Give the async listen callback a moment, then hit the endpoint.
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  const response = await fetch("http://127.0.0.1:9938/api/status");
+  const payload = await response.json();
+  assert.equal(payload.ok, true);
+  assert.equal(stopDeveloperApi(), true);
+  let refused = false;
+  try {
+    await fetch("http://127.0.0.1:9938/api/status");
+  } catch {
+    refused = true;
+  }
+  assert.equal(refused, true);
+});


### PR DESCRIPTION
验收标准:设置 → 关于 → 开发者 API 开启后,GET http://127.0.0.1:9938/api/status 返回会话状态 JSON(id/Agent/phase/时间戳+版本);默认关闭;配置令牌后无 Bearer 令牌的请求返回 401;响应不含 prompt、路径或会话内容;文档见 docs/DEVELOPER_API.md。

- 新增 src/main/developer-api.cjs:loopback-only HTTP 服务,注册时与设置变化后各同步一次(覆盖上次开着重启),端口默认 9938,失败仅记日志。
- 设置页「关于」新增开发者 API section(开关 + 可选访问令牌)。
- 新增 4 组单测(payload 脱敏/404/401 鉴权/真实监听与关闭),本地全绿。

Ref: B-9(Developer API,对标 Notchy 127.0.0.1:9999)