### PR TITLE
fix(nav): 会话回源宿主窗口，tmux pane 参与定位（#99）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workisland",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workisland",
-      "version": "1.3.0-beta.1",
+      "version": "1.3.0-beta.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workisland",
   "productName": "WorkIsland",
-  "version": "1.3.0-beta.1",
+  "version": "1.3.0-beta.2",
   "description": "macOS 与 Windows 本地 Work Agent 工作状态与注意力路由器",
   "private": true,
   "main": "./src/main/index.cjs",

--- a/src/island/hooks-cli/index.cjs
+++ b/src/island/hooks-cli/index.cjs
@@ -9,12 +9,15 @@ const { getSocketPath } = require("../../main/bridge-protocol.cjs");
 
 const TERMINAL_APP_ALIASES = Object.freeze({
   apple_terminal: "Terminal",
+  terminal: "Terminal",
   "iterm.app": "iTerm",
   iterm: "iTerm",
   warp: "Warp",
   warpterminal: "Warp",
   vscode: "VS Code",
   "vs code": "VS Code",
+  code: "VS Code",
+  "visual studio code": "VS Code",
   ghostty: "Ghostty",
   wezterm: "WezTerm",
   alacritty: "Alacritty",
@@ -27,10 +30,19 @@ const TERMINAL_APP_ALIASES = Object.freeze({
   pwsh: "PowerShell"
 });
 
+// `terminal_app` 有时来自 Agent 自己的兜底值（例如 Codex），它描述的是谁在
+// 执行任务，而不是用户眼前真正承载会话的窗口。Agent 身份已经由 hook source
+// 保存；这里把这类值降级为回源的最后兜底，让 IDE / 终端宿主优先。
+const AGENT_RUNTIME_APPS = new Set(["codex", "claude", "opencode"]);
+
 function canonicalTerminalApp(value) {
   if (typeof value !== "string" || !value.trim()) return undefined;
   const normalized = value.trim().toLowerCase();
   return TERMINAL_APP_ALIASES[normalized] || value.trim();
+}
+
+function isAgentRuntimeApp(value) {
+  return typeof value === "string" && AGENT_RUNTIME_APPS.has(value.trim().toLowerCase());
 }
 
 // 顺序有意义：更具体的放前面，先匹配到的先返回。
@@ -111,12 +123,20 @@ function detectDesktopHostApp() {
  */
 function enrichTerminalContext(payload, env = process.env) {
   const next = payload;
-  const terminalApp = canonicalTerminalApp(next.terminal_app)
-    || canonicalTerminalApp(env.TERM_PROGRAM)
+  const explicitApp = canonicalTerminalApp(next.terminal_app);
+  const inheritedApp = canonicalTerminalApp(env.TERM_PROGRAM)
     || (env.WT_SESSION ? "Windows Terminal" : undefined)
-    || (env.WARP_CLI_AGENT_PROTOCOL_VERSION ? "Warp" : undefined)
-    || detectDesktopHostApp();
-  if (terminalApp && !next.terminal_app) next.terminal_app = terminalApp;
+    || (env.WARP_CLI_AGENT_PROTOCOL_VERSION ? "Warp" : undefined);
+  // 只有没有明确宿主，或上游给的是 Agent 名称时才检查父进程树。这样既避免
+  // 每个 hook 都跑 ps，也能让 VS Code 插件中的 Codex 回到 VS Code，而非 Codex。
+  const terminalApp = explicitApp && !isAgentRuntimeApp(explicitApp)
+    ? explicitApp
+    : inheritedApp || detectDesktopHostApp() || explicitApp;
+  // 显式宿主元数据保留上游原样（例如 iTerm.app）；仅在缺失或它实际是
+  // Agent 兜底名称时才以检测到的宿主覆盖。
+  if (terminalApp && (!next.terminal_app || isAgentRuntimeApp(next.terminal_app))) {
+    next.terminal_app = terminalApp;
+  }
 
   const sessionId = env.WT_SESSION
     || env.WARP_SESSION_ID
@@ -131,6 +151,11 @@ function enrichTerminalContext(payload, env = process.env) {
   const paneId = env.WARP_PANE_UUID || env.WARP_PANE_ID;
   if (paneId && !next.warp_pane_uuid) next.warp_pane_uuid = paneId;
   if (env.TMUX_PANE && !next.tmux_target) next.tmux_target = env.TMUX_PANE;
+  // tmux pane 只负责内部位置；仍需记录它显示在哪个 IDE / 终端宿主中，才能把
+  // 对应窗口带到前台。不要把 Codex 这类 Agent 名称误写成宿主。
+  if (next.tmux_target && !next.tmux_outer_host && terminalApp && !isAgentRuntimeApp(terminalApp)) {
+    next.tmux_outer_host = terminalApp;
+  }
   return next;
 }
 
@@ -249,6 +274,7 @@ module.exports = {
   detectDesktopHostFromProcessList,
   enrichTerminalContext,
   enrichPayload,
+  isAgentRuntimeApp,
   resolveHookSource,
   run
 };

--- a/src/main/adapters-cli.cjs
+++ b/src/main/adapters-cli.cjs
@@ -1771,8 +1771,11 @@ class CodexAdapter {
     const metaTerminalApp = resolveCodexTerminalAppFromSessionMeta(
       payload._session_meta
     );
+    // `Codex` 是 Agent 身份而不是可靠的窗口位置。VS Code 插件会话带有
+    // transcript source 时，优先使用该宿主信息；真实终端/IDE 元数据仍优先。
+    const isAgentFallback = terminalApp.toLowerCase() === "codex";
     ctx.updateJumpTarget(sessionId, tool, {
-      terminal_app: terminalApp || metaTerminalApp || "Codex"
+      terminal_app: isAgentFallback ? metaTerminalApp || terminalApp : terminalApp || metaTerminalApp || "Codex"
     });
   }
 }

--- a/src/main/terminal-navigation.cjs
+++ b/src/main/terminal-navigation.cjs
@@ -11,7 +11,14 @@ const fs__namespace = fs;
 const path__namespace = path;
 const os__namespace = os;
 
-function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform = process.platform, windowsNavigation = createWindowsNavigation({ logger: log }) }) {
+function createTerminalNavigation({
+  isPluginAgentTool,
+  PLUGIN_BY_TOOL,
+  platform = process.platform,
+  windowsNavigation = createWindowsNavigation({ logger: log }),
+  execFile = child_process.execFile,
+  resolveTmuxBinary: resolveTmuxBinaryOverride
+}) {
   const COMMON_TMUX_PATHS = ["/opt/homebrew/bin/tmux", "/usr/local/bin/tmux"];
   function firstAbsoluteLine(stdout) {
     const text = String(stdout ?? "");
@@ -29,6 +36,7 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
     return result.status === 0 ? firstAbsoluteLine(result.stdout) : null;
   }
   function resolveTmuxBinary() {
+    if (typeof resolveTmuxBinaryOverride === "function") return resolveTmuxBinaryOverride();
     const override = process.env.FLUX_TMUX_BIN?.trim();
     if (override && path.isAbsolute(override)) return override;
     const fromBash = lookupTmuxWithShell("/bin/bash");
@@ -49,7 +57,7 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
     }
     return `${tmuxBin} attach -t "${escapeDoubleQuotedArg(session)}"`;
   }
-  const execFileAsync$6 = util.promisify(child_process.execFile);
+  const execFileAsync$6 = util.promisify(execFile);
   const CURSOR_BUNDLE_ID = "com.todesktop.230313mzl4w4u92";
   const CODEX_APP_BUNDLE_ID = "com.openai.codex";
   const CLAUDE_DESKTOP_BUNDLE_ID = "com.anthropic.claudefordesktop";
@@ -206,6 +214,8 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
     // VS Code (TERM_PROGRAM=vscode → detectTerminalApp returns 'VS Code' → toLowerCase = 'vs code')
     "vs code": VSCODE_BUNDLE_ID,
     vscode: VSCODE_BUNDLE_ID,
+    "visual studio code": VSCODE_BUNDLE_ID,
+    code: VSCODE_BUNDLE_ID,
     // Antigravity（Google 的 VS Code fork）—— hooks-cli detectVscodeForkApp 命中
     // bundleId=com.google.antigravity 后返回 'Antigravity'，toLowerCase = 'antigravity'。
     antigravity: ANTIGRAVITY_BUNDLE_ID,
@@ -239,7 +249,7 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
         ids.push("com.opencode.app", "com.opencode.desktop", "ai.opencode.desktop");
       }
     }
