### PR TITLE
fix(win): 应用内更新门控到 macOS，Windows 不再误报 DMG 更新

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,11 +214,11 @@ jobs:
           body: |
             ⚠️ Windows Alpha 内测版本
 
-            这是 WorkIsland 的首个 Windows 桌面版本（Alpha 级别，正在测试与内测中）。产品可能存在问题，不建议作为日常主力工具使用；遇到 Bug 请通过 [Issue](https://github.com/qianzhu18/workisland/issues) 或内测群反馈。
+            Windows 桌面版（Alpha 级别，正在测试与内测中），与 macOS 版同源同版本号，功能保持同步。产品可能存在问题，不建议作为日常主力工具使用；遇到 Bug 请通过 [Issue](https://github.com/qianzhu18/workisland/issues) 或内测群反馈。
 
             - 支持 Windows 11 x64，提供 NSIS 安装包与便携版
             - 安装包未签名，浏览器与 Windows 可能拦截，属正常现象：
               1. 下载阶段：Edge/Chrome 提示「不常用下载/已阻止」时，选择「保留」/「仍要下载」（Edge：下载列表 → ⋯ → 保留）
               2. 运行阶段：SmartScreen 蓝色弹窗 → 「更多信息」→ 「仍要运行」
-            - 已知限制：无法按 WT_SESSION 精确切换 Windows Terminal 标签页；不支持 Windows 10 / 32 位；暂无自动更新
-            - macOS 稳定版请前往 [v3.0.0](https://github.com/qianzhu18/workisland/releases/latest)
+            - 已知限制：无法按 WT_SESSION 精确切换 Windows Terminal 标签页；不支持 Windows 10 / 32 位；暂无自动更新（应用内更新入口仅对 macOS 生效）
+            - macOS 版请前往 [Releases](https://github.com/qianzhu18/workisland/releases/latest)

--- a/.github/workflows/windows-smoke.yml
+++ b/.github/workflows/windows-smoke.yml
@@ -7,6 +7,16 @@ on:
   push:
     branches:
       - "windows/**"
+  # 之前只监听 windows/** 分支（该分支已停用），workflow 因此长期静默；
+  # 改为凡是触碰 Windows 运行面（主进程/打包脚本/依赖/workflow 本身）的 PR
+  # 都在真机 runner 上打包并启动便携版自测。
+  pull_request:
+    paths:
+      - "src/**"
+      - "scripts/smoke-win-packaged.mjs"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/windows-smoke.yml"
 
 permissions:
   contents: read

--- a/src/main/update-service.cjs
+++ b/src/main/update-service.cjs
@@ -290,6 +290,7 @@ function createUpdateService({
   quit = () => app.quit?.(),
   openPath = (value) => shell?.openPath?.(value),
   arch = process.arch,
+  platform = process.platform,
   getInstallDir
 } = {}) {
   if (!app || typeof app.getVersion !== "function") throw new TypeError("app.getVersion is required");
@@ -299,6 +300,10 @@ function createUpdateService({
   let initialTimer = null;
   let intervalTimer = null;
   let updateState = { phase: "idle", progress: null, release: null, error: null, downloadedPath: null };
+
+  // 更新链路只覆盖 macOS（DMG 下载 + hdiutil 安装）；其他平台必须保持
+  // unavailable，否则 Windows 会把 releases/latest 的 DMG 当成可用更新（issue #96）。
+  const isSupportedPlatform = platform === "darwin";
 
   function currentVersion() {
     return String(app.getVersion());
@@ -419,6 +424,9 @@ function createUpdateService({
   }
 
   function check({ force = false, notify = true } = {}) {
+    if (!isSupportedPlatform) {
+      return Promise.resolve({ status: "unavailable", reason: "unsupported-platform", currentVersion: currentVersion() });
+    }
     if (isDevelopment()) {
       return Promise.resolve({ status: "disabled", reason: "development", currentVersion: currentVersion() });
     }
@@ -439,6 +447,7 @@ function createUpdateService({
 
   // 把更新下载到本地并做 SHA-256 校验，完成后进入 ready 阶段等待安装。
   async function download() {
+    if (!isSupportedPlatform) return { ...getUpdateState(), error: "当前平台暂不支持应用内更新，请前往发布页手动下载。" };
     if (isDevelopment()) return { ...getUpdateState(), error: "开发模式下不执行更新下载" };
     if (updateState.phase === "downloading" || updateState.phase === "ready" || updateState.phase === "installing") {
       return getUpdateState();
@@ -493,6 +502,7 @@ function createUpdateService({
   // 安装已下载的更新：挂载 DMG、替换当前安装目录内的应用并重启。
   // 任何一步失败都会回退为打开 DMG，让用户手动拖拽安装。
   async function install() {
+    if (!isSupportedPlatform) return { ...getUpdateState(), error: "当前平台暂不支持应用内更新，请前往发布页手动下载。" };
     if (isDevelopment()) return { ...getUpdateState(), error: "开发模式下不执行更新安装" };
     if (updateState.phase !== "ready" || !updateState.downloadedPath) {
       return getUpdateState();
@@ -523,7 +533,7 @@ function createUpdateService({
   }
 
   function start() {
-    if (isDevelopment() || initialTimer || intervalTimer) return;
+    if (!isSupportedPlatform || isDevelopment() || initialTimer || intervalTimer) return;
     initialTimer = setTimeout(() => {
       initialTimer = null;
       void check().catch(() => {});

--- a/tests/update-service.test.mjs
+++ b/tests/update-service.test.mjs
@@ -37,6 +37,7 @@ test("update service reports and notifies about a newer stable release once", as
     show() { shown.push(this); }
   }
   const service = createUpdateService({
+    platform: "darwin",
     app: makeApp("0.2.0"),
     shell: { openExternal: (url) => opened.push(url) },
     notificationClass: FakeNotification,
@@ -69,6 +70,7 @@ test("update service reports and notifies about a newer stable release once", as
 test("development builds never contact the release endpoint", async () => {
   let fetchCount = 0;
   const service = createUpdateService({
+    platform: "darwin",
     app: makeApp("0.2.0", false),
     userDataPath: mkdtempSync(join(tmpdir(), "workisland-update-dev-")),
     fetchImpl: async () => {
@@ -162,6 +164,7 @@ async function prepareDownloadedService({ userDataPath, runner, getInstallDir, r
   const dmgBytes = Buffer.from("12345678", "utf8");
   const dmgSha256 = createHash("sha256").update(dmgBytes).digest("hex");
   const service = createUpdateService({
+    platform: "darwin",
     app: makeApp("0.9.0"),
     userDataPath,
     arch: "arm64",
@@ -200,6 +203,7 @@ test("checksum mismatch aborts the download with an error state", async () => {
   const dmgBytes = Buffer.from("12345678", "utf8");
   const payload = releasePayload();
   const service = createUpdateService({
+    platform: "darwin",
     app: makeApp("0.9.0"),
     userDataPath,
     arch: "arm64",
@@ -222,6 +226,7 @@ test("download failure surfaces an error state with the message", async () => {
   const userDataPath = mkdtempSync(join(tmpdir(), "workisland-update-dl-err-"));
   const payload = releasePayload();
   const service = createUpdateService({
+    platform: "darwin",
     app: makeApp("0.9.0"),
     userDataPath,
     arch: "arm64",

--- a/tests/windows-platform.test.mjs
+++ b/tests/windows-platform.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
 import { createRequire } from "node:module";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test } from "node:test";
 
 const require = createRequire(import.meta.url);
@@ -9,6 +12,7 @@ const { wrapWithInstallCheck } = require("../src/main/hook-shared.cjs");
 const { enrichTerminalContext } = require("../src/island/hooks-cli/index.cjs");
 const { createWindowsNavigation, resolveWindowsApp } = require("../src/main/windows-navigation.cjs");
 const { parseWindowsTasklist } = require("../src/main/process-monitor.cjs");
+const { createUpdateService } = require("../src/main/update-service.cjs");
 
 test("Windows bridge uses a stable per-user named pipe", () => {
   const first = getSocketPath({}, "C:\\Users\\Ada", "win32");
@@ -91,4 +95,38 @@ test("Windows navigation activates existing windows and never spawns a bare term
 test("Windows process discovery reads tasklist CSV without localized columns", () => {
   const names = parseWindowsTasklist('"Cursor.exe","1200","Console","1","80,000 K"\r\n"WindowsTerminal.exe","1400","Console","1","90,000 K"');
   assert.deepEqual([...names], ["cursor.exe", "windowsterminal.exe"]);
+});
+
+test("Windows update service never offers the macOS DMG as an update (issue #96)", async () => {
+  const fetchCalls = [];
+  const service = createUpdateService({
+    app: { isPackaged: true, getVersion: () => "1.0.0-alpha.1" },
+    platform: "win32",
+    userDataPath: mkdtempSync(join(tmpdir(), "workisland-win-update-")),
+    fetchImpl: async (url) => {
+      fetchCalls.push(url);
+      return {
+        ok: true,
+        json: async () => ({
+          tag_name: "v1.2.0",
+          name: "WorkIsland 1.2.0",
+          html_url: "https://github.com/qianzhu18/workisland/releases/tag/v1.2.0",
+          prerelease: false,
+          assets: [{ name: "WorkIsland-1.2.0-arm64.dmg", browser_download_url: "https://example.com/WorkIsland-1.2.0-arm64.dmg", size: 1024 }]
+        })
+      };
+    },
+    logger: { warn() {} }
+  });
+
+  const result = await service.check({ force: true });
+  assert.equal(result.status, "unavailable");
+  assert.equal(result.reason, "unsupported-platform");
+  assert.equal(fetchCalls.length, 0, "must not poll GitHub releases on Windows");
+
+  service.start();
+  assert.equal(service.getUpdateState().phase, "idle");
+
+  assert.match((await service.download()).error, /暂不支持应用内更新/);
+  assert.match((await service.install()).error, /暂不支持应用内更新/);
 });


### PR DESCRIPTION
Fixes #96

## 改动

1. **update-service 平台门控**：新增 `platform` 选项（默认 `process.platform`），非 darwin 时：
   - `check()` 返回 `{ status: "unavailable", reason: "unsupported-platform" }`，**不发起任何网络请求**；
   - `start()` 不排程定时检查；
   - `download()/install()` 直接拒绝并提示手动下载。
2. **回归测试**：`windows-platform.test.mjs` 新增用例，验证 win32 下服务不可用且零网络调用（避免再回退）。
3. **release.yml Windows 发布说明**：移除过时的「macOS 稳定版请前往 v3.0.0」（版本重置前的旧指引），改为 Releases/latest；说明与 macOS 同源同步、应用内更新仅对 macOS 生效。
4. **windows-smoke.yml 复活**：之前只监听已停用的 `windows/**` 分支，自 8/28 起再未运行；补上按路径（`src/**`、打包脚本、依赖、workflow 本身）触发的 `pull_request` 运行，Windows 运行面的改动重新获得真机打包 + 自退出验证。

## 验证

- 本地 `npm run test:unit`：463/463 通过（基线 462 + 新增 1）；
- push 后 CI 的 `check.yml → windows-x64` 与新触发的 `windows-smoke` 将在真机 runner 上验证（含打包便携版并验证自退出）。