### PR TITLE
docs(roadmap): v1.4.0 范围修订——会话搜索 #115 列为下一版本核心功能，PRD-019 入库

### DIFF
--- a/docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md
+++ b/docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md
@@ -6,6 +6,13 @@
 
 v1.3.0 完成了公测门槛（Agent Doctor / 反馈通道 / 首启引导 / 签名公证）。v1.4.0 把竞品对标中已完成的"留存与开放"特性**发出去**，并补上发布侧的中英双语能力——重点是**交付**，不是开新摊子。
 
+## 范围修订（2026-09-07）
+
+- 用户拍板：**会话搜索与回源跳转**为下一版本核心功能——issue [#115](https://github.com/qianzhu18/workisland/issues/115)（已入 Milestone v1.4.0，`kind: epic` / P0），完整方案 PRD-019 随本修订入库 `docs/product/prd/`。
+- 发版纪律：**#115 不阻塞上面已就绪四功能的 tag**——M1–M3 全绿赶上就作为本版头牌发布；赶不上则搜索部分顺延 v1.5.0（届时把 issue 迁出 milestone 并回写本节）。
+- 交付线：M1 索引器（PR #120，`feature/session-search`）→ M2 搜索 UI + ⌘K + `SESSION_SEARCH_*` IPC + 回源跳转 → M3 设置开关 + 一键清除索引。
+- SSH/tmux 远程接入拆出为独立 epic [#116](https://github.com/qianzhu18/workisland/issues/116)，blocked 于 ADR-0005 裁定，明确不进 v1.4。
+
 ## 一、已定内容（代码已合 main，本版发布）
 
 | 功能 | PR | 说明 |

--- a/docs/product/prd/PRD-019-会话搜索与开发记录中枢.md
+++ b/docs/product/prd/PRD-019-会话搜索与开发记录中枢.md
@@ -1,0 +1,111 @@
+# PRD-019：会话搜索与开发记录中枢（Session Search & Dev Hub）
+
+状态：`accepted`（2026-09-07 用户拍板会话搜索为下一版本核心功能；P0 已立 issue [#115](https://github.com/qianzhu18/workisland/issues/115) 入 v1.4.0 milestone；SSH/tmux 远程接入拆出 [#116](https://github.com/qianzhu18/workisland/issues/116)，blocked 于 ADR-0005 裁定）  
+M1 交付：PR [#120](https://github.com/qianzhu18/workisland/pull/120)（`feature/session-search`，索引器 + 单测，2026-09-07）
+负责人：WorkIsland 负责人
+功能分支：`feature/session-search`（P0，待开）→ `feature/dev-hub-providers`（P1，待 P0 验收后开）
+来源：2026-09-07 用户本人刚需——「只记得绝对聊过，不记得放在哪个文件夹、哪个对话框聊的这个内容」
+最后复核：2026-09-07
+
+> 定位一句话：把 WorkIsland 从「Agent 状态监控器」升级为「开发记忆入口」——岛上输入关键词，直达那个会话、那个文件夹、那份记录。
+
+## 1. 背景与问题
+
+- 用户痛点（原话提炼）：跨 Agent、跨项目聊过的内容，事后想找时既不记得在哪个文件夹（项目目录），也不记得在哪个会话里，只确定聊过。目前只能靠肉眼翻各 Agent 的会话列表。
+- 数据基础已具备：所有会话记录本机就有——Claude Code 在 `~/.claude/projects/<编码后路径>/*.jsonl`，Codex 在 `~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl`，ZCode 在 `~/.zcode/cli/db/db.sqlite`（会话正文落盘位置需 spike 确认，见 M0）。
+- WorkIsland 已有两条现成地基，本 PRD 是在它们之间插入一层「索引+检索」：
+  1. **读取通道**：`usage-discovery.cjs` / `codex-transcript-watcher.cjs` 已在扫描上述会话文件（token 统计用途）；
+  2. **回源跳转**：`terminal-navigation.cjs`（2006 行）已打通 TTY 反查聚焦终端 + `claude://resume?session=<uuid>` 深链，IPC 走 `SESSION_JUMP`。
+- 竞品佐证：agentsview（MIT，~5.3k stars）验证了「本地会话浏览与检索」是刚需品类（与 PRD-015 引用同一竞品信号，此处是它的搜索半边）。
+
+## 2. 目标与非目标
+
+### 目标（P0：会话搜索直达）
+
+1. 岛上可输入关键词，跨 Agent（Claude Code / Codex / ZCode，后续扩其他）全文搜索历史会话。
+2. 结果卡片显示：Agent 图标、项目名（路径末段）、相对时间、命中片段（关键词高亮）。
+3. 点击结果 → 复用现有回源跳转通道回到那个会话（活跃会话聚焦终端 / Claude 桌面走 resume 深链 / 终端会话给 resume 命令）。
+4. 副操作解决「忘了哪个文件夹」：一键复制会话所属项目路径 / transcript 文件路径，或在 Finder 中显示。
+5. 索引全程本机：零网络请求，索引文件落本机应用数据目录；设置里可关闭、可一键清除。
+
+### 非目标（P0 明确不做）
+
+1. **不索引 AI 回复正文**（体积与 CPU 大头），P0 只索引用户提问、会话标题/summary、项目路径。P1 评估是否扩展。
+2. 不做任何形式的云端同步或上传（受 ADR-0004 本地优先边界约束）。
+3. 不修改任何 Agent 原始会话文件（只读）。
+4. 不做通用文件全文搜索（那是 P1 的 provider 化，见 §5）。
+
+## 3. 用户故事与需求
+
+| 用户故事 | 行为要求 | 优先级 | 验收证据 |
+| --- | --- | --- | --- |
+| 只记得聊过某个主题，想找回那个会话 | 输入关键词，≤1 秒出结果，按相关度/时间排序 | P0 | 实机搜索截图 + 命中片段核对 |
+| 找到了会话，想回到那个终端继续 | 点卡片 → 聚焦对应终端 tab 或给出 resume 命令 | P0 | 五类会话各实测一条跳转路径 |
+| 想知道这内容属于哪个项目/文件夹 | 卡片显示项目名；副操作复制项目路径 / 在 Finder 显示 transcript | P0 | 复制内容核对 |
+| 对隐私敏感，不希望内容被建索引 | 设置可整体关闭搜索；关闭后停止扫描并清空索引 | P0 | 设置开关行为测试 |
+| 笔记本用户，在意后台功耗 | 索引增量扫描，闲时节流，不破坏闲置 CPU<3% 口碑线 | P0 | 复用 #108 基准脚本前后对比 |
+| 索引损坏/首次启动，不想等 | 首次全量索引后台分片跑，UI 可用性与索引进度解耦 | P1 | 首跑引导态截图 |
+
+## 4. 技术方案与约束（P0）
+
+### 4.1 索引器
+
+- 新增 `src/main/session-search-service.cjs`，扫描范围与游标：
+  - claude：`~/.claude/projects/*/*.jsonl`（增量游标 = mtime + size，与 usage-discovery 同思路）；
+  - codex：`~/.codex/sessions/**/*.jsonl`；
+  - zcode：`~/.zcode/cli/db/db.sqlite` 或会话 transcript 落盘位置（**M0 spike 首任务**）。
+- 每条索引记录：`session_id / tool / project_path / title(或首条用户消息截断) / snippet / timestamp / transcript_path`。
+- 提取策略：逐行读 JSONL，仅抽取用户消息文本与 summary 行，丢弃其余——单文件内存占用可控。
+- 持久化：P0 用 JSON 文件落应用数据目录（沿用 `clipboard-history.json` 模式，**零新依赖**）；若数据量评估超限（估算：数千会话 × 数 KB 提取 ≈ 十几 MB，可接受），或 P1 扩全文时，升级为 SQLite FTS5（系统 `sqlite3` CLI，读 ZCode db 已有同款先例，避免新增 native 模块）。选型在 M0 spike 出结论。
+
+### 4.2 调度与性能红线
+
+- 闲置 CPU<3% 是对外口碑项（issue #108 实测 2.9%，贴线）。索引器必须：
+  - 变更驱动而非定时轮询：fs.watch 会话目录 + debounce（分钟级）批量扫描；
+  - 首次全量分片处理，单片间 `setImmediate` 让出事件循环，且避开会话活跃时段；
+  - 索引活动有独立日志计数，验收时跑 #108 的 `task/perf-idle-benchmark` 基准脚本对比。
+
+### 4.3 IPC 与 UI
+
+- 新增 IPC：`SESSION_SEARCH_QUERY` / `SESSION_SEARCH_STATE`（命名对齐现有 `session:*` 族）。**注意 `scripts/test-source.mjs` 的 IPC 契约守卫计数必须同步**（2026-09-02 时点 161，落码时以实际重数为准），否则 check 挂。
+- UI 落位：展开面板顶部加搜索条（对照 2026-09-07 面板截图顶栏空间），全局快捷键 ⌘K 唤起岛并聚焦搜索框（走 `shortcut-service`）。渲染层为手写 vanilla 组件（`src/renderer/island/components/`），新增 `SearchPanel.js` 对齐现有面板模式。
+- 跳转：结果卡片主按钮 → 复用 `SESSION_JUMP`；副按钮 → 复制路径 / Finder reveal。跳不到的（如已删除的 transcript）灰置并显示「文件已不存在」。
+
+### 4.4 隐私与承诺边界
+
+- 与 PRD-015 非目标（「不读取 prompt/transcript」）的措辞差异需在宣发时讲清：用量面板承诺的是「分析不碰内容」；搜索功能**明示**读取内容但「全程本机、不出机器、可关可清」——这与 unix domain socket「物理上出不了机器」的本地优先口径一致，不破坏承诺，但属于新的信任面，默认开启与否交用户拍板（建议默认开 + 首跑引导里一句话说明）。
+
+## 5. P1 方向：开发记录中枢（provider 化）
+
+回答「能否把所有平台的开发文件和记录都交给灵动岛管理」：**可以，且是 P0 架构的自然延伸**——把搜索层泛化为「中枢 + provider 注册制」，每个 provider 贡献索引源和跳转动作：
+
+| Provider | 数据源 | 跳转动作 |
+| --- | --- | --- |
+| sessions（P0 已有） | 各 Agent 会话文件 | resume / 聚焦终端 |
+| docs | 用户 vault / 项目 docs 的 Markdown 全文 | 默认编辑器打开 / Finder reveal |
+| clipboard | `clipboard-history.json`（store 已存在） | 复用 `CLIPBOARD_HISTORY_REPLAY` |
+| shelf | `shelf.json`（已有） | 复用 `SHELF_REVEAL` |
+| stats / usage | `stats/` 记录（PRD-015 面板） | 打开 Usage 面板 |
+
+- 统一入口即 ⌘K：一个搜索框，结果按 provider 分组。岛的定位从「监控 Agent」升级为「开发记忆入口」——这是竞品格局里（竞品三路线调研 2026-09）无人占据的差异化位置。
+- P1 原则：provider 一个一 PR；docs provider 需单独评估目录规模与排除规则（node_modules 等）。
+
+## 6. 里程碑与分支方案
+
+| 里程碑 | 内容 | 交付物 |
+| --- | --- | --- |
+| M0 spike（~1 天） | ZCode 会话正文落盘位置确认；索引存储选型（JSON vs sqlite3 CLI FTS5）出结论 | spike 结论回写本 PRD |
+| M1 索引器 | `session-search-service.cjs` + 游标增量 + 调度节流 + 单测 | `feat(search): ...` PR（只含主进程，无 UI） |
+| M2 UI 与跳转 | SearchPanel + IPC + ⌘K + 跳转/复制路径 | `feat(search): ...` PR |
+| M3 收口 | 设置开关 + 清除索引 + 首跑说明 + 文档 | `feat(search): ...` PR |
+
+- 分支纪律：从最新 main 拉 `feature/session-search`；**共享检出纪律**——仓库目录多会话共用（当前检出在 `task/perf-idle-benchmark`），开工用独立 `git worktree`，禁 `git add -A`；每个 PR 正文第一行写验收标准、末行挂 `Ref: PRD-019`；解决冲突后必跑 `npm run check` 再 push。
+- issue 骨架：拍板后按 issue-first 立一条「会话搜索：跨 Agent 关键词直达历史会话」issue，M1/M2/M3 PR 挂靠。
+- 版本归属建议：v1.4.0 已堆 4 个未发版功能，本 PRD 建议**列为 v1.5 候选**（与 #109–#112 顺延批次同待遇），或用户拍板插队 v1.4。
+
+## 7. 开放问题（等用户拍板）
+
+1. 版本归属：v1.5 候选还是插队 v1.4？
+2. 搜索默认开还是默认关（涉及 §4.4 信任面）？
+3. ⌘K 作为全局快捷键是否可接受（可能与用户已有全局键冲突，需注册失败降级提示）？
+4. P0 是否包含 ZCode（若 M0 spike 发现 ZCode 会话正文不可稳定读取，则 P0 先交付 Claude + Codex，ZCode 降级 P1）？

--- a/docs/product/prd/README.md
+++ b/docs/product/prd/README.md
@@ -16,5 +16,6 @@
 - [PRD-009: v3.1.0 Workstation Release](./PRD-009-v3.1.0-Workstation-Release.md)
 - [PRD-010: Windows MVP](./PRD-010-WINDOWS-MVP.md)
 - [PRD-011: v3.2.0 macOS Template & Appearance Release](./PRD-011-v3.2.0-macOS-Template-Appearance-Release.md)
+- [PRD-019: 会话搜索与开发记录中枢](./PRD-019-会话搜索与开发记录中枢.md)（issue #115 搜索 / #116 SSH+tmux 远程）
 
 编号只递增不复用。Feature PRD 的批准意味着可以拆 Issue，不意味着所有任务都必须在同一版本交付。


### PR DESCRIPTION
## 验收标准

- [x] v1.4.0 范围基线（SSOT）新增「范围修订（2026-09-07）」节：会话搜索 #115 列为下一版本核心功能，且**不阻塞已就绪四功能的 tag**（赶不上 M1–M3 全绿则顺延 v1.5.0 并迁出 milestone）
- [x] PRD-019（会话搜索与开发记录中枢）入库 `docs/product/prd/` 并挂 issue #115/#116 与 M1 PR #120
- [x] `check.mjs` 静态检查通过（164 源文件 + 78 资产）

## 说明

对应 2026-09-07 范围拍板与流转纪律第 3 条「改范围先改这里」：

- 范围修订写明交付线：M1 索引器（#120 已开）→ M2 搜索 UI + ⌘K + IPC + 回源跳转 → M3 设置开关与清除索引
- SSH/tmux 远程接入拆为独立 epic #116，blocked 于 ADR-0005 裁定，明确不进 v1.4

Refs: #115
