### PR TITLE
feat(usage): 参考 agentsview 新增用量发现通道，补齐 zcode/opencode/claude 客户端覆盖

### DIFF
--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -25,6 +25,7 @@ const { ZCodeHookManager, WorkBuddyHookManager, CodeBuddyHookManager } = require
 const { initSoundDirs, playSoundEvent } = require("./sound-service.cjs");
 const { createAgentSoundDeduplicator, resolveCodexTranscriptSoundEvent } = require("./agent-sound-policy.cjs");
 const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens, collectAndReportTokens } = require("./adapters-extended.cjs");
+const { UsageDiscoveryService } = require("./usage-discovery.cjs");
 const { getAgentDescriptor, validateAgentWiring } = require("../shared/agent-catalog.cjs");
 const { diagnoseReport } = require("../shared/agent-doctor.cjs");
 const { createPresentationRequest } = require("./presentation-policy.cjs");
@@ -178,6 +179,11 @@ function createAppCoordinatorClass({
      * 在 start() 里实例化并接入 bridge.emitEvent 管线。
      */
     codexTranscriptWatcher = null;
+    /**
+     * 用量发现通道（issue #90）—— 不依赖 hook，主动发现 zcode/opencode/claude
+     * 落盘的用量数据并入账 StatsService，补齐其余客户端的 token 覆盖。
+     */
+    usageDiscovery = null;
     /**
      * Agent 事件去重器。hook 通道与 transcript 通道会同时报告同一 session 的同一事件，
      * 用 5 秒窗口 dedup 让两条通道都跑但只放行第一个。
@@ -528,6 +534,7 @@ function createAppCoordinatorClass({
       });
       this.terminalService.setEnabled(this.settings.terminalEnabled !== false);
       this.startCodexTranscriptWatcher();
+      this.startUsageDiscovery();
       // Agent Doctor（B-1）：启动时后台自动检测并修复可修复的 hook 状态，
       // fire-and-forget，失败不影响启动路径。
       void this.runStartupDoctor();
@@ -591,6 +598,19 @@ function createAppCoordinatorClass({
         // watcher 启动失败不应阻断 app 启动；hook 通道仍可工作
         log.warn("[AppCoordinator] codex transcript watcher failed to start:", err.message);
         this.codexTranscriptWatcher = null;
+      }
+    }
+    /**
+     * 用量发现通道启动：延迟首扫（避开启动高峰），之后按固定周期扫描。
+     * 基线差分保证重复扫描/重启回填不重复计数，失败不阻断启动路径。
+     */
+    startUsageDiscovery() {
+      try {
+        this.usageDiscovery = new UsageDiscoveryService({ statsService: this.statsService });
+        this.usageDiscovery.start();
+      } catch (err) {
+        log.warn("[AppCoordinator] usage discovery failed to start:", err.message);
+        this.usageDiscovery = null;
       }
     }
     /**
@@ -845,6 +865,10 @@ function createAppCoordinatorClass({
       if (this.codexTranscriptWatcher) {
         this.codexTranscriptWatcher.stop();
         this.codexTranscriptWatcher = null;
+      }
+      if (this.usageDiscovery) {
+        this.usageDiscovery.stop();
+        this.usageDiscovery = null;
       }
       this.statsService.dispose();
       for (const cancel of this.pidWatchers.values()) cancel();

--- a/src/main/stats-service.cjs
+++ b/src/main/stats-service.cjs
@@ -57,11 +57,15 @@ class StatsService {
     this.dirty = true;
     this.scheduleSave();
   }
-  recordToken(tool, sessionId, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, remote, model) {
+  /**
+   * timestamp 可选：用量发现通道（usage-discovery）回填历史用量时传记录的
+   * 真实时间，让旧会话落到对应日期；缺省仍按当前时间入账。
+   */
+  recordToken(tool, sessionId, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, remote, model, timestamp) {
     const record = {
       tool,
       sessionId,
-      timestamp: Date.now(),
+      timestamp: Number.isFinite(timestamp) && timestamp > 0 ? timestamp : Date.now(),
       inputTokens,
       outputTokens,
       cacheReadTokens,

--- a/src/main/usage-discovery.cjs
+++ b/src/main/usage-discovery.cjs
@@ -1,0 +1,431 @@
+"use strict";
+
+/**
+ * 用量发现通道（issue #90）—— 与 hook 通道并行的第二采集路线。
+ *
+ * hook 通道要求客户端装 hook 且事件携带 transcript_path，且 token 采集
+ * switch 只覆盖 claude/codex/gemini/hermes。本模块参考 agentsview
+ * （kenn-io/agentsview）的会话目录矩阵，不依赖 hook，直接发现客户端
+ * 落盘的用量数据并入账 StatsService。首批来源（格式已在本机实证）：
+ *
+ *   zcode    ~/.zcode/cli/db/db.sqlite               model_usage 表（sqlite3 CLI，同 hermes 模式）
+ *   opencode ~/.local/share/opencode/storage/message/ 会话目录 msg json（assistant 带 tokens）
+ *   claude   ~/.claude/projects/                     *.jsonl（复用 parseClaudeTokens）
+ *
+ * 入账规则：
+ *   - 基线差分：每轮扫描先从 StatsService 已入账记录重建基线，只入账增量，
+ *     重复扫描 / 重启回填不重复计数（与 applyBaselineDiff 同思路，但按
+ *     tool+session(+model) 建基线，且不依赖进程内 Map）。
+ *   - 所有权：claude 会话只要已被任何通道入账过（hook 通道或本通道）即跳过，
+ *     两条通道不会对同一会话重复计费；zcode/opencode 没有 hook token 通道，
+ *     按基线差分自然幂等。
+ *   - 历史时间戳：recordToken 传记录真实时间（最后活跃时间），按日归档正确。
+ *   - ADR-0004 边界：只读 token 计数 / 时间 / 模型标识，不读 prompt 正文、
+ *     目录内容与密钥。
+ *
+ * 归档口径：整段会话的增量入账到「最后一次活跃」所在的日期（与 hook 通道
+ * 在完成时一次性入账的口径一致）。
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const { execFileSync } = require("node:child_process");
+const promises = require("node:fs/promises");
+const log = require("electron-log");
+const { parseClaudeTokens } = require("./adapters-extended.cjs");
+
+const DAY_MS = 24 * 60 * 60 * 1e3;
+const DEFAULT_SCAN_INTERVAL_MS = 10 * 60 * 1e3;
+const DEFAULT_START_DELAY_MS = 8 * 1e3;
+// 超大 transcript 跳过解析（hook 通道完成时也要整读一次，这里只挡离谱值）
+const MAX_CLAUDE_FILE_BYTES = 50 * 1024 * 1024;
+const SQLITE_TIMEOUT_MS = 3e3;
+
+function yieldToEventLoop() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function emptyTotals() {
+  return { input: 0, output: 0, cacheRead: 0, cacheCreation: 0 };
+}
+
+function totalsNonZero(t) {
+  return t.input > 0 || t.output > 0 || t.cacheRead > 0 || t.cacheCreation > 0;
+}
+
+/** 增量 = 累计 - 基线，逐项下限 0；全零返回 null。 */
+function diffTotals(cumulative, baseline) {
+  const input = Math.max(0, cumulative.input - baseline.input);
+  const output = Math.max(0, cumulative.output - baseline.output);
+  const cacheRead = Math.max(0, cumulative.cacheRead - baseline.cacheRead);
+  const cacheCreation = Math.max(0, cumulative.cacheCreation - baseline.cacheCreation);
+  if (input === 0 && output === 0 && cacheRead === 0 && cacheCreation === 0) return null;
+  return { input, output, cacheRead, cacheCreation };
+}
+
+// ── zcode：~/.zcode/cli/db/db.sqlite · model_usage ──────────────────────────
+
+const ZCODE_USAGE_SQL = (cutoffMs) => [
+  "SELECT session_id, model_id,",
+  "       SUM(input_tokens), SUM(output_tokens),",
+  "       SUM(cache_read_input_tokens), SUM(cache_creation_input_tokens),",
+  "       MAX(started_at)",
+  "FROM model_usage",
+  `WHERE started_at >= ${Math.floor(cutoffMs)}`,
+  "GROUP BY session_id, model_id"
+].join(" ");
+
+function parseSqliteRows(stdout, columnCount) {
+  const rows = [];
+  for (const line of stdout.split("\n")) {
+    if (!line) continue;
+    const fields = line.split("|");
+    if (fields.length < columnCount) continue;
+    rows.push(fields);
+  }
+  return rows;
+}
+
+function collectZcodeUsage({ dbPath, cutoffMs }) {
+  if (!fs.existsSync(dbPath)) return [];
+  const stdout = execFileSync(
+    "sqlite3",
+    [dbPath, ZCODE_USAGE_SQL(cutoffMs)],
+    { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"], timeout: SQLITE_TIMEOUT_MS }
+  ).trim();
+  const rows = parseSqliteRows(stdout, 7);
+  const results = [];
+  for (const [sessionId, modelId, input, output, cacheRead, cacheCreation, lastActive] of rows) {
+    if (!sessionId) continue;
+    const totals = {
+      input: Number(input) || 0,
+      output: Number(output) || 0,
+      cacheRead: Number(cacheRead) || 0,
+      cacheCreation: Number(cacheCreation) || 0
+    };
+    if (!totalsNonZero(totals)) continue;
+    const lastActiveAt = Number(lastActive);
+    results.push({
+      sessionId,
+      model: modelId || "unknown",
+      ...totals,
+      lastActiveAt: Number.isFinite(lastActiveAt) && lastActiveAt > 0 ? lastActiveAt : undefined
+    });
+  }
+  return results;
+}
+
+// ── opencode：~/.local/share/opencode/storage/message/ses_*/msg_*.json ──────
+
+function opencodeTotalsOf(message) {
+  if (message?.role !== "assistant" || !message.tokens) return null;
+  const t = message.tokens;
+  const totals = {
+    input: Number(t.input) || 0,
+    output: Number(t.output) || 0,
+    cacheRead: Number(t.cache?.read) || 0,
+    cacheCreation: Number(t.cache?.write) || 0
+  };
+  // reasoning tokens 是输出的一部分被 opencode 单列，这里不并入 output，
+  // 与其他客户端「output 即 API 返回 output_tokens」的口径一致。
+  if (!totalsNonZero(totals)) return null;
+  return totals;
+}
+
+async function collectOpencodeUsage({ storageRoot, cutoffMs, seenDirMtime }) {
+  const messageRoot = path.join(storageRoot, "storage", "message");
+  let sessionDirs;
+  try {
+    sessionDirs = await promises.readdir(messageRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const results = [];
+  for (const entry of sessionDirs) {
+    if (!entry.isDirectory() || !entry.name.startsWith("ses_")) continue;
+    const dirPath = path.join(messageRoot, entry.name);
+    let mtimeMs = 0;
+    try {
+      mtimeMs = (await promises.stat(dirPath)).mtimeMs;
+    } catch {
+      continue;
+    }
+    // 目录 mtime 未变化的会话上一轮已扫过，直接跳过（首次扫描除外）
+    if (seenDirMtime && seenDirMtime.get(dirPath) === mtimeMs) continue;
+    if (seenDirMtime) seenDirMtime.set(dirPath, mtimeMs);
+    if (mtimeMs < cutoffMs) continue;
+
+    let files;
+    try {
+      files = await promises.readdir(dirPath);
+    } catch {
+      continue;
+    }
+    // 整段会话全量累加（截断会导致累计值小于基线、漏记增量）
+    const perModel = new Map();
+    let lastActiveAt = 0;
+    for (const file of files) {
+      if (!file.endsWith(".json")) continue;
+      let message;
+      try {
+        message = JSON.parse(await promises.readFile(path.join(dirPath, file), "utf-8"));
+      } catch {
+        continue;
+      }
+      const totals = opencodeTotalsOf(message);
+      if (!totals) continue;
+      const model = message.model?.modelID || message.model?.providerID || "unknown";
+      let bucket = perModel.get(model);
+      if (!bucket) {
+        bucket = { ...emptyTotals() };
+        perModel.set(model, bucket);
+      }
+      bucket.input += totals.input;
+      bucket.output += totals.output;
+      bucket.cacheRead += totals.cacheRead;
+      bucket.cacheCreation += totals.cacheCreation;
+      const completedAt = Number(message.time?.completed) || Number(message.time?.created) || 0;
+      if (completedAt > lastActiveAt) lastActiveAt = completedAt;
+      await yieldToEventLoop();
+    }
+    for (const [model, totals] of perModel) {
+      if (!totalsNonZero(totals)) continue;
+      results.push({
+        sessionId: entry.name,
+        model,
+        ...totals,
+        lastActiveAt: lastActiveAt || undefined
+      });
+    }
+  }
+  return results;
+}
+
+// ── claude：~/.claude/projects/*/*.jsonl（复用 parseClaudeTokens）───────────
+
+async function collectClaudeUsage({ projectsRoot, cutoffMs, ownedSessions }) {
+  let projectDirs;
+  try {
+    projectDirs = await promises.readdir(projectsRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const results = [];
+  for (const entry of projectDirs) {
+    if (!entry.isDirectory()) continue;
+    let files;
+    try {
+      files = await promises.readdir(path.join(projectsRoot, entry.name));
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith(".jsonl")) continue;
+      const sessionId = file.slice(0, -".jsonl".length);
+      // 已被任何通道入账过的会话归原通道所有，跳过
+      if (ownedSessions.has(sessionId)) continue;
+      const filePath = path.join(projectsRoot, entry.name, file);
+      let stat;
+      try {
+        stat = await promises.stat(filePath);
+      } catch {
+        continue;
+      }
+      if (stat.mtimeMs < cutoffMs) continue;
+      if (stat.size > MAX_CLAUDE_FILE_BYTES) {
+        log.warn("[UsageDiscovery] claude transcript 超过大小上限，跳过: %s", filePath);
+        continue;
+      }
+      const cumulative = await parseClaudeTokens(filePath);
+      await yieldToEventLoop();
+      if (!cumulative) continue;
+      const totals = {
+        input: cumulative.inputTokens ?? 0,
+        output: cumulative.outputTokens ?? 0,
+        cacheRead: cumulative.cacheReadTokens ?? 0,
+        cacheCreation: cumulative.cacheCreationTokens ?? 0
+      };
+      if (!totalsNonZero(totals)) continue;
+      results.push({
+        sessionId,
+        model: cumulative.model || "unknown",
+        ...totals,
+        lastActiveAt: Math.round(stat.mtimeMs)
+      });
+    }
+  }
+  return results;
+}
+
+// ── 服务编排 ────────────────────────────────────────────────────────────────
+
+class UsageDiscoveryService {
+  /**
+   * 全部依赖可注入（测试传临时 homeDir / 假 statsService / 假 collect）。
+   * collectZcode/collectOpencode/collectClaude 覆写点见 this._collectors。
+   */
+  constructor({ statsService, homeDir, scanIntervalMs, startDelayMs, now = Date.now } = {}) {
+    this.statsService = statsService;
+    this.homeDir = homeDir ?? os.homedir();
+    this.scanIntervalMs = scanIntervalMs ?? DEFAULT_SCAN_INTERVAL_MS;
+    this.startDelayMs = startDelayMs ?? DEFAULT_START_DELAY_MS;
+    this.now = now;
+    this.scanTimer = null;
+    this.startTimer = null;
+    this.running = false;
+    this.scanning = false;
+    /** opencode 会话目录 mtime 快照（进程内，重启后首轮全量重扫） */
+    this.seenDirMtime = new Map();
+    this._collectors = {
+      zcode: (cutoffMs) => collectZcodeUsage({
+        dbPath: path.join(this.homeDir, ".zcode", "cli", "db", "db.sqlite"),
+        cutoffMs
+      }),
+      opencode: (cutoffMs) => collectOpencodeUsage({
+        storageRoot: path.join(this.homeDir, ".local", "share", "opencode"),
+        cutoffMs,
+        seenDirMtime: this.seenDirMtime
+      }),
+      claude: (cutoffMs, ownedSessions) => collectClaudeUsage({
+        projectsRoot: path.join(this.homeDir, ".claude", "projects"),
+        cutoffMs,
+        ownedSessions
+      })
+    };
+  }
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    this.startTimer = setTimeout(() => {
+      this.startTimer = null;
+      if (!this.running) return;
+      void this.scanAll();
+      this.scanTimer = setInterval(() => {
+        if (!this.scanning) void this.scanAll();
+      }, this.scanIntervalMs);
+    }, this.startDelayMs);
+    log.info(
+      "[UsageDiscovery] started (interval=%ds, home=%s)",
+      Math.round(this.scanIntervalMs / 1e3),
+      this.homeDir
+    );
+  }
+
+  stop() {
+    this.running = false;
+    if (this.startTimer) {
+      clearTimeout(this.startTimer);
+      this.startTimer = null;
+    }
+    if (this.scanTimer) {
+      clearInterval(this.scanTimer);
+      this.scanTimer = null;
+    }
+  }
+
+  /** 保留窗口（与 StatsService 保留期一致），超窗的旧数据不再扫描。 */
+  cutoffMs() {
+    const retentionDays = Number(this.statsService?.retentionDays) || 90;
+    return this.now() - retentionDays * DAY_MS;
+  }
+
+  /**
+   * 基线：StatsService 已入账记录重建。
+   * perSession 用于 claude 所有权判定（任何通道入账过即跳过）；
+   * perSessionModel 用于 zcode/opencode 的按 (session, model) 增量差分。
+   */
+  buildBaselines(tool) {
+    const perSession = new Map();
+    const perSessionModel = new Map();
+    for (const record of this.statsService.tokens) {
+      if (record.tool !== tool) continue;
+      const add = (map, key) => {
+        let t = map.get(key);
+        if (!t) {
+          t = { ...emptyTotals() };
+          map.set(key, t);
+        }
+        t.input += Number(record.inputTokens) || 0;
+        t.output += Number(record.outputTokens) || 0;
+        t.cacheRead += Number(record.cacheReadTokens) || 0;
+        t.cacheCreation += Number(record.cacheCreationTokens) || 0;
+      };
+      add(perSession, record.sessionId);
+      add(perSessionModel, `${record.sessionId}\u0000${record.model || "unknown"}`);
+    }
+    return { perSession, perSessionModel };
+  }
+
+  /** 单个来源入账，返回 {records, tokens}（tokens 为增量总和）。 */
+  ingest(tool, discovered) {
+    const { perSessionModel } = this.buildBaselines(tool);
+    let records = 0;
+    let tokenSum = 0;
+    for (const item of discovered) {
+      const key = `${item.sessionId}\u0000${item.model || "unknown"}`;
+      const delta = diffTotals(
+        { input: item.input, output: item.output, cacheRead: item.cacheRead, cacheCreation: item.cacheCreation },
+        perSessionModel.get(key) ?? emptyTotals()
+      );
+      if (!delta) continue;
+      this.statsService.recordToken(
+        tool,
+        item.sessionId,
+        delta.input,
+        delta.output,
+        delta.cacheRead,
+        delta.cacheCreation,
+        null,
+        item.model,
+        item.lastActiveAt
+      );
+      records += 1;
+      tokenSum += delta.input + delta.output + delta.cacheRead + delta.cacheCreation;
+    }
+    return { records, tokens: tokenSum };
+  }
+
+  /** claude 来源在收集前先算所有权集合（已被任何通道入账的会话）。 */
+  claudeOwnedSessions() {
+    const owned = new Set();
+    for (const record of this.statsService.tokens) {
+      if (record.tool === "claude" && record.sessionId) owned.add(record.sessionId);
+    }
+    return owned;
+  }
+
+  async scanAll() {
+    if (this.scanning) return;
+    this.scanning = true;
+    try {
+      const cutoff = this.cutoffMs();
+      for (const [tool, collect] of Object.entries(this._collectors)) {
+        try {
+          const owned = tool === "claude" ? this.claudeOwnedSessions() : null;
+          const discovered = await collect(cutoff, owned);
+          const { records, tokens } = this.ingest(tool, discovered);
+          if (records > 0) {
+            log.info("[UsageDiscovery] %s: 入账 %d 条增量记录，共 %d tokens", tool, records, tokens);
+          }
+        } catch (err) {
+          log.warn("[UsageDiscovery] %s 扫描失败:", tool, err?.message ?? err);
+        }
+        await yieldToEventLoop();
+      }
+    } finally {
+      this.scanning = false;
+    }
+  }
+}
+
+module.exports = {
+  UsageDiscoveryService,
+  collectZcodeUsage,
+  collectOpencodeUsage,
+  collectClaudeUsage,
+  opencodeTotalsOf,
+  diffTotals,
+  ZCODE_USAGE_SQL
+};

--- a/src/main/usage-service.cjs
+++ b/src/main/usage-service.cjs
@@ -165,6 +165,8 @@ class UsageService {
       const idx = dayIndex.get(this.localDateKey(r.completedAt));
       if (idx === undefined) continue;
       byDay[idx].sessionCount += 1;
+      // 按 Agent 的会话数（此前恒为 0，看板「会话」列一直是空）
+      bucketFor(byAgent, r.tool).sessionCount += 1;
     }
 
     const totalBucketTokens = (b) => b.inputTokens + b.outputTokens + b.cacheReadTokens + b.cacheCreationTokens;

--- a/src/renderer/shared/settings.js
+++ b/src/renderer/shared/settings.js
@@ -34,7 +34,8 @@ const AGENT_TOOL_LABELS = {
   "copilot-cli": "GitHub Copilot CLI",
   aiden: "Aiden",
   sara: "Sara CLI",
-  "traex": "TRAE CLI 2.0"
+  "traex": "TRAE CLI 2.0",
+  zcode: "ZCode"
 };
 function isPluginAgentTool(tool) {
   return typeof tool === "string" && tool.startsWith("plugin:");

--- a/tests/usage-discovery.test.mjs
+++ b/tests/usage-discovery.test.mjs
@@ -1,0 +1,292 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+const require = createRequire(import.meta.url);
+const dir = mkdtempSync(join(tmpdir(), "wi-usage-discovery-"));
+
+// stats-service 在模块加载时就调用 electron.app.getPath("userData")，普通 node
+// 下先往 require 缓存塞桩（同 tests/token-capture.test.mjs 的做法）。
+const electronId = require.resolve("electron");
+require.cache[electronId] = {
+  id: electronId,
+  filename: electronId,
+  loaded: true,
+  exports: { app: { getPath: () => dir }, ipcMain: { on() {}, handle() {}, removeListener() {}, removeHandler() {} } }
+};
+
+const { UsageDiscoveryService, collectZcodeUsage, collectOpencodeUsage, collectClaudeUsage, opencodeTotalsOf, diffTotals } = require("../src/main/usage-discovery.cjs");
+const { StatsService } = require("../src/main/stats-service.cjs");
+const { UsageService } = require("../src/main/usage-service.cjs");
+
+const DAY = 24 * 60 * 60 * 1e3;
+
+// ── 工具函数 ─────────────────────────────────────────────────────────────────
+
+function fakeStats({ tokens = [] } = {}) {
+  return {
+    tokens,
+    sessions: [],
+    retentionDays: 90,
+    recordSession(tool, startedAt, completedAt, sessionId) {
+      this.sessions.push(sessionId ? { tool, startedAt, completedAt, sessionId } : { tool, startedAt, completedAt });
+    },
+    recordToken(tool, sessionId, inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, remote, model, timestamp) {
+      this.tokens.push({
+        tool,
+        sessionId,
+        inputTokens,
+        outputTokens,
+        cacheReadTokens,
+        cacheCreationTokens,
+        model: model || "unknown",
+        timestamp: Number.isFinite(timestamp) && timestamp > 0 ? timestamp : Date.now()
+      });
+    }
+  };
+}
+
+function hasSqlite3() {
+  try {
+    execFileSync("sqlite3", ["--version"], { stdio: ["ignore", "pipe", "ignore"] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── recordToken 可选时间戳（历史用量归档的前提）────────────────────────────
+
+test("recordToken honors an explicit historical timestamp", () => {
+  const stats = new StatsService({ statsDir: join(dir, "stats-ts"), retentionDays: 90 });
+  const fixed = new Date(2026, 7, 1, 9, 0, 0).getTime();
+  stats.recordToken("opencode", "ses_x", 10, 5, 0, 0, null, "m1", fixed);
+  stats.recordToken("opencode", "ses_x", 1, 1, 0, 0, null, "m1");
+  assert.equal(stats.tokens[0].timestamp, fixed, "explicit timestamp must be preserved");
+  assert.ok(stats.tokens[1].timestamp > fixed, "missing timestamp falls back to now");
+  stats.dispose();
+});
+
+// ── 纯函数 ──────────────────────────────────────────────────────────────────
+
+test("opencodeTotalsOf maps assistant tokens and skips others", () => {
+  assert.deepEqual(
+    opencodeTotalsOf({ role: "assistant", tokens: { input: 10, output: 5, cache: { read: 100, write: 20 } } }),
+    { input: 10, output: 5, cacheRead: 100, cacheCreation: 20 }
+  );
+  assert.equal(opencodeTotalsOf({ role: "user", tokens: { input: 10, output: 5 } }), null);
+  assert.equal(opencodeTotalsOf({ role: "assistant", tokens: { input: 0, output: 0 } }), null);
+});
+
+test("diffTotals clamps at zero and returns null when nothing new", () => {
+  assert.deepEqual(diffTotals({ input: 10, output: 5, cacheRead: 3, cacheCreation: 1 }, { input: 4, output: 5, cacheRead: 0, cacheCreation: 0 }),
+    { input: 6, output: 0, cacheRead: 3, cacheCreation: 1 });
+  assert.equal(diffTotals({ input: 1, output: 0, cacheRead: 0, cacheCreation: 0 }, { input: 2, output: 0, cacheRead: 0, cacheCreation: 0 }), null);
+});
+
+// ── opencode 收集器 ─────────────────────────────────────────────────────────
+
+test("opencode collector aggregates per session+model", async () => {
+  const home = join(dir, "oc-home");
+  const sesDir = join(home, ".local/share/opencode/storage/message/ses_a");
+  mkdirSync(sesDir, { recursive: true });
+  writeFileSync(join(sesDir, "msg_1.json"), JSON.stringify({
+    role: "user",
+    time: { created: 1700000000000 }
+  }));
+  writeFileSync(join(sesDir, "msg_2.json"), JSON.stringify({
+    role: "assistant",
+    model: { providerID: "google", modelID: "gemini-3-pro" },
+    tokens: { input: 10, output: 5, reasoning: 2, cache: { read: 100, write: 20 } },
+    time: { created: 1700000001000, completed: 1700000002000 }
+  }));
+  writeFileSync(join(sesDir, "msg_3.json"), JSON.stringify({
+    role: "assistant",
+    model: { providerID: "anthropic", modelID: "claude-x" },
+    tokens: { input: 7, output: 3, cache: { read: 0, write: 0 } },
+    time: { created: 1700000003000, completed: 1700000004000 }
+  }));
+  const results = await collectOpencodeUsage({ storageRoot: join(home, ".local/share/opencode"), cutoffMs: 0, seenDirMtime: new Map() });
+  const gemini = results.find((r) => r.model === "gemini-3-pro");
+  const claude = results.find((r) => r.model === "claude-x");
+  assert.deepEqual({ ...gemini, sessionId: gemini.sessionId }, {
+    sessionId: "ses_a",
+    model: "gemini-3-pro",
+    input: 10, output: 5, cacheRead: 100, cacheCreation: 20,
+    lastActiveAt: 1700000004000 // 会话级最后活跃时间（跨模型取最大）
+  });
+  assert.equal(claude.input, 7);
+  assert.equal(claude.lastActiveAt, 1700000004000);
+});
+
+test("opencode collector skips unchanged session dirs via mtime memo", async () => {
+  const home = join(dir, "oc-home2");
+  const sesDir = join(home, ".local/share/opencode/storage/message/ses_b");
+  mkdirSync(sesDir, { recursive: true });
+  writeFileSync(join(sesDir, "msg_1.json"), JSON.stringify({
+    role: "assistant",
+    model: { modelID: "m1" },
+    tokens: { input: 1, output: 1 },
+    time: { created: 1700000000000, completed: 1700000000000 }
+  }));
+  const seen = new Map();
+  const root = join(home, ".local/share/opencode");
+  const first = await collectOpencodeUsage({ storageRoot: root, cutoffMs: 0, seenDirMtime: seen });
+  assert.equal(first.length, 1);
+  const second = await collectOpencodeUsage({ storageRoot: root, cutoffMs: 0, seenDirMtime: seen });
+  assert.equal(second.length, 0, "unchanged dirs must be skipped on rescan");
+  // 目录有新文件（mtime 变化）→ 重新扫描并累计全量（基线差分在 ingest 层做）
+  writeFileSync(join(sesDir, "msg_2.json"), JSON.stringify({
+    role: "assistant",
+    model: { modelID: "m1" },
+    tokens: { input: 2, output: 2 },
+    time: { created: 1700000005000, completed: 1700000006000 }
+  }));
+  const third = await collectOpencodeUsage({ storageRoot: root, cutoffMs: 0, seenDirMtime: seen });
+  assert.equal(third.length, 1);
+  assert.equal(third[0].input, 3, "cumulative includes all messages of the session");
+});
+
+// ── claude 收集器 ───────────────────────────────────────────────────────────
+
+test("claude collector parses transcripts and skips owned sessions", async () => {
+  const home = join(dir, "cl-home");
+  const projDir = join(home, ".claude/projects/proj-a");
+  mkdirSync(projDir, { recursive: true });
+  writeFileSync(join(projDir, "sess-free.jsonl"), [
+    JSON.stringify({ type: "user", message: { content: "hi" } }),
+    JSON.stringify({ type: "assistant", requestId: "r1", message: { model: "claude-x", usage: { input_tokens: 10, output_tokens: 5, cache_read_input_tokens: 50, cache_creation_input_tokens: 8 } } }),
+    ""
+  ].join("\n"));
+  writeFileSync(join(projDir, "sess-owned.jsonl"), [
+    JSON.stringify({ type: "assistant", requestId: "r2", message: { model: "claude-x", usage: { input_tokens: 99, output_tokens: 99 } } }),
+    ""
+  ].join("\n"));
+  const results = await collectClaudeUsage({
+    projectsRoot: join(home, ".claude/projects"),
+    cutoffMs: 0,
+    ownedSessions: new Set(["sess-owned"])
+  });
+  assert.equal(results.length, 1, "owned sessions must be skipped");
+  assert.equal(results[0].sessionId, "sess-free");
+  assert.equal(results[0].input, 10);
+  assert.equal(results[0].cacheRead, 50);
+  assert.ok(results[0].lastActiveAt > 0);
+});
+
+// ── zcode 收集器（需要 sqlite3 CLI）────────────────────────────────────────
+
+test("zcode collector reads model_usage aggregates", { skip: hasSqlite3() ? false : "sqlite3 CLI not available" }, () => {
+  const dbPath = join(dir, "zcode.db");
+  const cutoff = new Date(2026, 7, 1).getTime();
+  execFileSync("sqlite3", [dbPath, [
+    "CREATE TABLE model_usage (session_id text, model_id text, status text, started_at integer, input_tokens integer, output_tokens integer, cache_read_input_tokens integer, cache_creation_input_tokens integer);",
+    `INSERT INTO model_usage VALUES ('sess_z', 'glm-5', 'completed', ${cutoff + DAY}, 100, 50, 200, 10);`,
+    `INSERT INTO model_usage VALUES ('sess_z', 'glm-5', 'cancelled', ${cutoff + DAY + 1}, 30, 0, 0, 0);`,
+    `INSERT INTO model_usage VALUES ('sess_z', 'glm-5.5', 'completed', ${cutoff + DAY + 2}, 5, 5, 0, 0);`,
+    `INSERT INTO model_usage VALUES ('sess_old', 'glm-5', 'completed', ${cutoff - DAY}, 999, 999, 0, 0);`,
+    `INSERT INTO model_usage VALUES ('sess_zero', 'glm-5', 'completed', ${cutoff + DAY}, 0, 0, 0, 0);`
+  ].join(" ")]);
+  const results = collectZcodeUsage({ dbPath, cutoffMs: cutoff });
+  const glm5 = results.find((r) => r.model === "glm-5");
+  const glm55 = results.find((r) => r.model === "glm-5.5");
+  assert.deepEqual(glm5, {
+    sessionId: "sess_z", model: "glm-5",
+    input: 130, output: 50, cacheRead: 200, cacheCreation: 10,
+    lastActiveAt: cutoff + DAY + 1
+  });
+  assert.deepEqual(glm55, {
+    sessionId: "sess_z", model: "glm-5.5",
+    input: 5, output: 5, cacheRead: 0, cacheCreation: 0,
+    lastActiveAt: cutoff + DAY + 2
+  });
+  assert.equal(results.find((r) => r.sessionId === "sess_old"), undefined, "rows older than cutoff are excluded");
+  assert.equal(results.find((r) => r.sessionId === "sess_zero"), undefined, "all-zero rows are excluded");
+});
+
+// ── 服务编排：基线差分 + 所有权 ─────────────────────────────────────────────
+
+test("scanAll ingests once and stays idempotent across rescans", async () => {
+  const stats = fakeStats();
+  const svc = new UsageDiscoveryService({ statsService: stats, scanIntervalMs: 1e9, startDelayMs: 1e9 });
+  const zcodeRows = [
+    { sessionId: "s1", model: "glm-5", input: 100, output: 50, cacheRead: 0, cacheCreation: 0, lastActiveAt: 1700000000000 }
+  ];
+  svc._collectors = {
+    zcode: async () => zcodeRows,
+    opencode: async () => [{ sessionId: "s2", model: "m1", input: 10, output: 5, cacheRead: 0, cacheCreation: 0, lastActiveAt: 1700000000000 }],
+    claude: async () => []
+  };
+  await svc.scanAll();
+  assert.equal(stats.tokens.length, 2);
+  assert.ok(stats.tokens.every((r) => r.timestamp === 1700000000000), "historical timestamps preserved");
+  // 第二轮：同样的累计值 → 基线差分后无增量
+  await svc.scanAll();
+  assert.equal(stats.tokens.length, 2, "rescan with unchanged cumulative must not double count");
+  // 数据增长 → 只入账增量
+  zcodeRows[0].input = 150;
+  zcodeRows[0].output = 60;
+  await svc.scanAll();
+  assert.equal(stats.tokens.length, 3);
+  const delta = stats.tokens[2];
+  assert.equal(delta.inputTokens, 50);
+  assert.equal(delta.outputTokens, 10);
+  svc.stop();
+});
+
+test("scanAll passes the owned-session set to the claude collector", async () => {
+  const stats = fakeStats({
+    tokens: [{ tool: "claude", sessionId: "owned", inputTokens: 10, outputTokens: 0, cacheReadTokens: 0, cacheCreationTokens: 0, model: "claude-x" }]
+  });
+  const svc = new UsageDiscoveryService({ statsService: stats, scanIntervalMs: 1e9, startDelayMs: 1e9 });
+  let seenOwned;
+  svc._collectors = {
+    zcode: async () => [],
+    opencode: async () => [],
+    claude: async (cutoffMs, ownedSessions) => {
+      seenOwned = ownedSessions;
+      // 所有权过滤本身在真实 collectClaudeUsage 内部（已有单测覆盖），
+      // 这里验证 scanAll 把已入账集合正确传进来，且自由会话正常入账
+      return [{ sessionId: "sess-free", model: "claude-x", input: 100, output: 0, cacheRead: 0, cacheCreation: 0, lastActiveAt: 1 }];
+    }
+  };
+  await svc.scanAll();
+  assert.ok(seenOwned.has("owned"), "claude collector must receive the owned-session set");
+  assert.equal(stats.tokens.length, 2);
+  assert.equal(stats.tokens[1].sessionId, "sess-free");
+  svc.stop();
+});
+
+test("scanAll survives a failing source without blocking others", async () => {
+  const stats = fakeStats();
+  const svc = new UsageDiscoveryService({ statsService: stats, scanIntervalMs: 1e9, startDelayMs: 1e9 });
+  svc._collectors = {
+    zcode: async () => { throw new Error("boom"); },
+    opencode: async () => [{ sessionId: "s2", model: "m1", input: 1, output: 1, cacheRead: 0, cacheCreation: 0, lastActiveAt: 1 }],
+    claude: async () => []
+  };
+  await svc.scanAll();
+  assert.equal(stats.tokens.length, 1, "other sources still ingest after one fails");
+  svc.stop();
+});
+
+// ── usage-service：按 Agent 会话数 ──────────────────────────────────────────
+
+test("usage summary counts sessions per agent", () => {
+  const stats = fakeStats();
+  const usage = new UsageService({ statsService: stats, now: () => new Date(2026, 7, 28, 12).getTime() });
+  const day = new Date(2026, 7, 28, 9).getTime();
+  stats.recordSession("opencode", day, day + 1000, "ses_a");
+  stats.recordSession("opencode", day, day + 2000, "ses_b");
+  stats.recordSession("codex", day, day + 3000, "ses_c");
+  stats.recordToken("opencode", "ses_a", 10, 5, 0, 0, null, "m1", day);
+  const summary = usage.getUsageSummary({ days: 7 });
+  const byAgent = Object.fromEntries(summary.byAgent.map((r) => [r.tool, r]));
+  assert.equal(byAgent.opencode.sessionCount, 2);
+  assert.equal(byAgent.codex.sessionCount, 1);
+  assert.equal(byAgent.opencode.inputTokens, 10);
+});


### PR DESCRIPTION
Refs #90（本 PR 先落 P0 部分，剩余适配器继续在该 issue 跟踪）

## 问题

用量看板只统计 claude / codex / gemini / hermes 四个 tool 的 token——token 采集入口 `collectAndReportTokens` 的 switch 只处理这四个，其余 13 个已注册适配器（zcode、opencode、cursor、kimi 等）会话能上岛但用量永远不入账；claude / gemini 还依赖 hook 携带 `transcript_path`，缺失即漏记（截图里 7 天 266 会话但「按 Agent」只有 Codex 一行）。详见 #90。

## 方案：参考 agentsview 的会话目录发现模式

[kenn-io/agentsview](https://github.com/kenn-io/agentsview) 不依赖 hook，为每个客户端维护「会话数据目录映射」主动发现用量。本 PR 新增与 hook 通道并行的 `UsageDiscoveryService`（`src/main/usage-discovery.cjs`），首批覆盖三个数据源（格式均已在真机实证）：

| 来源 | 数据源 | 机制 |
| --- | --- | --- |
| zcode | `~/.zcode/cli/db/db.sqlite` `model_usage` 表 | sqlite3 CLI 直读（沿用 hermes 模式），按 (session, model) 聚合 |
| opencode | `~/.local/share/opencode/storage/message/` | assistant 消息 `tokens` 字段，目录 mtime 记忆跳过未变化会话 |
| claude | `~/.claude/projects/` | 目录发现 + 复用现有 `parseClaudeTokens`，修复 hook 不带 transcript_path / WorkIsland 启动前已完成会话的漏记 |

## 入账规则

- **基线差分**：每轮扫描从 StatsService 已入账记录重建基线（按 tool+session+model），只入账增量；重复扫描、重启回填不重复计数
- **双通道所有权**：claude 会话已被任何通道入账过即跳过，hook 通道与本通道不对同一会话重复计费
- **历史时间戳**：`recordToken` 新增可选 `timestamp` 参数（向后兼容），回填的历史用量按真实时间落到对应日期，而非全部堆到回填当天
- **保留窗口**：与 StatsService 保留期一致（默认 90 天），超窗旧数据不扫
- **边界**：只读 token 计数 / 时间 / 模型标识，不读 prompt 正文与密钥（ADR-0004）

## 附带修复

- 用量看板「按 Agent」的会话数恒为 0（`usage-service` 只把 sessionCount 记进 byDay，没进 byAgent）
- `AGENT_TOOL_LABELS` 补 `zcode: "ZCode"` 显示名

## 接线与测试

- `app-coordinator` 启动时延迟 8s 首扫，之后每 10 分钟一轮；失败不影响启动路径，stop() 随生命周期清理
- 新增 `tests/usage-discovery.test.mjs`（11 例）：三个收集器格式解析、mtime 记忆、基线差分幂等、claude 所有权、来源失败隔离、recordToken 时间戳、按 Agent 会话数
- 全量 `npm run test:unit` 468/468 通过

## 真机验证（本机，2026-09-03）

- 首扫 388ms：zcode 入账 96 条（10.2 亿 tokens，GLM 系列），claude 补上 32 条 hook 漏掉的会话（5.4 亿 tokens），重扫零新增
- 基线差分与所有权规则工作正常

## 后续（issue #90 的 P1/P2）

- P1：按 agentsview 矩阵逐个补 qwen / iflow / kimi / cursor / copilot-cli / goose 等收集器（每个以真实格式验证后并入）
- P2：claude / gemini 从「sessionCompleted 一次」改为增量采集，消除长会话中途漏记

