### PR TITLE
docs(release): v1.4.0 双语发布内容——CHANGELOG 补录、Release Notes 草稿与官网 changelog 追平

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 > **版本体系重置（2026-09-02）**：公开版本号统一归位——内测期整理为 `v0.1.0 – v0.10.0`（原 `v0.2.x` 系列与初版 `v0.1.0` 重排，各版本说明注明原版本号）；`v3.0.0 / v3.1.0 / v3.2.0` 分别平移为 `v1.0.0 / v1.1.0 / v1.2.0`；`v3.2.0-rc.1` 与整条 `v1.0.0-alpha`（Windows 试验线）已删除，Windows 支持暂停维护、欢迎社区贡献者主导适配。
 
+## [Unreleased]
+
+### Added
+
+- **安静时段与锁屏静音**（#95）：设置 → 声音可配置勿扰时段（如 22:00 → 08:00，支持跨午夜），时段内不播放任务提示音；macOS 锁屏期间同样静音；两项独立开关。手机推送（Bark）刻意不受抑制——安静时段用户不在电脑前，推送正是通知出口。
+- **Plan 确认卡 Markdown 渲染**（#92）：Plan 确认文本按 Markdown 渲染（标题、列表、代码块，复用岛上既有渲染样式），默认折叠至固定高度、可一键展开全文；不新增依赖与 IPC 通道。
+- **本地开发者 API**（#93）：设置 → 关于可开启只读状态端点 `127.0.0.1:9938/api/status`，返回会话状态 JSON（id / Agent / phase / 时间戳 + 版本）；默认关闭，可选 Bearer 令牌鉴权；响应不含 prompt、路径或会话内容。详见 [DEVELOPER_API.md](docs/DEVELOPER_API.md)。
+- **用量发现通道（首批）**（#94）：zcode / opencode / claude 三个客户端的 token 用量改为主动从各客户端本地会话数据发现并入账，不再依赖 Hook 携带 `transcript_path`；此前这些客户端会话能上岛但用量不入账。剩余适配器在 issue #90 跟踪。
+- **性能实测数据公开**（#108）：Apple M4 · v1.3.0 实测闲置 CPU 中位 2.9%（达标 < 3%，贴线）、内存 top 口径 535 MB / RSS 341 MB；方法与原始采样见 [PERFORMANCE.md](docs/PERFORMANCE.md)，`scripts/perf-idle-benchmark.mjs` 可复现，README 增加展示位。
+
+> **English summary:** Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations now render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
+
 ## [1.3.0] - 2026-09-05
 
 公测收口版本：Agent 自检自修、应用内反馈与新手引导就位，并修复更新提示与定位跳转两处关键体验问题。

--- a/docs/RELEASE_NOTES_UNRELEASED.md
+++ b/docs/RELEASE_NOTES_UNRELEASED.md
@@ -1,57 +1,53 @@
-# WorkIsland v3.2.0 Release Notes（发布候选）
+# WorkIsland v1.4.0 Release Notes（发布候选）
 
-状态：`release-candidate — 本地打包验证中；Tag 推送后由 GitHub Actions 签名公证并创建正式 Release`
+状态：`release-candidate — 范围冻结；Tag 推送后由 GitHub Actions 签名公证并创建正式 Release`
 
-这是 macOS `v3.x` 正式版本线的 `v3.2.0`。它包含 rc.1 的外观模板系统、本次迭代的两个 P0（应用内更新闭环与 Intel 芯片兼容），以及终端/弹窗交互修复。Windows `v1.0.0-alpha.*` 为独立内测线，不包含在本版本中。
+本版主题「覆盖与留存 · 第一阶段收口」：把已合入 `main` 验证的四个留存/开放特性正式发出去，并首次公开性能实测数据。范围基线见 [`docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md`](./03-roadmap/v1.4.0-版本规划-2026-09-06.md)；完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)。
 
