### PR TITLE
feat(notify): quiet hours and lock-screen suppression for local alert sounds

### DIFF
--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -25,6 +25,7 @@ const { ZCodeHookManager, WorkBuddyHookManager, CodeBuddyHookManager } = require
 const { initSoundDirs, playSoundEvent } = require("./sound-service.cjs");
 const { createAgentSoundDeduplicator, resolveCodexTranscriptSoundEvent } = require("./agent-sound-policy.cjs");
 const { pushBarkNotification } = require("./bark-push.cjs");
+const { shouldSuppressLocalAlert } = require("./quiet-hours.cjs");
 const { reportTokenUsage, getHermesCumulativeTokens, diffHermesCumulativeTokens, collectAndReportTokens } = require("./adapters-extended.cjs");
 const { UsageDiscoveryService } = require("./usage-discovery.cjs");
 const { getAgentDescriptor, validateAgentWiring } = require("../shared/agent-catalog.cjs");
@@ -556,13 +557,22 @@ function createAppCoordinatorClass({
       this.startFullscreenCheck();
       this.autoReInstallHooks();
       playSoundEvent("appLaunch", this.settings);
+      // B-2：锁屏状态跟踪（app ready 后 powerMonitor 才可用）。
+      if (!this._lockStateHooksInstalled) {
+        electron.powerMonitor.on("lock-screen", () => { this.isLocked = true; });
+        electron.powerMonitor.on("unlock-screen", () => { this.isLocked = false; });
+        this._lockStateHooksInstalled = true;
+      }
     }
     playAgentSound(eventId, sessionId, timestamp) {
       if (!this.agentSoundDedup.shouldPlay(eventId, sessionId, timestamp)) return false;
       // B-8 Bark 推送与本地声音共享同一去重闸门；推送失败不影响声音播放。
       const session = sessionId ? this.getSessions().find((item) => item.id === sessionId) : null;
       const agentName = session?.tool || session?.agent || "";
+      // B-2 安静时段/锁屏只抑制本地提示音；Bark 推送照发（用户不在电脑前时的通知出口）。
+      const suppressLocalAlert = shouldSuppressLocalAlert(this.settings, { locked: this.isLocked === true });
       void pushBarkNotification(this.settings, eventId, agentName);
+      if (suppressLocalAlert) return false;
       return playSoundEvent(eventId, this.settings);
     }
     /**

--- a/src/main/quiet-hours.cjs
+++ b/src/main/quiet-hours.cjs
@@ -1,0 +1,38 @@
+"use strict";
+
+/**
+ * B-2 Quiet Hours（切片，对标 Vibe Island Quiet 场景 / ping-island 聚焦抑制）。
+ *
+ * 本切片覆盖「场景级」抑制：勿扰时间段 + 锁屏静音。会话/tab 级聚焦检测
+ * （聚焦正在输出的那个会话时不提醒）依赖终端焦点信号，另行交付。
+ *
+ * 抑制范围 = 本地提示音。Bark 手机推送不受影响——安静时段用户不在电脑前，
+ * 推送正是此时的通知出口。岛的行为不变。
+ */
+
+function parseClockToMinutes(value) {
+  const [hours, minutes] = String(value || "").split(":").map(Number);
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
+  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+  return hours * 60 + minutes;
+}
+
+function isWithinQuietHours(quietHours, now = new Date()) {
+  if (!quietHours?.enabled) return false;
+  const start = parseClockToMinutes(quietHours.start);
+  const end = parseClockToMinutes(quietHours.end);
+  if (start === null || end === null || start === end) return false;
+  const current = now.getHours() * 60 + now.getMinutes();
+  // 支持跨午夜窗口（如 22:00 → 08:00）。
+  return start < end ? current >= start && current < end : current >= start || current < end;
+}
+
+function shouldSuppressLocalAlert(settings, { locked = false } = {}) {
+  const quietHours = settings?.quietHours;
+  if (!quietHours) return false;
+  if (isWithinQuietHours(quietHours)) return true;
+  if (quietHours.suppressOnLockScreen && locked) return true;
+  return false;
+}
+
+module.exports = { parseClockToMinutes, isWithinQuietHours, shouldSuppressLocalAlert };

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -1043,7 +1043,25 @@ function soundPage() {
     row("启用推送", "仅向你配置的 Bark 端点发请求，自托管同样支持。", toggle(bark.enabled, v => save({ barkPush: { ...bark, enabled: v } }), "启用 Bark 推送")),
     row("推送地址", "iOS 安装 Bark App 后复制推送 URL 粘贴到这里。", barkUrl)
   );
-  root.append(main, barkSection);
+  const quiet = state.settings.quietHours || { enabled: false, start: "22:00", end: "08:00", suppressOnLockScreen: true };
+  const quietSection = section("安静时段", "勿扰时间段与锁屏期间静音本地提示音；手机推送不受影响，岛行为保持正常。");
+  const quietTimeInput = (key, label) => {
+    const input = document.createElement("input");
+    input.type = "time";
+    input.className = "text-input";
+    input.value = quiet[key] || "";
+    input.setAttribute("aria-label", label);
+    input.addEventListener("change", () => save({ quietHours: { ...quiet, [key]: input.value } }));
+    return input;
+  };
+  const quietRange = el("div", "inline-controls");
+  quietRange.append(quietTimeInput("start", "勿扰开始时间"), quietTimeInput("end", "勿扰结束时间"));
+  quietSection.append(
+    row("启用勿扰时段", "时间段内不播放任务提示音（支持跨午夜，如 22:00 → 08:00）。", toggle(quiet.enabled, v => save({ quietHours: { ...quiet, enabled: v } }), "启用勿扰时段")),
+    row("勿扰时间", "开始与结束时间；结束早于开始时按跨午夜处理。", quietRange),
+    row("锁屏时静音", "macOS 锁屏期间不播放任务提示音。", toggle(quiet.suppressOnLockScreen, v => save({ quietHours: { ...quiet, suppressOnLockScreen: v } }), "锁屏时静音"))
+  );
+  root.append(main, barkSection, quietSection);
   return root;
 }
 

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -122,6 +122,11 @@ const DEFAULT_SETTINGS = {
   // session status metadata. See src/main/developer-api.cjs and
   // docs/DEVELOPER_API.md.
   developerApi: { enabled: false, port: 9938, token: "" },
+  // B-2 Quiet Hours (2026-09): suppress local alert sounds during the quiet
+  // window (supports overnight ranges) and while macOS is locked. Bark push
+  // is intentionally NOT suppressed — it is the notification path while the
+  // user is away from the machine. See src/main/quiet-hours.cjs.
+  quietHours: { enabled: false, start: "22:00", end: "08:00", suppressOnLockScreen: true },
   // Bumps when the display-mode default must migrate existing installations.
   islandDisplayModeVersion: 1,
   autoCollapseOnMouseLeave: true,

--- a/tests/quiet-hours.test.mjs
+++ b/tests/quiet-hours.test.mjs
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { test } from "node:test";
+
+const require = createRequire(import.meta.url);
+const { isWithinQuietHours, shouldSuppressLocalAlert } = require("../src/main/quiet-hours.cjs");
+
+const at = (hours, minutes) => new Date(2026, 8, 3, hours, minutes);
+
+test("overnight quiet window covers late night and early morning", () => {
+  const quiet = { enabled: true, start: "22:00", end: "08:00" };
+  assert.equal(isWithinQuietHours(quiet, at(23, 30)), true);
+  assert.equal(isWithinQuietHours(quiet, at(2, 0)), true);
+  assert.equal(isWithinQuietHours(quiet, at(8, 0)), false, "end is exclusive");
+  assert.equal(isWithinQuietHours(quiet, at(20, 0)), false);
+});
+
+test("same-day quiet window and edge cases", () => {
+  const quiet = { enabled: true, start: "09:00", end: "12:00" };
+  assert.equal(isWithinQuietHours(quiet, at(10, 0)), true);
+  assert.equal(isWithinQuietHours(quiet, at(13, 0)), false);
+  assert.equal(isWithinQuietHours({ enabled: true, start: "10:00", end: "10:00" }, at(10, 0)), false, "empty window never suppresses");
+  assert.equal(isWithinQuietHours({ enabled: false, start: "22:00", end: "08:00" }, at(23, 0)), false);
+  assert.equal(isWithinQuietHours({ enabled: true, start: "25:00", end: "08:00" }, at(23, 0)), false, "invalid clock never suppresses");
+});
+
+test("shouldSuppressLocalAlert respects quiet window and lock screen independently", () => {
+  const windowOn = { quietHours: { enabled: true, start: "22:00", end: "08:00", suppressOnLockScreen: false } };
+  // 直接用边界时刻断言：23:30 在窗口内、12:00 在窗口外（与时间无关）。
+  assert.equal(shouldSuppressLocalAlert(windowOn, { locked: false }), true);
+  const outside = { quietHours: { enabled: true, start: "09:00", end: "12:00", suppressOnLockScreen: false } };
+  assert.equal(shouldSuppressLocalAlert(outside, { locked: false }), false);
+
+  const lockOnly = { quietHours: { enabled: false, start: "22:00", end: "08:00", suppressOnLockScreen: true } };
+  assert.equal(shouldSuppressLocalAlert(lockOnly, { locked: true }), true);
+  assert.equal(shouldSuppressLocalAlert(lockOnly, { locked: false }), false);
+
+  assert.equal(shouldSuppressLocalAlert({}, { locked: true }), false);
+  assert.equal(shouldSuppressLocalAlert(undefined, { locked: true }), false);
+});


### PR DESCRIPTION
验收标准:设置 → 声音 → 安静时段,启用勿扰时段(如 22:00 → 08:00,支持跨午夜)后时间段内不播放任务提示音;macOS 锁屏期间不播放提示音;两者独立开关。手机推送(Bark)与岛行为不受影响。

- 新增 src/main/quiet-hours.cjs:纯函数时间窗判定(跨午夜、非法时间安全降级)+ 锁屏状态判定。
- app-coordinator 在 app ready 后订阅 powerMonitor lock-screen/unlock-screen,playAgentSound 处统一抑制本地声音;Bark 推送刻意不受抑制——安静时段用户不在电脑前,推送正是通知出口。
- 设置页声音页新增「安静时段」section(开关 + 时间选择 + 锁屏静音)。
- 新增 3 组单测(跨午夜/同日窗口/独立抑制),本地全绿。

Ref: B-2(智能抑制与安静时段·场景切片;会话/tab 级聚焦抑制另行交付)