-    if (session.jumpTarget && session.jumpTarget.app.toLowerCase() === "tmux" && !session.isRemote && session.jumpTarget.tmuxOuterHost) {
+    if (session.jumpTarget?.tmuxTarget && !session.isRemote && session.jumpTarget.tmuxOuterHost) {
       const outer = session.jumpTarget.tmuxOuterHost.toLowerCase();
       const id = TERMINAL_APP_TO_BUNDLE_ID[outer];
       if (id) ids.push(id);
@@ -247,34 +257,38 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
       if (jb) ids.push(...jb);
       if (outer.includes("trae")) ids.push(...TRAE_BUNDLE_IDS);
     }
+    // 回源与提醒抑制都必须服从已捕获的宿主窗口。Agent 身份只在完全没有
+    // jump target 时才作为兜底；否则 Codex 在 VS Code 内运行会错误地把
+    // "正在看 VS Code" 当成 "正在看 Codex"，反过来也会漏掉真正的提醒。
+    const hasHostTarget = Boolean(session.jumpTarget?.app?.trim());
     switch (session.tool) {
       case "cursor":
-        ids.push(CURSOR_BUNDLE_ID);
+        if (!hasHostTarget) ids.push(CURSOR_BUNDLE_ID);
         break;
       case "codex":
-        ids.push(CODEX_APP_BUNDLE_ID);
+        if (!hasHostTarget) ids.push(CODEX_APP_BUNDLE_ID);
         break;
       case "coco":
       case "trae":
-        ids.push(...TRAE_BUNDLE_IDS);
+        if (!hasHostTarget) ids.push(...TRAE_BUNDLE_IDS);
         break;
       case "claude":
-        ids.push(CLAUDE_DESKTOP_BUNDLE_ID);
+        if (!hasHostTarget) ids.push(CLAUDE_DESKTOP_BUNDLE_ID);
         break;
       case "opencode":
-        ids.push("com.opencode.app", "com.opencode.desktop", "ai.opencode.desktop");
+        if (!hasHostTarget) ids.push("com.opencode.app", "com.opencode.desktop", "ai.opencode.desktop");
         break;
       case "zcode":
-        ids.push("dev.zcode.app");
+        if (!hasHostTarget) ids.push("dev.zcode.app");
         break;
       case "workbuddy":
-        ids.push("com.workbuddy.workbuddy");
+        if (!hasHostTarget) ids.push("com.workbuddy.workbuddy");
         break;
       case "codebuddy":
-        ids.push("com.tencent.codebuddycn");
+        if (!hasHostTarget) ids.push("com.tencent.codebuddycn");
         break;
       default:
-        if (isPluginAgentTool(session.tool)) {
+        if (!hasHostTarget && isPluginAgentTool(session.tool)) {
           const plugin = PLUGIN_BY_TOOL.get(session.tool);
           if (plugin) ids.push(...plugin.suppressionBundleIds);
         }
@@ -1507,7 +1521,9 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
     return false;
   }
   async function jumpTmuxWithOuter(target) {
-    const outer = target.tmuxOuterHost?.trim();
+    // 新 payload 会显式带 tmuxOuterHost；旧版本只记录 app 时，仍把 app
+    // 视作可聚焦宿主，保持既有会话的回源能力。
+    const outer = target.tmuxOuterHost?.trim() || (target.app?.trim().toLowerCase() === "tmux" ? "" : target.app?.trim());
     const session = parseTmuxSessionName(target.tmuxTarget);
     const tmuxBin = resolveTmuxBinaryForJump("jumpTmuxWithOuter");
     if (!tmuxBin) {
@@ -1637,7 +1653,13 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
     }
     const app = target.app.toLowerCase();
     try {
-      if (app === "ghostty") {
+      // pane 是比 IDE/终端窗口更具体的位置；必须先选 tmux pane，再把对应
+      // 宿主窗口前置。此前 VS Code / Terminal 分支先返回，tmux_target 因而
+      // 从未参与定位。
+      if (target.tmuxTarget) {
+        log.debug("[TerminalJumpService] dispatch tmux branch, target:", JSON.stringify(target));
+        await jumpTmuxWithOuter(target);
+      } else if (app === "ghostty") {
         await jumpGhostty(target);
       } else if (app === "iterm2" || app === "iterm" || app === "iterm.app") {
         await jumpITerm2(target);
@@ -1665,7 +1687,7 @@ function createTerminalNavigation({ isPluginAgentTool, PLUGIN_BY_TOOL, platform 
         await jumpVSCodeFamily(target, "antigravity");
       } else if (app === "intellij idea" || app === "webstorm" || app === "pycharm" || app === "goland" || app === "clion" || app === "rubymine" || app === "phpstorm" || app === "rider" || app === "rustrover") {
         await jumpJetBrains(target, app);
-      } else if (app === "tmux" || target.tmuxTarget) {
+      } else if (app === "tmux") {
         log.debug("[TerminalJumpService] dispatch tmux branch, target:", JSON.stringify(target));
         await jumpTmuxWithOuter(target);
       } else {

--- a/tests/codex-adapter.test.mjs
+++ b/tests/codex-adapter.test.mjs
@@ -34,6 +34,19 @@ test("Codex prompt and stop hooks produce visible lifecycle events", () => {
   assert.ok(events.some((event) => event.type === "sessionCompleted" && event.sessionId === "codex-regression-session"));
 });
 
+test("Codex session metadata overrides its generic app fallback for IDE sessions", () => {
+  const targets = [];
+  const adapter = new CodexAdapter();
+  adapter.updateJumpTarget("codex-vscode", "codex", {
+    terminal_app: "Codex",
+    _session_meta: { source: "vscode" }
+  }, {
+    updateJumpTarget: (_sessionId, _tool, target) => targets.push(target)
+  });
+
+  assert.deepEqual(targets, [{ terminal_app: "VS Code" }]);
+});
+
 test("Claude attention notifications trigger one reminder sound per turn", () => {
   const sounds = [];
   const adapter = new ClaudeAdapter();

--- a/tests/warp-claude-hook.test.mjs
+++ b/tests/warp-claude-hook.test.mjs
@@ -34,6 +34,16 @@ test("explicit hook metadata wins over inherited terminal environment", () => {
   assert.equal(payload.terminal_session_id, "explicit");
 });
 
+test("an Agent fallback is replaced by the actual VS Code host", () => {
+  const payload = enrichTerminalContext({ terminal_app: "Codex" }, {
+    TERM_PROGRAM: "vscode",
+    TMUX_PANE: "project:3.1"
+  });
+  assert.equal(payload.terminal_app, "VS Code");
+  assert.equal(payload.tmux_target, "project:3.1");
+  assert.equal(payload.tmux_outer_host, "VS Code");
+});
+
 test("desktop hook process trees distinguish CodeBuddy from WorkBuddy", () => {
   const processList = [
     "600 1 /Applications/CodeBuddy CN.app/Contents/MacOS/Electron",
@@ -92,6 +102,39 @@ test("Claude Code and Codex resolve Warp and Terminal bundle IDs for source jump
     tool: "workbuddy",
     jumpTarget: { app: "CodeBuddy CN" }
   }).includes("com.tencent.codebuddycn"));
+  const vscodeCodexBundles = navigation.getSessionBundleIds({
+    tool: "codex",
+    jumpTarget: { app: "VS Code" }
+  });
+  assert.deepEqual(vscodeCodexBundles, ["com.microsoft.VSCode"]);
+});
+
+test("tmux pane targeting takes precedence over its VS Code host", async () => {
+  const calls = [];
+  const navigation = createTerminalNavigation({
+    isPluginAgentTool: () => false,
+    PLUGIN_BY_TOOL: new Map(),
+    platform: "darwin",
+    resolveTmuxBinary: () => "/tmp/tmux",
+    execFile(file, args, _options, callback) {
+      calls.push({ file, args });
+      if (args[0] === "list-clients") {
+        callback(null, { stdout: "/dev/ttys001 project\n" });
+        return;
+      }
+      callback(null, { stdout: "" });
+    }
+  });
+
+  await navigation.jumpToTarget({
+    app: "VS Code",
+    workingDirectory: "/tmp/workisland",
+    tmuxTarget: "project:3.1",
+    tmuxOuterHost: "VS Code"
+  });
+
+  assert.ok(calls.some(({ file, args }) => file === "/tmp/tmux" && args[0] === "select-window" && args[2] === "project:3.1"));
+  assert.ok(calls.some(({ file, args }) => file === "/tmp/tmux" && args[0] === "select-pane" && args[2] === "project:3.1"));
 });
 
 test("packaged launcher remains a JavaScript entrypoint for Electron Node mode", () => {


### PR DESCRIPTION
Closes #99

## 修复内容

**hook 端（`src/island/hooks-cli/index.cjs`）**
- `enrichTerminalContext` 捕获 `TMUX_PANE` 时同步记录 `tmux_outer_host`（排除 Agent 运行时名称），旧字段保持不动。
- 新增 `AGENT_RUNTIME_APPS`（codex / claude / opencode）：这类值是"谁在执行"而非"用户眼前哪个窗口"，只在完全没有宿主时作为最后兜底；父进程树检测宿主优先，避免每个 hook 都跑 `ps` 的同时又让 VS Code 插件中的 Codex 回到 VS Code。
- 补齐 `terminal` / `code` / `visual studio code` 别名。

**跳转端（`src/main/terminal-navigation.cjs`）**
- `dispatch`：有 `tmux_target` 时优先走 tmux 分支——先 `select-pane`，再把宿主窗口前置。此前 VS Code / Terminal 分支先返回，pane 从未参与定位（精度停留在窗口级）。
- `jumpTmuxWithOuter`：旧 payload 只有 `app` 没有 `tmuxOuterHost` 时，仍把 `app` 视作可聚焦宿主，保持既有会话回源兼容。
- 回源与提醒抑制的 bundle id 收集：有已捕获宿主窗口时服从宿主，Agent 身份仅作兜底；同时支持 tmux outer host 为 VS Code 变体名。
- `resolveTmuxBinary` 支持注入 override，便于测试。

**适配器（`src/main/adapters-cli.cjs`）**
- Codex 适配器：`terminal_app` 为 `Codex` 兜底值时改用 session meta 里的真实宿主信息。

## 测试

- `tests/warp-claude-hook.test.mjs` 新增 43 行：`tmux_outer_host` 捕获、Agent 名称降级、别名归一化。
- `tests/codex-adapter.test.mjs` 新增 13 行：VS Code 插件会话使用 transcript source 宿主。
- 本地 `node --test` 两文件 12/12 通过。