-完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)，版本 PRD 见 [PRD-011](./product/prd/PRD-011-v3.2.0-macOS-Template-Appearance-Release.md)。
+自本版起，GitHub Release 说明采用 **中文全文在前 + `### English Summary` 在后** 的双语结构（英文为摘要，不逐条直译），检查项见 [`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md)。
 
-## 本版本范围
+## 中文说明（tag 时粘贴到 Release 页前半）
 
-### 应用内更新闭环（P0）
+### 覆盖与留存：四个新特性
 
-- 灵动岛顶部的 Codex 额度格子右侧新增版本升级入口，点击展开更新弹层。
-- 完整闭环：下载与当前芯片匹配的官方安装包（含进度）→ SHA-256 校验 → 本机挂载安装 → 自动重启；任一步骤失败自动回退为打开 DMG 手动拖拽。
-- 下载完成后弹出「点击立即安装」系统通知。
-- 「设置 → 关于 → 更新」提供同一状态机（下载并安装 / 进度 / 重启并完成安装 / 重试）。
+- **安静时段与锁屏静音**（#95）：设置 → 声音可配置勿扰时段（如 22:00 → 08:00，支持跨午夜），时段内不播放任务提示音；macOS 锁屏期间同样静音；两项独立开关。手机推送（Bark）刻意不受抑制——安静时段用户不在电脑前，推送正是通知出口。
+- **Plan 确认卡 Markdown 渲染**（#92）：Plan 确认文本按 Markdown 渲染（标题、列表、代码块，复用岛上既有渲染样式），默认折叠、一键展开全文；链接点击走系统浏览器。
+- **本地开发者 API**（#93）：设置 → 关于可开启只读状态端点 `127.0.0.1:9938/api/status`，返回会话状态 JSON；默认关闭，可选 Bearer 令牌鉴权；响应不含 prompt、路径或会话内容。详见 [DEVELOPER_API.md](./DEVELOPER_API.md)。
+- **用量发现通道（首批）**（#94）：zcode / opencode / claude 三个客户端的 token 用量改为主动从本地会话数据发现并入账，不再依赖 Hook 携带 `transcript_path`；此前这些客户端会话能上岛但用量不入账。
 
-### Intel 芯片兼容与兼容性真值表（P0）
+### 性能
 
-- 首次提供 Intel（x64）macOS 安装包：`*-x64.dmg`；原生模块按目标架构编译，node-pty 使用 darwin-x64 预编译。
-- 发布流水线按 arm64 / x64 矩阵出包，Intel 校验文件为 `SHA256SUMS-x64.txt`。
-- 新增 [兼容性真值表](./COMPATIBILITY.md)：芯片、macOS 版本与功能级矩阵，Intel 机型以悬浮岛形态呈现灵动岛；媒体工作台在 Intel 上为「尽力支持」。
-- 应用内更新按芯片自动选择 arm64 / x64 安装包并校验对应校验文件。
+- **闲置性能实测数据公开**（#108）：Apple M4 · v1.3.0 实测闲置 CPU 中位 **2.9%**（< 3% 达标，贴线）、内存 top 口径 535 MB / RSS 341 MB；测试方法与原始采样见 [PERFORMANCE.md](./PERFORMANCE.md)，`scripts/perf-idle-benchmark.mjs` 可复现。
 
-### 外观模板与恢复（rc.1 内容）
+### 说明
 
-- 新增外观模板系统。官方小宇（守岛人）是可恢复默认模板；五个会话状态 SVG 在运行时从校验过的模板包加载，损坏时回退官方包。
-- 模板包包含清单、文件哈希、许可证与 SVG 安检；安装采用事务化写入，不完整或篡改内容不会替换现有配置。
-- 设置 → 外观新增「外观模板」区块，可选择、检查和恢复模板，无需使用终端。
+- 本 DMG 已 Developer ID 签名并通过 Apple 公证，下载后可直接打开（SHA256 见 `SHA256SUMS.txt`）。
+- Intel（x64）安装包：#103 已修复 Intel 构建路径，本版 tag 是第一个验证点——x64 DMG 产出并通过签名公证后，才在宣发中解锁「支持 Intel」；发布后回填实际结果。
+- 装过 3.x 旧包的同学：由于版本号重置，旧包认不出 1.x 是新版，请手动下载重装这一次；此后应用内自动升级即生效。
 
-### 本机 AI 外观自定义（rc.1 内容）
+### English Summary
 
-- 本机 Agent 可使用 `workisland-cli` 预览并在明确确认后修改 Island 背景、透明度、渐变、背景图和桌宠精灵图。
-- `workisland-cli template` 支持检查、预览、应用、重置、导出、下载与受限发布；GitHub 下载使用域名白名单与双重哈希校验。
-- 所有控制通过本机 Unix socket 完成，不开放网络端口；详细边界见 [AI Customization](./AI-CUSTOMIZATION.md)。
+Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
 
-### 稳定性
+## What's Changed
 
-- 修复灵动岛弹窗透明区域拦截点击、影响下方应用操作的问题。
-- 修复终端工作台交互场景下控制键被弹层抢占的问题。
+（tag 时由 GitHub「Generate release notes」自动生成后填充）
 
 ## 发布前验收
 
-- [ ] `package.json` 与 `package-lock.json` 均为 `3.2.0`。
+- [ ] `package.json` 与 `package-lock.json` 均为 `1.4.0`（prepare 提交时更新）。
 - [ ] `npm run check` 通过。
-- [ ] `npm run release:check -- --tag v3.2.0` 通过。
-- [ ] 本地完成 arm64（Apple Silicon）与 x64（Intel 交叉编译）打包验证。
-- [ ] GitHub Actions 完成双架构签名、公证、Staple、Gatekeeper 校验，并生成 `SHA256SUMS.txt` / `SHA256SUMS-x64.txt`。
-- [ ] GitHub Release `v3.2.0` 为正式版（非 Pre-release），成为 releases 页 Latest 置顶。
-- [ ] 官网首页、手册、更新日志和下载链接可访问。
+- [ ] `npm run release:check -- --tag v1.4.0` 通过。
+- [ ] `CHANGELOG.md` 的 `[Unreleased]` 段改名为 `[1.4.0]` + 发布日期，英文摘要保留。
+- [ ] Release 页说明 = 本文件中文段在前 + `### English Summary` 在后。
+- [ ] 官网 `website/changelog/index.html` 加入 v1.4.0 条目（口径与 Release 页一致），随 Tag 部署，不提前上线。
+- [ ] GitHub Actions 双架构签名、公证、Staple、Gatekeeper 校验通过，生成 `SHA256SUMS.txt` / `SHA256SUMS-x64.txt`。
+- [ ] **tag 后验证 x64 管线**：确认 x64 DMG 真实产出并通过签名公证（第一个验证点，见上「说明」）。
+- [ ] Release 成为 `releases/latest`，应用内更新可检测到 v1.4.0。
 
 ## 已知限制与回滚
 
-- Intel 机型媒体工作台依赖的 MediaRemote 私有框架行为与 Apple Silicon 存在差异，属尽力支持（见 [COMPATIBILITY.md](./COMPATIBILITY.md)）。
-- Windows Alpha 不在本版本范围，自动更新暂不覆盖 Windows 通道。
-- 模板远程下载仅支持受限 GitHub 静态目录；不会执行模板中携带的脚本。
-- 出现 P0 时发布新的 `v3.2.1`，绝不覆盖既有 Tag 或替换既有产物。
+- Intel 机型的媒体工作台依赖 MediaRemote 私有框架，行为与 Apple Silicon 存在差异，属尽力支持（见 [COMPATIBILITY.md](./COMPATIBILITY.md)）。
+- Windows Alpha 为独立版本线，不在本版本范围（见版本规划第五节）。
+- 会话/tab 级聚焦抑制（#111）、五大终端 tab 级跳转（#112）、无刘海悬浮条（#109）、应用内 i18n（#110）明确顺延 v1.5+，勿提前开工。
+- 出现 P0 时发布新的 `v1.4.1`，绝不覆盖既有 Tag 或替换既有产物。

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -52,7 +52,7 @@ npm run release:check -- --tag v3.0.0
 ## 正式发布
 
 1. 创建对应平台的 release 分支。macOS 使用 `release/macos-vX.Y.Z-rc.N`，Windows Alpha 使用 `windows/v1.0.0-alpha.N`；先确认该分支没有另一条平台的未发布版本号。
-2. 修改 `package.json` 和 `package-lock.json` 的版本号，并更新版本 PRD、官网手册、`CHANGELOG.md` 与 `docs/RELEASE_NOTES_UNRELEASED.md`。
+2. 修改 `package.json` 和 `package-lock.json` 的版本号，并更新版本 PRD、官网手册与官网 changelog 页、`CHANGELOG.md` 与 `docs/RELEASE_NOTES_UNRELEASED.md`。
 3. 在真实 macOS 设备完成未签名候选包安装、首个 Agent 事件、设置写入和卸载/回退验证；Windows Alpha 只在 Windows 11 真机验收。
 4. 运行完整检查并提交。macOS RC 验收后把同一范围升级为 `vX.Y.Z` 正式版；不得将 `-alpha` 版本直接改名为 macOS 正式版。
 5. 创建并推送与版本一致的 Tag：
@@ -72,6 +72,14 @@ npm run release:check -- --tag v3.0.0
 7. 在 GitHub Actions 和 Release 页面确认产物可下载、版本号匹配且平台产物没有串线。
 
 发布 workflow 必须保持以下门禁：macOS job 仅响应非 `-alpha` Tag；Windows job 仅响应 `-alpha` Tag。修改发布 workflow 时必须同步更新本表和版本 PRD，不能依靠人工记忆区分平台。
+
+## 双语与口径检查（v1.4.0 起固定检查项）
+
+Release 侧的中英双语与多渠道口径一致性自 v1.4.0 起为固定检查项，后续版本不回退：
+
+- [ ] GitHub Release 说明 = 中文全文在前 + `### English Summary` 在后；英文为摘要，不逐条直译。
+- [ ] `CHANGELOG.md` 每个新版本段落末尾配一段英文摘要（`> **English summary:** …`），并链接中文全文。
+- [ ] 官网 `website/changelog/index.html` 新增本版条目，与 Release 页保持同一摘要与同一日期；随 Tag 一起部署，不提前发布未 Tag 内容。
 
 ## GitHub Secrets
 

--- a/website/changelog/index.html
+++ b/website/changelog/index.html
@@ -50,11 +50,72 @@
         <article class="changelog-release changelog-release-latest">
           <div class="changelog-release-meta">
             <span class="changelog-release-label">LATEST STABLE</span>
-            <time datetime="2026-08-28">2026-08-28</time>
+            <time datetime="2026-09-05">2026-09-05</time>
           </div>
           <div class="changelog-release-body">
-            <h2>v3.1.0</h2>
-            <p class="changelog-summary">让 Media、工具箱、声音和桌宠都更贴近同一个 Agent 工作流。</p>
+            <h2>v1.3.0</h2>
+            <p class="changelog-summary">公测收口：Agent 自检自修、应用内反馈与新手引导就位，并修复更新提示与定位跳转两处关键体验问题。</p>
+            <div class="changelog-columns">
+              <section>
+                <h3>新增</h3>
+                <ul>
+                  <li>Agent Doctor 一键检测与一键修复：扫描全部 Agent 的 Hook 健康，自动备份修复并留痕，启动时自愈可修复状态。</li>
+                  <li>一键吐槽：设置内反馈入口，自动附带版本与 Agent 状态预填 GitHub issue。</li>
+                  <li>首启引导：尚未接入 Agent 时，灵动岛分步引导接入而非空白列表。</li>
+                  <li>Bark 手机推送：审批、提问、完成、失败四类事件可推送到 iPhone，默认关闭、不含会话内容。</li>
+                  <li>会话回顾：岛收起期间的事件折叠为摘要，展开即可回顾。</li>
+                </ul>
+              </section>
+              <section>
+                <h3>改进与修复</h3>
+                <ul>
+                  <li>修复升级箭头重启后消失：24 小时内重启也会从缓存恢复升级提示。</li>
+                  <li>修复会话定位跳转：tmux 先选中对应 pane 再带回宿主窗口，VS Code 宿主不再被误判。</li>
+                  <li>修复工具箱图标点击不稳定：轻点不再被误判为拖拽。</li>
+                  <li>Windows 版不再误报 macOS DMG 更新。</li>
+                </ul>
+              </section>
+            </div>
+            <a class="changelog-release-link" href="https://github.com/qianzhu18/workisland/releases/tag/v1.3.0" target="_blank" rel="noreferrer">查看 v1.3.0 Release 与下载 ↗</a>
+          </div>
+        </article>
+
+        <article class="changelog-release">
+          <div class="changelog-release-meta">
+            <span>STABLE</span>
+            <time datetime="2026-09-02">2026-09-02</time>
+          </div>
+          <div class="changelog-release-body">
+            <h2>v1.2.0</h2>
+            <p class="changelog-summary">应用内更新闭环与 MCP 产品助手落地；修复新版 ZCode 无法连接的问题。（原 v3.2.0 平移，同一构建）</p>
+            <div class="changelog-columns">
+              <section>
+                <h3>新增</h3>
+                <ul>
+                  <li>应用内更新闭环：岛顶升级入口与「设置 → 关于 → 更新」同构，下载、SHA-256 校验、安装、自动重启一体完成。</li>
+                  <li>MCP 产品助手：本地 MCP 服务可询问灵动岛功能、查询任务状态、诊断模块问题。</li>
+                  <li>外观模板系统与 <code>workisland-cli template</code>：模板可检查、预览、应用与恢复。</li>
+                </ul>
+              </section>
+              <section>
+                <h3>改进与修复</h3>
+                <ul>
+                  <li>修复 ZCode（≥3.10）始终无法连接：Hook 现在同步写入最近活跃项目的项目级配置。</li>
+                </ul>
+              </section>
+            </div>
+            <a class="changelog-release-link" href="https://github.com/qianzhu18/workisland/releases/tag/v1.2.0" target="_blank" rel="noreferrer">查看 v1.2.0 Release 与下载 ↗</a>
+          </div>
+        </article>
+
+        <article class="changelog-release">
+          <div class="changelog-release-meta">
+            <span>STABLE</span>
+            <time datetime="2026-09-01">2026-09-01</time>
+          </div>
+          <div class="changelog-release-body">
+            <h2>v1.1.0</h2>
+            <p class="changelog-summary">让 Media、工具箱、声音和桌宠都更贴近同一个 Agent 工作流。（原 v3.1.0 平移，同一构建）</p>
             <div class="changelog-columns">
               <section>
                 <h3>新增</h3>
@@ -74,24 +135,24 @@
                 </ul>
               </section>
             </div>
-            <a class="changelog-release-link" href="https://github.com/qianzhu18/workisland/releases/tag/v3.1.0" target="_blank" rel="noreferrer">查看 v3.1.0 Release 与下载 ↗</a>
+            <a class="changelog-release-link" href="https://github.com/qianzhu18/workisland/releases/tag/v1.1.0" target="_blank" rel="noreferrer">查看 v1.1.0 Release 与下载 ↗</a>
           </div>
         </article>
 
         <article class="changelog-release">
           <div class="changelog-release-meta">
             <span>STABLE</span>
-            <time datetime="2026-08-24">2026-08-24</time>
+            <time datetime="2026-08-23">2026-08-23</time>
           </div>
           <div class="changelog-release-body">
-            <h2>v3.0.0</h2>
-            <p class="changelog-summary">WorkIsland 首个公开稳定版。</p>
+            <h2>v1.0.0</h2>
+            <p class="changelog-summary">WorkIsland 首个公开稳定版。（原 v3.0.0 平移，同一构建）</p>
             <ul>
               <li>完善多 Agent 会话状态、审批、提问和回源体验。</li>
               <li>加入本地优先的隐私披露、匿名统计开关和版本更新检查。</li>
               <li>建立用户手册、反馈入口与公开 macOS DMG 分发链路。</li>
             </ul>
-            <a class="changelog-release-link" href="https://github.com/qianzhu18/workisland/releases/tag/v3.0.0" target="_blank" rel="noreferrer">查看 v3.0.0 Release ↗</a>
+            <a class="changelog-release-link" href="https://github.com/qianzhu18/workisland/releases/tag/v1.0.0" target="_blank" rel="noreferrer">查看 v1.0.0 Release ↗</a>
           </div>
         </article>
 


### PR DESCRIPTION
验收标准：①CHANGELOG 补录 v1.4.0 四功能与性能数据并配英文摘要（[Unreleased] 段，tag 时改名）；②docs/RELEASE_NOTES_UNRELEASED.md 从 v3.2.0 旧稿重写为 v1.4.0 中英双语发布稿（中文在前 + English Summary 在后，含发布前验收清单）；③RELEASE_PROCESS.md 新增「双语与口径检查」固定检查项（v1.4.0 起不回退），并把官网 changelog 页纳入发版更新清单；④官网 changelog 页从 v3.1.0 追平到 v1.3.0，修正版本重置后的 1.x 条目、日期与失效 tag 链接（随 tag 部署，不提前上线）。

对应 issue #107 范围三条：GitHub Release 说明双语结构 / CHANGELOG 每版英文摘要 / 官网 changelog 与 Release 页口径一致。

发布顺序提醒：本 PR 合并后按 [v1.4.0 版本规划](https://github.com/qianzhu18/workisland/blob/main/docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md) 做版本号 prepare 提交 → tag v1.4.0 → 验证 x64 管线 → 官网 changelog 部署。

Closes #107
Ref: B-11（分发前置：Homebrew Cask 与双语 Release Notes 后半）