### PR TITLE
ci: fix Intel release payload verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,10 @@ jobs:
         run: |
           node <<'NODE'
           const asar = require('@electron/asar');
-          const archive = `release/mac-${{ matrix.arch }}/WorkIsland.app/Contents/Resources/app.asar`;
+          // electron-builder names a single x64 app directory `mac`, while an
+          // arm64 app directory is `mac-arm64`.
+          const appDirectory = '${{ matrix.arch }}' === 'x64' ? 'mac' : 'mac-arm64';
+          const archive = `release/${appDirectory}/WorkIsland.app/Contents/Resources/app.asar`;
           const files = new Set(asar.listPackage(archive));
           const required = [
             '/src/main/telemetry-service.cjs',

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "setup:electron": "npm install --prefix ./.tools/electron-shell --no-save electron@43.3.0 --cache ./.npm-cache",
     "build:native": "node ./scripts/build-native.mjs",
     "package:mac": "npm run build:assets && npm run build:native && npm run check && electron-builder --mac --arm64 --publish never",
-    "package:mac:intel": "npm run build:assets && WORKISLAND_NATIVE_ARCH=x86_64 npm run build:native && npm run check && electron-builder --mac --x64 --publish never",
+    "package:mac:intel": "npm run build:assets && WORKISLAND_NATIVE_ARCH=x86_64 npm run build:native && npm run check && electron-builder --mac dmg --x64 --publish never",
     "package:win": "npm run build:assets && npm run check && electron-builder --win nsis portable --x64 --publish never",
     "release:check": "node ./scripts/release-check.mjs",
     "check": "npm run build:renderer && node ./scripts/check.mjs && node ./scripts/test-source.mjs && npm run test:unit",


### PR DESCRIPTION
## What changed

- force the Intel packaging script to request only the x64 DMG target, instead of combining the configured arm64 target with `--x64`
- verify the x64 app at electron-builder's actual single-architecture output directory, `release/mac/`

## Why

The v1.3.0 release run packaged x64 successfully into `release/mac/WorkIsland.app`, but the following step attempted to open `release/mac-x64/WorkIsland.app/.../app.asar` and failed with `ENOENT`. The same x64 job also unexpectedly built arm64 because the configured target remained active.

Evidence: https://github.com/qianzhu18/workisland/actions/runs/33920485346/job/101177417655

## Verification

- `package.json` JSON parse
- `.github/workflows/release.yml` YAML parse
- `npm run test:unit` — 468 passed
- `git diff --check`

A tagged release is still needed to exercise signing/notarization; this change addresses the observed output-path mismatch without touching credentials.