### PR TITLE
fix(update): 24h 内重启后从缓存恢复升级箭头（#98）

### DIFF
--- a/src/main/update-service.cjs
+++ b/src/main/update-service.cjs
@@ -332,10 +332,15 @@ function createUpdateService({
   }
 
   function getUpdateState() {
+    const latestVersion = updateState.release?.version ?? state.latestRelease?.version ?? null;
+    const current = currentVersion();
     return {
       ...updateState,
-      currentVersion: currentVersion(),
-      latestVersion: updateState.release?.version ?? state.latestRelease?.version ?? null,
+      currentVersion: current,
+      latestVersion,
+      // 岛端升级箭头只在 onUpdateAvailable 推送时点亮；hasUpdate 让缓存里的
+      // 新版本信息在重启后也能自行恢复入口（issue #98）。
+      hasUpdate: latestVersion !== null && compareVersions(latestVersion, current) === 1,
       releaseUrl: updateState.release?.url ?? state.latestRelease?.url ?? DEFAULT_DOWNLOAD_URL
     };
   }
@@ -434,7 +439,15 @@ function createUpdateService({
       return Promise.resolve({ status: "disabled", reason: "user-disabled", currentVersion: currentVersion() });
     }
     if (!force && state.lastCheckedAt && now() - state.lastCheckedAt < minIntervalMs) {
-      if (state.latestRelease) return Promise.resolve(resultForRelease(state.latestRelease));
+      if (state.latestRelease) {
+        const cachedResult = resultForRelease(state.latestRelease);
+        // 缓存捷径不经过 runCheck 的推送链路；缓存里已有新版时补一次状态推送，
+        // 否则 24h 内重启的岛端收不到任何消息，升级箭头不出现（issue #98）。
+        if (cachedResult.status === "update-available" && updateState.phase === "idle") {
+          publishState({ release: state.latestRelease });
+        }
+        return Promise.resolve(cachedResult);
+      }
       return Promise.resolve({ status: "skipped", reason: "recently-checked", currentVersion: currentVersion() });
     }
     if (!inFlight) {

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -55,10 +55,15 @@ function useIslandState() {
     });
     bridge.onQuotaUpdate((quotas) => setAgentQuotas(quotas));
     const offUpdate = bridge.onUpdateAvailable?.(() => setHasUpdate(true));
-    const offUpdateState = bridge.onUpdateState?.((state) => setUpdateState(state));
-    void bridge.getUpdateState?.().then((state) => {
-      if (state && typeof state === "object") setUpdateState(state);
-    }).catch(() => {});
+    // hasUpdate 由主进程从缓存 release 推导；启动拉取与状态推送都能恢复升级
+    // 箭头，不再依赖一次可能被 24h 去重跳过的真检测（issue #98）。
+    const applyUpdateState = (state) => {
+      if (!state || typeof state !== "object") return;
+      setUpdateState(state);
+      if (state.hasUpdate) setHasUpdate(true);
+    };
+    const offUpdateState = bridge.onUpdateState?.(applyUpdateState);
+    void bridge.getUpdateState?.().then(applyUpdateState).catch(() => {});
     void bridge.getQuotaMap().then((quotas) => {
       if (quotas && Object.keys(quotas).length > 0) setAgentQuotas(quotas);
     });

--- a/tests/update-service.test.mjs
+++ b/tests/update-service.test.mjs
@@ -299,3 +299,72 @@ test("failed install falls back to opening the dmg for manual drag install", asy
   assert.equal(opened.length, 1);
   assert.match(state.error, /拖入「应用程序」/);
 });
+
+test("relaunch inside the check interval restores the update arrow from cache without network", async () => {
+  const userDataPath = mkdtempSync(join(tmpdir(), "workisland-update-relaunch-"));
+  const first = createUpdateService({
+    platform: "darwin",
+    app: makeApp("1.2.0"),
+    userDataPath,
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({
+        tag_name: "v1.3.0",
+        name: "WorkIsland 1.3.0",
+        html_url: "https://github.com/qianzhu18/workisland/releases/tag/v1.3.0",
+        prerelease: false
+      })
+    }),
+    logger: { warn() {} }
+  });
+  assert.equal((await first.check({ force: true })).status, "update-available");
+
+  // 模拟 24h 内重启：新实例读到同一份 update-check.json，命中缓存捷径。
+  const statePushes = [];
+  const relaunched = createUpdateService({
+    platform: "darwin",
+    app: makeApp("1.2.0"),
+    userDataPath,
+    onUpdateState: (pushed) => statePushes.push(pushed),
+    fetchImpl: async () => {
+      throw new Error("cache shortcut must not hit the network");
+    },
+    logger: { warn() {} }
+  });
+  const result = await relaunched.check();
+  assert.equal(result.status, "update-available");
+  assert.equal(result.latestVersion, "1.3.0");
+
+  const state = relaunched.getUpdateState();
+  assert.equal(state.hasUpdate, true);
+  assert.equal(state.latestVersion, "1.3.0");
+  assert.ok(
+    statePushes.some((pushed) => pushed.hasUpdate === true && pushed.latestVersion === "1.3.0"),
+    "cache shortcut should push state so the island can relight the upgrade arrow"
+  );
+});
+
+test("hasUpdate stays false when the cache is empty or already up to date", async () => {
+  const empty = createUpdateService({
+    platform: "darwin",
+    app: makeApp("1.2.0"),
+    userDataPath: mkdtempSync(join(tmpdir(), "workisland-update-empty-")),
+    fetchImpl: async () => { throw new Error("no network expected"); },
+    logger: { warn() {} }
+  });
+  assert.equal(empty.getUpdateState().hasUpdate, false);
+
+  const userDataPath = mkdtempSync(join(tmpdir(), "workisland-update-uptodate-"));
+  const upToDate = createUpdateService({
+    platform: "darwin",
+    app: makeApp("1.3.0"),
+    userDataPath,
+    fetchImpl: async () => ({
+      ok: true,
+      json: async () => ({ tag_name: "v1.3.0", name: "WorkIsland 1.3.0", prerelease: false })
+    }),
+    logger: { warn() {} }
+  });
+  assert.equal((await upToDate.check({ force: true })).status, "up-to-date");
+  assert.equal(upToDate.getUpdateState().hasUpdate, false);
+});


### PR DESCRIPTION
Closes #98

## 根因回顾

1. `check()` 的 24h 去重缓存捷径直接返回缓存结果，不经过 `runCheck`，因此不触发 `onUpdateAvailable` / `onUpdateState` 推送；
2. 岛端 `hasUpdate`（升级箭头）只由 `onUpdateAvailable` 点亮；
3. 岛端启动虽有 `getUpdateState()` 拉取，但只存面板状态、不推导箭头。

## 修复（三层，最小改动）

- **`getUpdateState()` 新增 `hasUpdate`**：由缓存 release 版本与当前版本比较推导（`compareVersions > 0`），无缓存 / 已最新时为 `false`。
- **缓存捷径补推送**：命中 `update-available` 且 `phase === "idle"` 时 `publishState({ release })` 推一次状态。刻意不走 `onUpdateAvailable`，系统通知仍由 `lastNotifiedVersion` 节流，不会重复弹。
- **岛端推导**：`applyUpdateState` 统一处理启动拉取与 `onUpdateState` 推送，`state.hasUpdate === true` 即 `setHasUpdate(true)`。

## 测试

新增 2 个用例（`tests/update-service.test.mjs`，14/14 通过）：

- 「24h 内重启」场景：第一个实例真检测落盘 → 新实例 `fetchImpl` 直接 throw（证明不走网络）→ `check()` 返回 `update-available`、`getUpdateState().hasUpdate === true`、且收到了带 `hasUpdate` 的状态推送；
- 空缓存 / 已最新时 `hasUpdate` 保持 `false`。

## 验收建议

真机：跑一次带新版缓存的重启（或用 `--smoke-user-data` 演示包），确认岛顶升级箭头出现。