### PR TITLE
feat(remote): observe-only 远程接入第一阶段——SSH 隧道状态上岛

### DIFF
--- a/docs/REMOTE_ONBOARDING.md
+++ b/docs/REMOTE_ONBOARDING.md
@@ -1,0 +1,81 @@
+# WorkIsland 远程接入指南（AI 可读版）v1
+
+状态：`v1`（ADR-0005 第一阶段 observe-only 已裁定通过，对应 PRD-016 T4；取代 vault 中的 v0 草稿）
+日期：2026-09-07
+目标读者：**远程机器上的 AI 编码助手**（Claude Code / Codex CLI / Cursor CLI 等）。人类用户只需把本文档交给远程机器上的 AI，并在 WorkIsland 里生成一次配对令牌。
+
+---
+
+## 给 AI 助手的任务说明
+
+你的任务：让这台远程机器上运行的 AI 编码 Agent 的**状态**（运行中 / 等待审批 / 完成 / 失败）出现在用户本地 Mac 的 WorkIsland 岛上。全程 **observe-only**：只回传状态，不回传代码、prompt、路径；服务端入口也会强制丢弃这些字段。
+
+### 硬性边界（违反即停止）
+
+1. 禁止修改 sshd 全局配置（`/etc/ssh/sshd_config`），也禁止修改 Mac 的系统设置。
+2. 禁止把配对令牌写入任何持久化文件（只在 pair 命令参数中一次性使用）。
+3. 禁止安装本指南之外的软件包；只需 `bash`、`ssh`、`node ≥ 18`。
+4. 禁止把回传内容扩展到状态之外（不要发明新事件类型或额外字段）。
+5. 每一步执行后必须运行「自检」；自检不过就停下并向用户报告，重试不超过 2 次。
+
+### 用户侧前置（请向用户确认，不要替用户操作）
+
+1. Mac 已开启「远程登录」：系统设置 → 通用 → 共享 → 远程登录（这会启用系统级 sshd，是用户自管 SSH 的前提）。
+2. 用户已告知你 Mac 的登录名与地址（形如 `qianzhu@192.168.1.8`，同局域网或可达）。
+3. WorkIsland「设置 → Agents → 远程主机」已开启远程接入，并生成了**配对令牌**（10 分钟内有效、只能用一次）。
+4. 脚本已放在本机：`~/workisland-remote/workisland-remote.cjs`（从 WorkIsland 仓库 `resources/remote/` 获取），SHA-256 校验和与文末一致。
+
+### 步骤
+
+1. **环境自检**：`bash`、`ssh`、`node -v`（≥18）可用；记录 OS 与架构。
+2. **校验脚本**：`shasum -a 256 ~/workisland-remote/workisland-remote.cjs`，与文末校验和比对，不一致立即停止。
+3. **建立身份**：`node ~/workisland-remote/workisland-remote.cjs init`（生成 `~/.workisland-remote/host-id`，已存在则复用）。
+4. **建立 SSH 隧道**（注意方向：本机发起 `-L` 本地转发，事件流向 远程 → Mac）：
+   ```bash
+   ssh -N -L 17878:127.0.0.1:7878 <user>@<mac> -o ServerAliveInterval=15 -o ExitOnForwardFailure=yes
+   ```
+   用 `nohup` 或 tmux 会话常驻；隧道必须保持存活，断开期间状态会丢失（岛上显示断线，不补发）。
+5. **配对**（令牌 10 分钟有效、一次性）：
+   ```bash
+   node ~/workisland-remote/workisland-remote.cjs pair <配对令牌>
+   ```
+   成功后会话密钥存入 `~/.workisland-remote/session-key`（0600），令牌即弃，不会落盘。
+6. **安装回传 hook**（当前支持 Claude Code）：
+   ```bash
+   node ~/workisland-remote/workisland-remote.cjs install-hooks
+   ```
+   这会把 SessionStart / UserPromptSubmit / Notification / Stop / SessionEnd 五个 hook 指向本脚本；安装前自动备份 `~/.claude/settings.json`。
+7. **自检清单**：
+   - [ ] 隧道进程存活：`nc -z 127.0.0.1 17878` 成功
+   - [ ] 手动状态：`node ~/workisland-remote/workisland-remote.cjs send running selftest-0001 claude` 后，用户岛上出现该主机的新会话卡（问用户确认）
+   - [ ] 收尾测试：`... send completed selftest-0001 claude` 后卡片转为完成态
+   - [ ] 跑一条真实 Agent 命令，岛上状态从 running → completed
+   - [ ] 断开隧道 30 秒重连：岛上会话变为「远程连接已断开」，重连后状态恢复，无假 running
+
+### 常见失败与诊断话术
+
+| 现象 | 最可能原因 | 给用户的话术 |
+| --- | --- | --- |
+| 隧道秒断 | Mac 的 22 端口未开（未开远程登录） | 「请在 Mac 上开启：系统设置 → 通用 → 共享 → 远程登录」 |
+| 本机连 17878 超时 | 隧道未建立 / WorkIsland 远程接入未开启 | 「请确认第 4 步 ssh 进程存活，且 WorkIsland 设置里远程接入已启用」 |
+| 配对失败 TOKEN_INVALID | 令牌过期或已被使用 | 「请用户在 WorkIsland 设置里重新生成一次性令牌」 |
+| 发送失败 HOST_UNKNOWN_OR_REVOKED | 用户撤销了这台主机 | 「请用户重新生成令牌并重跑第 5、6 步」 |
+| 岛上无反应 | hook 没触发 | 「请确认 Claude Code 版本支持 hooks 配置，重跑自检第 2 步」 |
+
+### 已知限制（第一阶段）
+
+- observe-only：岛上只展示状态；审批仍在远程终端完成，岛上的远程会话卡没有审批/追问按钮。
+- 不支持 tmux attach / 交互式操作（二期另裁，见 ADR-0005）。
+- 隧道断开期间的事件会丢失（岛上显示断线，不补发）。
+- 自动回传 hook 当前只装 Claude Code；其他 Agent 可用 `send` 子命令手动回传。
+- 不支持 Windows 远程侧。
+
+---
+
+脚本 SHA-256：
+
+```
+91007ed61900324fe0613ceb6f60bdbd0a14cbcf2f2e36250f38213f79e9d152  workisland-remote.cjs
+```
+
+> 校验和对应本文件提交版本的 `resources/remote/workisland-remote.cjs`；脚本随版本更新时此行同步更新。

--- a/resources/remote/workisland-remote.cjs
+++ b/resources/remote/workisland-remote.cjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+"use strict";
+
+/**
+ * WorkIsland 远程接入脚本（observe-only，PRD-016 / ADR-0005 第一阶段）。
+ *
+ * 在远程机器（跑 Agent 的那台）上使用，零 npm 依赖，Node ≥ 18。
+ *
+ *   node workisland-remote.cjs init                 生成稳定 host id（UUID）
+ *   node workisland-remote.cjs pair <令牌>          用一次性令牌换取会话密钥
+ *   node workisland-remote.cjs hook                 Claude Code hook 入口（stdin JSON → 状态行）
+ *   node workisland-remote.cjs send <状态> <会话id> [工具]   手动发一条状态（自检用）
+ *   node workisland-remote.cjs install-hooks        把 Claude Code hook 写入 ~/.claude/settings.json
+ *   node workisland-remote.cjs uninstall-hooks      从 ~/.claude/settings.json 移除上述 hook
+ *
+ * 硬性边界（ADR-0005）：
+ * - 只回传状态（running / completed / failed / approval_requested / stale），
+ *   不回传 prompt、代码、路径；服务端入口也会丢弃这些字段（D3）。
+ * - 配对令牌不落盘；换取的会话密钥存在 ~/.workisland-remote/session-key（0600）。
+ * - 数据通道是用户自管的 SSH 隧道（远程侧 ssh -L 17878:127.0.0.1:7878 <mac>），
+ *   本脚本只连 127.0.0.1:17878，从不直接访问网络。
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const net = require("node:net");
+const crypto = require("node:crypto");
+
+const REMOTE_DIR = path.join(os.homedir(), ".workisland-remote");
+const HOST_ID_PATH = path.join(REMOTE_DIR, "host-id");
+const SESSION_KEY_PATH = path.join(REMOTE_DIR, "session-key");
+const CLAUDE_SETTINGS = path.join(os.homedir(), ".claude", "settings.json");
+const HOOK_MARKER = "workisland-remote.cjs";
+
+// Claude Code hook 事件 → observe-only 状态（D3 白名单内）。
+const HOOK_STATE_MAP = {
+  SessionStart: "running",
+  UserPromptSubmit: "running",
+  Notification: "approval_requested",
+  Stop: "completed",
+  SessionEnd: "stale"
+};
+
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{8,128}$/;
+const FORWARD_PORT_DEFAULT = 17878;
+
+function readSessionKey() {
+  try {
+    const key = fs.readFileSync(SESSION_KEY_PATH, "utf8").trim();
+    return key.length >= 16 ? key : null;
+  } catch {
+    return null;
+  }
+}
+
+function ensureHostId() {
+  fs.mkdirSync(REMOTE_DIR, { recursive: true, mode: 0o700 });
+  try {
+    const existing = fs.readFileSync(HOST_ID_PATH, "utf8").trim();
+    if (/^[0-9a-f-]{36}$/i.test(existing)) return existing;
+  } catch {}
+  const id = crypto.randomUUID();
+  fs.writeFileSync(HOST_ID_PATH, `${id}\n`, { mode: 0o600 });
+  return id;
+}
+
+/**
+ * 与 WorkIsland observe-only 入口的一次性短连接：连接 → 发送 → 收到期望
+ * 回应后主动断开。超时或被拒时抛错（错误信息直接给人看）。
+ */
+function talk(port, lines, { expectType = "ack", timeoutMs = 8000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect({ port, host: "127.0.0.1" });
+    let buffer = "";
+    const received = [];
+    let settled = false;
+    const finish = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      socket.destroy();
+      fn(value);
+    };
+    const timer = setTimeout(() => {
+      finish(reject, new Error(`连接 127.0.0.1:${port} 超时——SSH 隧道未建立或 WorkIsland 远程接入未开启`));
+    }, timeoutMs);
+    socket.on("data", (chunk) => {
+      buffer += chunk.toString("utf8");
+      let index;
+      while ((index = buffer.indexOf("\n")) >= 0) {
+        const line = buffer.slice(0, index).trim();
+        buffer = buffer.slice(index + 1);
+        if (!line) continue;
+        try {
+          received.push(JSON.parse(line));
+        } catch {}
+      }
+      if (expectType && received.some((r) => r.type === expectType)) {
+        finish(resolve, received);
+      }
+    });
+    socket.on("error", (err) => {
+      finish(reject, new Error(`无法连接 127.0.0.1:${port}（${err.code ?? err.message}）——SSH 隧道未建立？`));
+    });
+    socket.on("close", () => finish(resolve, received));
+    for (const line of lines) socket.write(`${JSON.stringify(line)}\n`);
+  });
+}
+
+function sessionIdFromPayload(payload) {
+  const id = typeof payload?.session_id === "string" ? payload.session_id.trim() : "";
+  return SESSION_ID_RE.test(id) ? id : null;
+}
+
+async function main() {
+  const [command, ...rest] = process.argv.slice(2);
+
+  if (command === "init") {
+    const hostId = ensureHostId();
+    console.log(`host-id: ${hostId}`);
+    return;
+  }
+
+  if (command === "pair") {
+    const token = rest[0];
+    const port = Number(rest[1] ?? process.env.WORKISLAND_FORWARD_PORT) || FORWARD_PORT_DEFAULT;
+    if (!token) {
+      console.error("用法：workisland-remote.cjs pair <配对令牌> [转发端口]");
+      process.exitCode = 1;
+      return;
+    }
+    const hostId = ensureHostId();
+    const replies = await talk(port, [
+      { type: "pair", hostId, displayName: os.hostname(), token }
+    ], { expectType: "pairResult" });
+    const result = replies.find((r) => r.type === "pairResult");
+    if (!result?.ok) {
+      console.error(`配对失败：${result?.error ?? "无响应"}（令牌过期/已用？请让用户重新生成）`);
+      process.exitCode = 1;
+      return;
+    }
+    fs.mkdirSync(REMOTE_DIR, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(SESSION_KEY_PATH, `${result.sessionKey}\n`, { mode: 0o600 });
+    console.log(`配对成功：${result.displayName}（host ${result.hostId}），会话密钥已存 ${SESSION_KEY_PATH}`);
+    return;
+  }
+
+  if (command === "hook") {
+    let raw = "";
+    await new Promise((resolve) => {
+      process.stdin.setEncoding("utf8");
+      process.stdin.on("data", (chunk) => { raw += chunk; });
+      process.stdin.on("end", resolve);
+      // hook 上下文里 stdin 可能已关闭
+      setTimeout(resolve, 1500).unref?.();
+    });
+    let payload = {};
+    try {
+      payload = JSON.parse(raw);
+    } catch {}
+    const state = HOOK_STATE_MAP[payload?.hook_event_name];
+    const sessionKey = readSessionKey();
+    const sessionId = sessionIdFromPayload(payload);
+    if (!state || !sessionKey || !sessionId) return; // 非 Claude hook / 未配对 / 无会话 id：静默忽略
+    const port = Number(process.env.WORKISLAND_FORWARD_PORT) || FORWARD_PORT_DEFAULT;
+    await talk(port, [{ type: "state", sessionKey, state, sessionId, tool: "claude" }], { timeoutMs: 4000 });
+    return;
+  }
+
+  if (command === "send") {
+    const [state, sessionId, tool = "claude"] = rest;
+    const sessionKey = readSessionKey();
+    if (!sessionKey) {
+      console.error("尚未配对：先运行 pair <令牌>");
+      process.exitCode = 1;
+      return;
+    }
+    if (!state || !sessionId) {
+      console.error("用法：workisland-remote.cjs send <running|completed|failed|approval_requested|stale> <会话id> [工具]");
+      process.exitCode = 1;
+      return;
+    }
+    const port = Number(process.env.WORKISLAND_FORWARD_PORT) || FORWARD_PORT_DEFAULT;
+    const replies = await talk(port, [{ type: "state", sessionKey, state, sessionId, tool }]);
+    const ack = replies.find((r) => r.type === "ack");
+    if (!ack?.ok) {
+      console.error(`发送失败：${ack?.error ?? "无响应"}`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log(`已发送：${tool} ${sessionId} → ${state}`);
+    return;
+  }
+
+  if (command === "install-hooks" || command === "uninstall-hooks") {
+    let settings = {};
+    try {
+      settings = JSON.parse(fs.readFileSync(CLAUDE_SETTINGS, "utf8"));
+    } catch {}
+    if (command === "install-hooks") {
+      if (!fs.existsSync(CLAUDE_SETTINGS)) fs.mkdirSync(path.dirname(CLAUDE_SETTINGS), { recursive: true });
+      try { fs.copyFileSync(CLAUDE_SETTINGS, `${CLAUDE_SETTINGS}.workisland-remote-backup`); } catch {}
+      const selfPath = path.resolve(process.argv[1]);
+      const entry = () => ({
+        hooks: [{ type: "command", command: `node ${selfPath} hook` }]
+      });
+      settings.hooks = settings.hooks ?? {};
+      for (const event of Object.keys(HOOK_STATE_MAP)) {
+        const list = Array.isArray(settings.hooks[event]) ? settings.hooks[event] : [];
+        if (list.some((g) => (g.hooks ?? []).some((h) => String(h.command ?? "").includes(HOOK_MARKER)))) continue;
+        list.push(entry(event));
+        settings.hooks[event] = list;
+      }
+      fs.writeFileSync(CLAUDE_SETTINGS, `${JSON.stringify(settings, null, 2)}\n`);
+      console.log(`Claude Code hook 已写入 ${CLAUDE_SETTINGS}（备份：settings.json.workisland-remote-backup）`);
+    } else {
+      if (settings.hooks) {
+        for (const event of Object.keys(settings.hooks)) {
+          settings.hooks[event] = (settings.hooks[event] ?? []).filter(
+            (group) => !(group.hooks ?? []).some((h) => String(h.command ?? "").includes(HOOK_MARKER))
+          );
+        }
+      }
+      fs.writeFileSync(CLAUDE_SETTINGS, `${JSON.stringify(settings, null, 2)}\n`);
+      console.log("WorkIsland 远程 hook 已移除");
+    }
+    return;
+  }
+
+  console.log(`WorkIsland 远程接入脚本（observe-only）
+
+用法：
+  node workisland-remote.cjs init                    生成/显示 host id
+  node workisland-remote.cjs pair <令牌> [端口]       用一次性令牌换取会话密钥
+  node workisland-remote.cjs hook                    Claude Code hook 入口
+  node workisland-remote.cjs send <状态> <会话id> [工具]  手动发送状态（自检）
+  node workisland-remote.cjs install-hooks           安装 Claude Code hook
+  node workisland-remote.cjs uninstall-hooks         移除 Claude Code hook
+
+前置：SSH 隧道已建立（ssh -N -L 17878:127.0.0.1:7878 <user>@<mac>）`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/scripts/test-source.mjs
+++ b/scripts/test-source.mjs
@@ -59,7 +59,9 @@ const {
 // public bridge contract. Agent Doctor (B-1 PR2) adds settings:repair-hook /
 // repair-all-hooks / get-doctor-audit (155 -> 158 via MCP, +3 here).
 // Island first-run empty state adds island:get-agent-setup-status (161 -> 162, 2026-09).
-assert.equal(Object.keys(IPC).length, 162, "IPC contract changed; review both main and preload consumers");
+// PRD-016 remote access (observe-only) adds remote-hosts:get-state /
+// create-token / revoke (162 -> 165, 2026-09).
+assert.equal(Object.keys(IPC).length, 165, "IPC contract changed; review both main and preload consumers");
 assert.equal(listProductCapabilities({ platform: "darwin" }).length, 15, "MCP product catalog must stay explicit");
 assert.equal(diagnoseMcpSubject("performance-details-not-visible", { settings: {} }).subject, "performance-details-not-visible");
 assert.equal(IPC.APP_UPDATE_DOWNLOAD, "app:update-download");

--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -38,6 +38,8 @@ const { createAppIconResolver } = require("./app-icon-resolver.cjs");
 const { PerformanceService } = require("./performance-service.cjs");
 const { ShelfService } = require("./shelf-service.cjs");
 const { ClipboardHistoryService } = require("./clipboard-history-service.cjs");
+const { RemoteBridgeServer } = require("./remote-bridge-server.cjs");
+const { createRemoteHostStore } = require("./remote-host-store.cjs");
 const { TerminalService } = require("./terminal-service.cjs");
 const { resolveRecentProjectCwd, resolveTerminalCommand } = require("../shared/terminal-state.cjs");
 const { listCodexPets } = require("./codex-pet.cjs");
@@ -302,6 +304,16 @@ function createAppCoordinatorClass({
         shouldAcceptHook: (source) => this.shouldAcceptHookSource(source),
         controlService: this.localControlService
       });
+      // PRD-016 远程接入（observe-only）：远程状态事件复用 bridge 的
+      // agentEvent 总线，去重 / 工具开关 / 通知 / UI 推送与本地会话同一条
+      // 管道；远程侧不产生 hookDirective（无远程审批）。
+      this.remoteHostStore = createRemoteHostStore();
+      this.remoteBridge = new RemoteBridgeServer({
+        hostStore: this.remoteHostStore,
+      });
+      this.remoteBridge.on("agentEvent", (event) => {
+        this.bridge.emit("agentEvent", event);
+      });
       // AI customization commands (workisland-cli) share the settings
       // pipeline: updateSettings persists once and broadcasts to the island,
       // settings, and pet windows.
@@ -521,6 +533,7 @@ function createAppCoordinatorClass({
         this.playAgentSound(eventId, context?.sessionId, context?.timestamp);
       });
       this.bridge.start();
+      this.syncRemoteBridge();
       this.quotaService.start();
       this.processMonitor.start();
       this.mediaService.start();
@@ -869,6 +882,7 @@ function createAppCoordinatorClass({
     }
     stop() {
       log.info("[AppCoordinator] stopping local services...");
+      this.remoteBridge.stop();
       this.bridge.stop();
       this.quotaService.stop();
       this.processMonitor.stop();
@@ -1069,6 +1083,24 @@ function createAppCoordinatorClass({
       if (!this.fullscreenOverrideForNotification) return;
       this.fullscreenOverrideForNotification = false;
       this.evaluateFullscreenVisibility();
+    }
+    // PRD-016 远程接入（observe-only）：设置页状态、配对令牌与主机管理的
+    // 主进程入口；监听器启停跟随 remoteAccess 设置（对齐 developer-api 模式）。
+    syncRemoteBridge() {
+      return this.remoteBridge.sync(this.getSettings()?.remoteAccess ?? {});
+    }
+    getRemoteHostsState() {
+      return {
+        enabled: this.getSettings()?.remoteAccess?.enabled === true,
+        listener: this.remoteBridge.getStatus(),
+        hosts: this.remoteBridge.listHosts()
+      };
+    }
+    createRemotePairingToken() {
+      return this.remoteBridge.createPairingToken();
+    }
+    revokeRemoteHost(hostId) {
+      return this.remoteBridge.revokeHost(hostId);
     }
     getSessions() {
       return getVisibleSessions(this.state);

--- a/src/main/ipc-services.cjs
+++ b/src/main/ipc-services.cjs
@@ -211,6 +211,8 @@ function createIpcServices({ performHapticFeedback, isAllowedExternalUrl, readPa
       coordinator.updateSettings(partial, "settings");
       // B-9：注册时与设置变化后各同步一次，覆盖「上次开着重启」与开关切换。
       syncDeveloperApi(coordinator);
+      // PRD-016 远程接入：observe-only 监听器随设置开关启停。
+      coordinator.syncRemoteBridge();
     });
     electron.ipcMain.handle(IPC.SETTINGS_SELECT_DIRECTORY, (event) => {
       return selectDirectory(electron.BrowserWindow.fromWebContents(event.sender) ?? void 0);
@@ -231,6 +233,17 @@ function createIpcServices({ performHapticFeedback, isAllowedExternalUrl, readPa
     });
     electron.ipcMain.handle(IPC.SETTINGS_GET_HOOK_STATUS, () => {
       return coordinator.getHookStatus();
+    });
+    // PRD-016 远程接入（observe-only）：设置页远程主机管理通道。
+    electron.ipcMain.handle(IPC.REMOTE_HOSTS_GET_STATE, () => {
+      return coordinator.getRemoteHostsState();
+    });
+    electron.ipcMain.handle(IPC.REMOTE_HOSTS_CREATE_TOKEN, () => {
+      return coordinator.createRemotePairingToken();
+    });
+    electron.ipcMain.handle(IPC.REMOTE_HOSTS_REVOKE, (_event, { hostId } = {}) => {
+      if (typeof hostId !== "string" || hostId.length === 0) return false;
+      return coordinator.revokeRemoteHost(hostId);
     });
     electron.ipcMain.handle(IPC.ISLAND_GET_AGENT_SETUP_STATUS, () => {
       return coordinator.getHookStatus();

--- a/src/main/remote-bridge-server.cjs
+++ b/src/main/remote-bridge-server.cjs
@@ -1,0 +1,264 @@
+"use strict";
+
+/**
+ * PRD-016 T2/T3 远程接入 observe-only 入口（ADR-0005 D1–D7 第一阶段）。
+ *
+ * 边界约束：
+ * - 仅监听 127.0.0.1（D1 loopback）；端口被占用时报可读错误，不静默换端口（风险 3）；
+ * - 配对：一次性短时效令牌（D2）换取持久会话密钥，密钥只存哈希；
+ * - D3 白名单在 remote-protocol.cjs 强制执行：状态事件之外的一切（含
+ *   attach / 输入 / 内容回传）在本入口被拒收，不进入任何下游对象；
+ * - 观察模式：只发 agentEvent，不发 hookDirective —— 远程审批、远程操作
+ *   在第一阶段一律不开放（PRD-016 非目标 2）。
+ */
+
+const net = require("node:net");
+const crypto = require("node:crypto");
+const log = require("electron-log");
+const { EventEmitter } = require("node:events");
+const { encodeLine, decodeLines } = require("./bridge-protocol.cjs");
+const {
+  DEFAULT_REMOTE_PORT,
+  MAX_PAIR_FAILURES,
+  createPairingTokenManager,
+  validatePairRequest,
+  validateStateEnvelope,
+  mapStateToAgentEvents,
+  buildDisconnectedEvents
+} = require("./remote-protocol.cjs");
+const { createRemoteHostStore } = require("./remote-host-store.cjs");
+
+class RemoteBridgeServer extends EventEmitter {
+  server = null;
+  port = null;
+  lastError = null;
+  connections = /* @__PURE__ */ new Map();
+  hostStore;
+  tokenManager;
+
+  constructor({ hostStore, tokenManager } = {}) {
+    super();
+    this.hostStore = hostStore ?? createRemoteHostStore();
+    this.tokenManager = tokenManager ?? createPairingTokenManager();
+  }
+
+  /** 按设置启停（对齐 developer-api 的 sync 生命周期模式）。 */
+  sync(remoteAccess = {}) {
+    const wantRunning = remoteAccess?.enabled === true;
+    if (!wantRunning) {
+      this.stop();
+      return this.getStatus();
+    }
+    const port = Number(remoteAccess.port) > 0 ? Number(remoteAccess.port) : DEFAULT_REMOTE_PORT;
+    if (this.server && this.port === port) return this.getStatus();
+    this.stop();
+    this.start(port);
+    return this.getStatus();
+  }
+
+  start(port = DEFAULT_REMOTE_PORT) {
+    if (this.server) return;
+    const server = net.createServer((socket) => this.handleConnection(socket));
+    server.on("error", (err) => {
+      if (err.code === "EADDRINUSE") {
+        // ADR-0005 风险 3：端口冲突必须可读，禁止静默换端口。
+        this.lastError = "PORT_IN_USE";
+        this.server = null;
+        this.port = null;
+        log.error("[RemoteBridge]", `监听失败：127.0.0.1:${port} 已被占用。请释放该端口或在设置中更换远程接入端口。`);
+      } else {
+        this.lastError = "LISTEN_ERROR";
+        log.error("[RemoteBridge] server error:", err.message);
+      }
+    });
+    server.listen(port, "127.0.0.1", () => {
+      this.lastError = null;
+      // port=0（测试临时端口）时回填系统分配的真实端口。
+      this.port = server.address()?.port ?? port;
+      log.info("[RemoteBridge]", `observe-only 入口已就绪：127.0.0.1:${this.port}`);
+    });
+    this.server = server;
+    this.port = port;
+  }
+
+  stop() {
+    for (const conn of this.connections.values()) {
+      try {
+        conn.socket.destroy();
+      } catch {
+        // socket 已关闭时的销毁失败可以忽略
+      }
+    }
+    this.connections.clear();
+    if (this.server) {
+      try {
+        this.server.close();
+      } catch (err) {
+        log.warn("[RemoteBridge] close failed:", err?.message ?? String(err));
+      }
+      this.server = null;
+      this.port = null;
+    }
+  }
+
+  getStatus() {
+    return {
+      running: !!this.server,
+      port: this.port,
+      lastError: this.lastError,
+      connectedHosts: this.hostStore ? Array.from(new Set(Array.from(this.connections.values(), (c) => c.hostId).filter(Boolean))) : []
+    };
+  }
+
+  listHosts() {
+    return this.hostStore.listHosts();
+  }
+
+  hostCount() {
+    return this.hostStore.hostCount();
+  }
+
+  createPairingToken() {
+    return this.tokenManager.createToken();
+  }
+
+  revokeHost(hostId) {
+    const changed = this.hostStore.revokeHost(hostId);
+    if (changed) {
+      // 撤销即断开该主机现存连接（D5）：旧会话密钥随记录删除而失效。
+      for (const conn of this.connections.values()) {
+        if (conn.hostId === hostId) {
+          try {
+            conn.socket.destroy();
+          } catch {
+            // 忽略销毁失败
+          }
+        }
+      }
+    }
+    return changed;
+  }
+
+  handleConnection(socket) {
+    const connId = crypto.randomUUID();
+    const conn = {
+      id: connId,
+      socket,
+      buffer: Buffer.alloc(0),
+      hostId: null,
+      hostName: null,
+      // sessionId → tool，断线时用于收卡
+      sessions: /* @__PURE__ */ new Map(),
+      pairFailures: 0
+    };
+    this.connections.set(connId, conn);
+    // 欢迎行：让远程脚本连接后立刻能确认到达的是 WorkIsland observe-only 入口。
+    this.writeLine(conn, { type: "ready", protocolVersion: 1, observeOnly: true });
+    socket.on("data", (chunk) => {
+      conn.buffer = Buffer.concat([conn.buffer, chunk]);
+      const { messages, remainder, errors } = decodeLines(conn.buffer);
+      conn.buffer = remainder;
+      for (const error of errors) {
+        this.writeLine(conn, { type: "ack", ok: false, error: error.code });
+      }
+      for (const msg of messages) {
+        this.handleLine(conn, msg);
+      }
+    });
+    const finish = () => {
+      this.connections.delete(connId);
+      if (conn.hostId && conn.sessions.size > 0) {
+        for (const event of buildDisconnectedEvents({
+          sessions: conn.sessions,
+          hostId: conn.hostId,
+          hostName: conn.hostName ?? "远程主机"
+        })) {
+          this.emit("agentEvent", event);
+        }
+      }
+    };
+    socket.on("close", finish);
+    socket.on("error", finish);
+  }
+
+  handleLine(conn, msg) {
+    if (msg?.type === "pair") {
+      this.handlePair(conn, msg);
+      return;
+    }
+    if (msg?.type === "state") {
+      this.handleState(conn, msg);
+      return;
+    }
+    this.writeLine(conn, { type: "ack", ok: false, error: "UNKNOWN_TYPE" });
+  }
+
+  handlePair(conn, msg) {
+    if (!this.tokenManager.consume(msg.token)) {
+      conn.pairFailures += 1;
+      this.writeLine(conn, { type: "pairResult", ok: false, error: "TOKEN_INVALID" });
+      if (conn.pairFailures >= MAX_PAIR_FAILURES) {
+        conn.socket.destroy();
+      }
+      return;
+    }
+    const pair = validatePairRequest(msg);
+    if (!pair.ok) {
+      this.writeLine(conn, { type: "pairResult", ok: false, error: pair.reason });
+      return;
+    }
+    const sessionKey = crypto.randomBytes(32).toString("base64url");
+    const host = this.hostStore.upsertHost(pair.hostId, pair.displayName, sessionKey);
+    conn.hostId = host.hostId;
+    conn.hostName = host.displayName;
+    log.info("[RemoteBridge]", `主机已配对：${host.displayName} (${host.hostId})`);
+    this.writeLine(conn, { type: "pairResult", ok: true, sessionKey, hostId: host.hostId, displayName: host.displayName });
+  }
+
+  handleState(conn, msg) {
+    const envelope = validateStateEnvelope(msg);
+    if (!envelope.ok) {
+      this.writeLine(conn, { type: "ack", ok: false, error: envelope.reason });
+      return;
+    }
+    const host = this.hostStore.findBySessionKey(envelope.sessionKey);
+    if (!host) {
+      this.writeLine(conn, { type: "ack", ok: false, error: "HOST_UNKNOWN_OR_REVOKED" });
+      return;
+    }
+    // 同主机重连接管：旧连接不再持有该主机的会话，断开时不发误报收卡。
+    for (const other of this.connections.values()) {
+      if (other !== conn && other.hostId === host.hostId && other.sessions.size > 0) {
+        other.sessions.clear();
+      }
+    }
+    conn.hostId = host.hostId;
+    conn.hostName = host.displayName;
+    if (envelope.state === "stale" || envelope.state === "completed" || envelope.state === "failed") {
+      conn.sessions.delete(envelope.sessionId);
+    } else {
+      conn.sessions.set(envelope.sessionId, envelope.tool);
+    }
+    for (const event of mapStateToAgentEvents({
+      state: envelope.state,
+      sessionId: envelope.sessionId,
+      tool: envelope.tool,
+      timestamp: Date.now(),
+      hostId: host.hostId,
+      hostName: host.displayName
+    })) {
+      this.emit("agentEvent", event);
+    }
+    this.writeLine(conn, { type: "ack", ok: true });
+  }
+
+  writeLine(conn, payload) {
+    try {
+      conn.socket.write(encodeLine(payload));
+    } catch (err) {
+      log.warn("[RemoteBridge] write failed:", err?.message ?? String(err));
+    }
+  }
+}
+
+module.exports = { RemoteBridgeServer };

--- a/src/main/remote-host-store.cjs
+++ b/src/main/remote-host-store.cjs
@@ -1,0 +1,95 @@
+"use strict";
+
+/**
+ * 远程主机注册表（ADR-0005 D4 / D5）。
+ *
+ * 持久化在 ~/.flux/remote-hosts.json（0600）：
+ * - hostId（UUID，远程侧生成）→ 显示名 + 会话密钥的 SHA-256 哈希；
+ * - 撤销 = 删除记录，旧会话密钥立即失效（D5）；
+ * - 配对令牌与明文会话密钥永远不落盘。
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const crypto = require("node:crypto");
+
+function getStorePath(homeDir = os.homedir()) {
+  return path.join(homeDir, ".flux", "remote-hosts.json");
+}
+
+function hashSessionKey(sessionKey) {
+  return crypto.createHash("sha256").update(sessionKey, "utf8").digest("hex");
+}
+
+function createRemoteHostStore({ filePath = getStorePath(), now = Date.now } = {}) {
+  let data = { hosts: [] };
+
+  function load() {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      if (parsed && Array.isArray(parsed.hosts)) data = { hosts: parsed.hosts };
+    } catch {
+      data = { hosts: [] };
+    }
+    return data;
+  }
+
+  function save() {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), { mode: 0o600 });
+  }
+
+  load();
+
+  return {
+    /** 首次配对或刷新显示名；每次调用都会轮换会话密钥哈希。 */
+    upsertHost(hostId, displayName, sessionKey) {
+      const timestamp = now();
+      let host = data.hosts.find((h) => h.hostId === hostId);
+      if (host) {
+        host.displayName = displayName;
+        host.sessionKeyHash = hashSessionKey(sessionKey);
+        host.pairedAt = timestamp;
+        host.lastSeenAt = timestamp;
+      } else {
+        host = {
+          hostId,
+          displayName,
+          sessionKeyHash: hashSessionKey(sessionKey),
+          pairedAt: timestamp,
+          lastSeenAt: timestamp
+        };
+        data.hosts.push(host);
+      }
+      save();
+      return { hostId: host.hostId, displayName: host.displayName, pairedAt: host.pairedAt, lastSeenAt: host.lastSeenAt };
+    },
+    /** 会话密钥 → 主机记录（哈希比对）；命中时刷新 lastSeenAt。 */
+    findBySessionKey(sessionKey) {
+      const hash = hashSessionKey(sessionKey);
+      const host = data.hosts.find((h) => h.sessionKeyHash === hash);
+      if (!host) return null;
+      host.lastSeenAt = now();
+      return { hostId: host.hostId, displayName: host.displayName, pairedAt: host.pairedAt, lastSeenAt: host.lastSeenAt };
+    },
+    /** D5 撤销：删除记录即拉黑当前会话密钥；重新配对需要用户重新生成令牌。 */
+    revokeHost(hostId) {
+      const before = data.hosts.length;
+      data.hosts = data.hosts.filter((h) => h.hostId !== hostId);
+      const changed = data.hosts.length !== before;
+      if (changed) save();
+      return changed;
+    },
+    listHosts() {
+      return data.hosts
+        .map(({ hostId, displayName, pairedAt, lastSeenAt }) => ({ hostId, displayName, pairedAt, lastSeenAt }))
+        .sort((a, b) => (b.lastSeenAt ?? 0) - (a.lastSeenAt ?? 0));
+    },
+    hostCount() {
+      return data.hosts.length;
+    }
+  };
+}
+
+module.exports = { createRemoteHostStore, getStorePath, hashSessionKey };

--- a/src/main/remote-protocol.cjs
+++ b/src/main/remote-protocol.cjs
@@ -1,0 +1,175 @@
+"use strict";
+
+/**
+ * PRD-016 T2 远程接入协议（第一阶段 observe-only，ADR-0005 D1–D7）。
+ *
+ * 纯函数模块，不依赖 electron / net —— 全部规则在这里单测覆盖：
+ * - D2 配对令牌：一次性、短时效（10 分钟），换取持久会话密钥；
+ * - D3 事件白名单：入口只读取 sessionKey / state / sessionId / tool 四个字段，
+ *   其余字段（prompt/transcript/路径等）即使出现在报文中也不进入下游对象；
+ * - 状态 → agentEvent 映射只产出固定、无内容的摘要文案，不透传远程内容。
+ */
+
+const crypto = require("node:crypto");
+
+const DEFAULT_REMOTE_PORT = 7878;
+const PAIRING_TOKEN_TTL_MS = 10 * 60 * 1000;
+const MAX_PAIR_FAILURES = 5;
+
+// D3：仅接受这五种状态事件。交互式（attach / 输入 / 内容回传）一律不在此列。
+const REMOTE_STATES = Object.freeze(["running", "completed", "failed", "approval_requested", "stale"]);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SESSION_ID_RE = /^[A-Za-z0-9_-]{8,128}$/;
+const TOOL_RE = /^[a-z][a-z0-9-]{1,23}$/;
+
+/**
+ * 配对令牌管理器（D2）。令牌只存在于内存，从不持久化；
+ * consume 一次即销毁，无论成功与否。
+ */
+function createPairingTokenManager({ now = Date.now, ttlMs = PAIRING_TOKEN_TTL_MS } = {}) {
+  const tokens = /* @__PURE__ */ new Map();
+  return {
+    createToken() {
+      for (const [token, expiresAt] of tokens) {
+        if (expiresAt <= now()) tokens.delete(token);
+      }
+      const token = crypto.randomBytes(24).toString("base64url");
+      const expiresAt = now() + ttlMs;
+      tokens.set(token, expiresAt);
+      return { token, expiresAt, ttlMs };
+    },
+    consume(token) {
+      if (typeof token !== "string" || token.length === 0) return false;
+      const expiresAt = tokens.get(token);
+      if (expiresAt === undefined) return false;
+      tokens.delete(token);
+      return expiresAt > now();
+    },
+    get pendingCount() {
+      return tokens.size;
+    }
+  };
+}
+
+/** 校验配对请求（hostId 必须是 UUID，显示名去控制字符并限长）。 */
+function validatePairRequest(msg) {
+  const hostId = typeof msg?.hostId === "string" ? msg.hostId.trim() : "";
+  if (!UUID_RE.test(hostId)) return { ok: false, reason: "HOST_ID_INVALID" };
+  let displayName = typeof msg?.displayName === "string" ? msg.displayName.trim() : "";
+  displayName = displayName.replace(/[\u0000-\u001f]/g, "").slice(0, 64);
+  if (!displayName) displayName = "远程主机";
+  return { ok: true, hostId, displayName };
+}
+
+/**
+ * D3 白名单校验与字段抽取。返回对象只含四个白名单字段——
+ * 这是「入口丢弃内容字段」的物理实现：下游拿不到没被读出来的东西。
+ */
+function validateStateEnvelope(msg) {
+  const sessionKey = typeof msg?.sessionKey === "string" ? msg.sessionKey : "";
+  if (sessionKey.length < 16 || sessionKey.length > 128) {
+    return { ok: false, reason: "SESSION_KEY_INVALID" };
+  }
+  const state = msg?.state;
+  if (!REMOTE_STATES.includes(state)) {
+    return { ok: false, reason: "STATE_NOT_ALLOWED" };
+  }
+  const sessionId = typeof msg?.sessionId === "string" ? msg.sessionId : "";
+  if (!SESSION_ID_RE.test(sessionId)) {
+    return { ok: false, reason: "SESSION_ID_INVALID" };
+  }
+  const tool = typeof msg?.tool === "string" ? msg.tool : "";
+  if (!TOOL_RE.test(tool)) {
+    return { ok: false, reason: "TOOL_INVALID" };
+  }
+  return { ok: true, sessionKey, state, sessionId, tool };
+}
+
+function shortSessionCode(sessionId) {
+  return sessionId.slice(-6);
+}
+
+/**
+ * 远程状态 → 本地 agentEvent 映射。只产出固定形状、无远程内容的事件：
+ * 标题用 tool + sessionId 短码合成，摘要文案固定，不含远程发来的任何文本。
+ */
+function mapStateToAgentEvents({ state, sessionId, tool, timestamp, hostId, hostName }) {
+  const base = {
+    sessionId,
+    tool,
+    timestamp,
+    isRemote: true,
+    remoteHostId: hostId,
+    remoteHostName: hostName
+  };
+  switch (state) {
+    case "running":
+      return [{ ...base, type: "sessionStarted", title: `${tool} · ${shortSessionCode(sessionId)}` }];
+    case "approval_requested":
+      return [{
+        ...base,
+        type: "permissionRequested",
+        title: `${tool} · ${shortSessionCode(sessionId)}`,
+        // observe-only：不携带工具参数等审批内容；远程会话不走审批卡，仅展示等待状态。
+        permissionRequest: { toolName: "remote" }
+      }];
+    case "completed":
+      return [{
+        ...base,
+        type: "sessionCompleted",
+        title: `${tool} · ${shortSessionCode(sessionId)}`,
+        isSessionEnd: false,
+        summary: "远程任务完成"
+      }];
+    case "failed":
+      return [{
+        ...base,
+        type: "sessionCompleted",
+        title: `${tool} · ${shortSessionCode(sessionId)}`,
+        isSessionEnd: false,
+        error: "remote-failed",
+        summary: "远程任务失败"
+      }];
+    case "stale":
+      return [{
+        ...base,
+        type: "sessionCompleted",
+        isSessionEnd: true
+      }];
+    default:
+      return [];
+  }
+}
+
+/** 隧道断开时对该连接内的活跃会话发出的收卡事件（ADR-0005 风险 2 / 附注 3）。 */
+function buildDisconnectedEvents({ sessions, hostId, hostName, timestamp = Date.now() }) {
+  const events = [];
+  for (const [sessionId, tool] of sessions) {
+    events.push({
+      type: "sessionCompleted",
+      sessionId,
+      tool,
+      timestamp,
+      isRemote: true,
+      remoteHostId: hostId,
+      remoteHostName: hostName,
+      isSessionEnd: false,
+      error: "remote-disconnected",
+      summary: "远程连接已断开"
+    });
+  }
+  return events;
+}
+
+module.exports = {
+  DEFAULT_REMOTE_PORT,
+  PAIRING_TOKEN_TTL_MS,
+  MAX_PAIR_FAILURES,
+  REMOTE_STATES,
+  createPairingTokenManager,
+  validatePairRequest,
+  validateStateEnvelope,
+  mapStateToAgentEvents,
+  buildDisconnectedEvents
+};

--- a/src/main/session-state.cjs
+++ b/src/main/session-state.cjs
@@ -361,6 +361,16 @@ function createSessionState({ isVisibleInIsland }) {
         return state;
       }
     }
+    // PRD-016 远程会话（observe-only）：isRemote / 主机标注随事件透传，
+    // 本地事件不含这些字段，行为与之前完全一致。
+    if (event.isRemote || prev.isRemote || prev.remoteHostId) {
+      session = {
+        ...session,
+        isRemote: event.isRemote ?? prev.isRemote ?? false,
+        remoteHostId: event.remoteHostId ?? prev.remoteHostId,
+        remoteHostName: event.remoteHostName ?? prev.remoteHostName
+      };
+    }
     sessions.set(event.sessionId, session);
     syncSubagentFields(sessions, session);
     return { sessions };

--- a/src/preload/settings.js
+++ b/src/preload/settings.js
@@ -21,6 +21,10 @@ electron.contextBridge.exposeInMainWorld("settingsApi", {
   repairHook: (agentId) => electron.ipcRenderer.invoke(ipc.IPC.SETTINGS_REPAIR_HOOK, { agentId }),
   repairAllHooks: () => electron.ipcRenderer.invoke(ipc.IPC.SETTINGS_REPAIR_ALL_HOOKS),
   getDoctorAudit: () => electron.ipcRenderer.invoke(ipc.IPC.SETTINGS_GET_DOCTOR_AUDIT),
+  // PRD-016 远程接入（observe-only）：远程主机管理。
+  getRemoteHostsState: () => electron.ipcRenderer.invoke(ipc.IPC.REMOTE_HOSTS_GET_STATE),
+  createRemotePairingToken: () => electron.ipcRenderer.invoke(ipc.IPC.REMOTE_HOSTS_CREATE_TOKEN),
+  revokeRemoteHost: (hostId) => electron.ipcRenderer.invoke(ipc.IPC.REMOTE_HOSTS_REVOKE, { hostId }),
   // 插件元信息：renderer 缓存供 AgentToolBadge 等做 label/badgeColor 兜底。
   getPluginAgentMeta: () => electron.ipcRenderer.invoke(ipc.IPC.PLUGIN_AGENT_META),
   onSettingsChanged: (cb) => {

--- a/src/renderer/island/components/IslandPanel.css
+++ b/src/renderer/island/components/IslandPanel.css
@@ -266,6 +266,21 @@
   flex-shrink: 0;
 }
 
+/* PRD-016 远程会话：主机名标注（按 host 分组识别来源机器）。 */
+.session-remote-host {
+  font-size: 11px;
+  line-height: 1.4em;
+  padding: 0 5px;
+  border-radius: 4px;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.14);
+  white-space: nowrap;
+  max-width: 96px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 0;
+}
+
 .session-title {
   font-size: 13px;
   font-weight: 500;

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -532,7 +532,7 @@ function SessionRow({
         height: 32
       }
     ),
-    /* @__PURE__ */ React.createElement("div", { className: "session-body" }, /* @__PURE__ */ React.createElement("div", { className: "session-headline" }, /* @__PURE__ */ React.createElement("div", { className: "session-headline-left" }, /* @__PURE__ */ React.createElement(AgentToolBadge, { tool: session.tool }), /* @__PURE__ */ React.createElement("span", { className: "session-title" }, session.title)), /* @__PURE__ */ React.createElement("div", { className: "session-meta" }, terminalApp && /* @__PURE__ */ React.createElement("span", { className: "session-terminal" }, terminalApp.toLowerCase() === "claude" ? "APP" : cleanAppName(terminalApp)), /* @__PURE__ */ React.createElement("span", { className: "session-elapsed" }, elapsed), canContinueSession && /* @__PURE__ */ React.createElement(
+    /* @__PURE__ */ React.createElement("div", { className: "session-body" }, /* @__PURE__ */ React.createElement("div", { className: "session-headline" }, /* @__PURE__ */ React.createElement("div", { className: "session-headline-left" }, /* @__PURE__ */ React.createElement(AgentToolBadge, { tool: session.tool }), session.remoteHostName && /* @__PURE__ */ React.createElement("span", { className: "session-remote-host", title: "远程主机" }, session.remoteHostName), /* @__PURE__ */ React.createElement("span", { className: "session-title" }, session.title)), /* @__PURE__ */ React.createElement("div", { className: "session-meta" }, terminalApp && /* @__PURE__ */ React.createElement("span", { className: "session-terminal" }, terminalApp.toLowerCase() === "claude" ? "APP" : cleanAppName(terminalApp)), /* @__PURE__ */ React.createElement("span", { className: "session-elapsed" }, elapsed), canContinueSession && /* @__PURE__ */ React.createElement(
       "button",
       {
         type: "button",
@@ -1428,6 +1428,9 @@ function ContinuePromptInput({
 }
 function renderActionableCard(props) {
   const { session, actionableId, isFollowUpOpen, onCollapse, onFollowUpClick } = props;
+  // PRD-016 远程会话（observe-only）：审批/追问/跳转都作用不到远程机器，
+  // 不渲染可操作卡，仅保留常规状态卡与等待角标。
+  if (session.isRemote) return null;
   if (session.phase === "waitingForApproval")
     return /* @__PURE__ */ React.createElement(ApprovalCard, { session });
   if (session.phase === "waitingForAnswer") {

--- a/src/renderer/island/session-model.mjs
+++ b/src/renderer/island/session-model.mjs
@@ -2,6 +2,10 @@ export function isVisibleInIsland(session) {
   if (session.parentSessionId) return false;
   if (session.phase === "waitingForApproval" || session.phase === "waitingForAnswer") return true;
 
+  // PRD-016 远程会话（observe-only）：不回传 latestUserPrompt（D3），
+  // 只要未结束就保留在岛上；断线时以断线完成态收卡，不悬挂假 running。
+  if (session.isRemote) return !session.isSessionEnded;
+
   if (session.isHookManaged) {
     if (session.isSessionEnded) return false;
     if (session.tool === "trae") return Boolean(session.latestUserPrompt);

--- a/src/renderer/settings-app.css
+++ b/src/renderer/settings-app.css
@@ -121,3 +121,10 @@ input[type=range] { flex:1; accent-color:var(--accent); }
 .complaint-status { margin: 0; min-height: 1em; font-size: 12px; color: var(--muted); }
 .complaint-actions { display: flex; gap: 8px; justify-content: flex-end; }
 .setting-actions-group { display: flex; gap: 8px; }
+
+/* PRD-016 远程接入：主机列表与一次性配对令牌展示。 */
+.remote-host-card { display:flex; align-items:center; justify-content:space-between; gap:12px; min-height:60px; padding:12px 14px; background:var(--card); border:1px solid var(--line); border-radius:11px; }
+.remote-host-copy { min-width:0; }
+.remote-host-name { font-weight:600; }
+.remote-host-detail { font-size:12px; color:var(--muted, #8a8f98); margin-top:2px; }
+.remote-token-box { max-width:280px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; padding:6px 10px; background:var(--card); border:1px solid var(--line); border-radius:8px; font-family:ui-monospace, SFMono-Regular, Menlo, monospace; font-size:12px; user-select:all; }

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -34,7 +34,7 @@ const AGENT_ICON_URLS = Object.freeze({
   "plugin:pi": "../assets/brands/pi.svg"
 });
 const VERIFY_ON_REAL_EVENT_AGENT_IDS = new Set(["dsh", "trae"]);
-const state = { settings: null, statuses: new Map(), doctorSummary: null, displays: [], codexPets: [], templates: { active: null, templates: [] }, shareProviders: [], activeTab: "general", busy: new Set(), expandedSettingDetails: new Set(), latestUpdate: null, updateState: null, onUpdateStateUi: null, telemetryStatus: null, agentControl: null, agentControlManual: null, commandDraft: { name: "", command: "" } };
+const state = { settings: null, statuses: new Map(), doctorSummary: null, displays: [], codexPets: [], templates: { active: null, templates: [] }, shareProviders: [], activeTab: "general", busy: new Set(), expandedSettingDetails: new Set(), latestUpdate: null, updateState: null, onUpdateStateUi: null, telemetryStatus: null, agentControl: null, agentControlManual: null, commandDraft: { name: "", command: "" }, remoteHosts: null, remotePairing: null };
 
 function el(tag, className, text) {
   const node = document.createElement(tag);
@@ -717,6 +717,85 @@ function agentCard(report) {
   return card;
 }
 
+async function loadRemoteHosts(render = false) {
+  try {
+    state.remoteHosts = await api.getRemoteHostsState?.() || null;
+  } catch {
+    state.remoteHosts = null;
+  }
+  if (render && state.activeTab === "agents") renderPage();
+}
+
+function copyText(text, label) {
+  navigator.clipboard?.writeText(text).then(
+    () => showToast(`${label}已复制`),
+    () => showToast("复制失败，请手动选择复制", true)
+  );
+}
+
+// PRD-016 / ADR-0005 远程接入（observe-only）：令牌、主机列表与撤销。
+function remoteHostsSection() {
+  const remote = state.remoteHosts;
+  const cfg = state.settings.remoteAccess || { enabled: false, port: 7878 };
+  const node = section("远程主机", "远程机器上的 Agent 状态实时上岛。observe-only：只回传运行状态，不回传提示词、代码或路径；远程接入需要 Mac 开启「远程登录」并在远程机器上按 docs/REMOTE_ONBOARDING.md 建立隧道。");
+  node.append(row("启用远程接入", "开启后 WorkIsland 在本机 127.0.0.1 只新增一个 observe-only 监听端口。", toggle(remote?.enabled ?? cfg.enabled, async v => {
+    await save({ remoteAccess: { ...cfg, enabled: v } });
+    await loadRemoteHosts();
+    renderPage();
+  }, "启用远程接入")));
+  if (!remote) {
+    node.append(el("div", "setting-description", "远程主机状态不可用。"));
+    return node;
+  }
+  if (remote.enabled && !remote.listener?.running) {
+    node.append(el("div", "doctor-summary", remote.listener?.lastError === "PORT_IN_USE" ? `监听失败：端口 ${remote.listener?.port ?? cfg.port} 已被占用，请更换端口后重试。` : "监听未运行，请尝试重新开关远程接入。"));
+  }
+  const tokenArea = el("div", "inline-controls");
+  tokenArea.append(button("生成配对令牌", async () => {
+    try {
+      state.remotePairing = await api.createRemotePairingToken();
+      renderPage();
+    } catch (error) {
+      showToast(error?.message || "生成令牌失败", true);
+    }
+  }, "primary"));
+  if (state.remotePairing?.token) {
+    const expires = new Date(state.remotePairing.expiresAt).toLocaleTimeString();
+    const tokenBox = el("code", "remote-token-box", state.remotePairing.token);
+    tokenArea.append(tokenBox, button("复制", () => copyText(state.remotePairing.token, "令牌")));
+    node.append(el("div", "setting-description", `令牌 ${state.remotePairing.token.slice(0, 4)}… 只显示本次，10 分钟内有效且只能用一次（至 ${expires}）。把它提供给远程机器上的 AI 助手完成配对。`));
+  }
+  node.append(row("配对令牌", "远程机器首次接入时使用；每个令牌只能绑定一台主机一次。", tokenArea));
+  const list = el("div", "agent-list");
+  for (const host of remote.hosts || []) {
+    const pairedAt = host.pairedAt ? new Date(host.pairedAt).toLocaleString() : "";
+    const online = (remote.listener?.connectedHosts || []).includes(host.hostId);
+    const card = el("div", "remote-host-card");
+    const content = el("div", "remote-host-copy");
+    content.append(el("div", "remote-host-name", host.displayName));
+    content.append(el("div", "remote-host-detail", `${online ? "已连接" : "未连接"} · 配对于 ${pairedAt}`));
+    const revoke = button("撤销", async () => {
+      if (!window.confirm(`撤销 ${host.displayName} 后，该主机的会话密钥立即失效；重新接入需要生成新令牌。`)) return;
+      try {
+        await api.revokeRemoteHost(host.hostId);
+        state.remotePairing = null;
+        await loadRemoteHosts();
+        renderPage();
+        showToast("主机已撤销");
+      } catch (error) {
+        showToast(error?.message || "撤销失败", true);
+      }
+    }, "danger");
+    card.append(content, revoke);
+    list.append(card);
+  }
+  if ((remote.hosts || []).length === 0) {
+    list.append(el("div", "setting-description", "还没有接入的远程主机。生成配对令牌后，把 docs/REMOTE_ONBOARDING.md 交给远程机器上的 AI 助手即可。"));
+  }
+  node.append(list);
+  return node;
+}
+
 function agentsPage() {
   const root = document.createDocumentFragment();
   const hooks = section("本地 Agent", "连接只会修改对应 Agent 的本地 Hook 配置，不依赖云端服务。一键检测会扫描全部 Agent 的 Hook 配置并给出修复建议。");
@@ -744,6 +823,7 @@ function agentsPage() {
   );
   hooks.append(tools);
   root.append(hooks);
+  root.append(remoteHostsSection());
   return root;
 }
 
@@ -1227,11 +1307,15 @@ async function start() {
   await loadDisplays();
   await loadCodexPets();
   await loadAgentControlStatus();
+  await loadRemoteHosts();
   await loadTemplates();
   document.querySelectorAll(".nav-item").forEach(item => item.addEventListener("click", () => {
     state.activeTab = item.dataset.tab;
     renderPage();
-    if (state.activeTab === "agents") refreshAgents().catch(error => showToast(error.message, true));
+    if (state.activeTab === "agents") {
+      refreshAgents().catch(error => showToast(error.message, true));
+      loadRemoteHosts(true).catch(error => showToast(error.message, true));
+    }
     if (state.activeTab === "mcp") loadAgentControlStatus(true).catch(() => {});
   }));
   api.onNavigateToTab?.(tab => {

--- a/src/shared/ipc.cjs
+++ b/src/shared/ipc.cjs
@@ -156,6 +156,10 @@ const IPC = Object.freeze({
   SETTINGS_DISCONNECT_AGENT_CONTROL_CLIENT: "settings:disconnect-agent-control-client",
   SETTINGS_GET_AGENT_CONTROL_MANUAL_CONFIG: "settings:get-agent-control-manual-config",
 
+  REMOTE_HOSTS_GET_STATE: "remote-hosts:get-state",
+  REMOTE_HOSTS_CREATE_TOKEN: "remote-hosts:create-token",
+  REMOTE_HOSTS_REVOKE: "remote-hosts:revoke",
+
   GET_LOCALE: "locale:get",
   SET_LOCALE: "locale:set",
   APP_QUIT: "app:quit",

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -122,6 +122,11 @@ const DEFAULT_SETTINGS = {
   // session status metadata. See src/main/developer-api.cjs and
   // docs/DEVELOPER_API.md.
   developerApi: { enabled: false, port: 9938, token: "" },
+  // PRD-016 / ADR-0005 远程接入（2026-09）：observe-only SSH 隧道入口，默认
+  // 关闭。开启后 WorkIsland 只新增 127.0.0.1:7878 一个 loopback 监听；远程
+  // 状态事件经用户自管 SSH 隧道进入，入口白名单剥离一切内容字段（D3）。
+  // See src/main/remote-bridge-server.cjs and docs/REMOTE_ONBOARDING.md.
+  remoteAccess: { enabled: false, port: 7878 },
   // B-2 Quiet Hours (2026-09): suppress local alert sounds during the quiet
   // window (supports overnight ranges) and while macOS is locked. Bark push
   // is intentionally NOT suppressed — it is the notification path while the

--- a/tests/remote-bridge-server.test.mjs
+++ b/tests/remote-bridge-server.test.mjs
@@ -1,0 +1,277 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect } from "node:net";
+
+const require = createRequire(import.meta.url);
+const { RemoteBridgeServer } = require("../src/main/remote-bridge-server.cjs");
+const { createPairingTokenManager } = require("../src/main/remote-protocol.cjs");
+const { createRemoteHostStore } = require("../src/main/remote-host-store.cjs");
+
+const UUID = "a1b2c3d4-e5f6-4a1b-8c2d-1234567890ab";
+
+function makeStore() {
+  const dir = mkdtempSync(join(tmpdir(), "workisland-remote-test-"));
+  const store = createRemoteHostStore({ filePath: join(dir, "remote-hosts.json") });
+  return { store, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+/** 行协议客户端：收到的每行 JSON 依次出队。 */
+function makeClient(port) {
+  const socket = connect({ port, host: "127.0.0.1" });
+  let buffer = "";
+  const queue = [];
+  const pending = [];
+  socket.on("data", (chunk) => {
+    buffer += chunk.toString("utf8");
+    let index;
+    while ((index = buffer.indexOf("\n")) >= 0) {
+      const line = buffer.slice(0, index);
+      buffer = buffer.slice(index + 1);
+      if (!line) continue;
+      if (pending.length > 0) pending.shift()(JSON.parse(line));
+      else queue.push(JSON.parse(line));
+    }
+  });
+  const nextLine = () => new Promise((resolve) => pending.push(resolve));
+  const waitLine = async () => (queue.length > 0 ? queue.shift() : nextLine());
+  const send = (obj) => socket.write(`${JSON.stringify(obj)}\n`);
+  return { socket, waitLine, send, end: () => new Promise((r) => socket.end(r)) };
+}
+
+async function setupServer() {
+  const { store, cleanup } = makeStore();
+  const tokenManager = createPairingTokenManager();
+  const server = new RemoteBridgeServer({ hostStore: store, tokenManager });
+  const events = [];
+  server.on("agentEvent", (event) => events.push(event));
+  server.start(0);
+  for (let i = 0; i < 50 && !server.port; i += 1) {
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  assert.ok(server.port > 0, "server must expose its bound port");
+  return { server, port: server.port, events, store, tokenManager, cleanup, stop: () => server.stop() };
+}
+
+test("pair with valid token issues session key once (D2)", async () => {
+  const ctx = await setupServer();
+  try {
+    const { token } = ctx.tokenManager.createToken();
+    const client = makeClient(ctx.port);
+    await client.waitLine(); // ready
+    client.send({ type: "pair", hostId: UUID, displayName: "dev-box", token });
+    const pairResult = await client.waitLine();
+    assert.equal(pairResult.ok, true);
+    assert.ok(pairResult.sessionKey.length >= 16);
+    assert.equal(ctx.store.hostCount(), 1);
+    await client.end();
+
+    // 同一令牌第二次配对必须失败（一次性）
+    const attacker = makeClient(ctx.port);
+    await attacker.waitLine();
+    attacker.send({ type: "pair", hostId: UUID, displayName: "dev-box", token });
+    const second = await attacker.waitLine();
+    assert.equal(second.ok, false, "token must be single-use");
+    assert.equal(second.error, "TOKEN_INVALID");
+    await attacker.end();
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("pair with invalid token is rejected and never registers a host", async () => {
+  const ctx = await setupServer();
+  try {
+    const client = makeClient(ctx.port);
+    await client.waitLine();
+    client.send({ type: "pair", hostId: UUID, displayName: "dev-box", token: "forged" });
+    const result = await client.waitLine();
+    assert.equal(result.ok, false);
+    assert.equal(result.error, "TOKEN_INVALID");
+    assert.equal(ctx.store.hostCount(), 0);
+    await client.end();
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("state events flow with host metadata and never carry content (D3)", async () => {
+  const ctx = await setupServer();
+  try {
+    const { token } = ctx.tokenManager.createToken();
+    const client = makeClient(ctx.port);
+    await client.waitLine();
+    client.send({ type: "pair", hostId: UUID, displayName: "dev-box", token });
+    const { sessionKey } = await client.waitLine();
+
+    client.send({
+      type: "state",
+      sessionKey,
+      state: "running",
+      sessionId: "sess-12345678",
+      tool: "claude",
+      prompt: "机密提示词",
+      transcript_path: "/home/user/.claude/x.jsonl"
+    });
+    const ack = await client.waitLine();
+    assert.equal(ack.ok, true);
+
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(ctx.events.length, 1);
+    const event = ctx.events[0];
+    assert.equal(event.type, "sessionStarted");
+    assert.equal(event.isRemote, true);
+    assert.equal(event.remoteHostId, UUID);
+    assert.equal(event.remoteHostName, "dev-box");
+    assert.equal(event.sessionId, "sess-12345678");
+    assert.equal(event.prompt, undefined, "content fields must be dropped at entry");
+    assert.equal(event.transcript_path, undefined, "content fields must be dropped at entry");
+    await client.end();
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("state with unknown session key is rejected", async () => {
+  const ctx = await setupServer();
+  try {
+    const client = makeClient(ctx.port);
+    await client.waitLine();
+    client.send({ type: "state", sessionKey: "nobody-issued-this-key-0001", state: "running", sessionId: "sess-12345678", tool: "claude" });
+    const ack = await client.waitLine();
+    assert.equal(ack.ok, false);
+    assert.equal(ack.error, "HOST_UNKNOWN_OR_REVOKED");
+    await client.end();
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("revoked host key stops working immediately (D5)", async () => {
+  const ctx = await setupServer();
+  try {
+    const { token } = ctx.tokenManager.createToken();
+    const client = makeClient(ctx.port);
+    await client.waitLine();
+    client.send({ type: "pair", hostId: UUID, displayName: "dev-box", token });
+    const { sessionKey } = await client.waitLine();
+
+    client.send({ type: "state", sessionKey, state: "running", sessionId: "sess-12345678", tool: "claude" });
+    assert.equal((await client.waitLine()).ok, true);
+
+    // D5：撤销即拉黑当前会话密钥，并断开该主机现存连接。
+    assert.equal(ctx.server.revokeHost(UUID), true);
+    const fresh = makeClient(ctx.port);
+    await fresh.waitLine();
+    fresh.send({ type: "state", sessionKey, state: "completed", sessionId: "sess-12345678", tool: "claude" });
+    const ack = await fresh.waitLine();
+    assert.equal(ack.ok, false, "revoked key must fail");
+    assert.equal(ack.error, "HOST_UNKNOWN_OR_REVOKED");
+    await fresh.end();
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("non-whitelisted state is rejected without emitting events", async () => {
+  const ctx = await setupServer();
+  try {
+    const { token } = ctx.tokenManager.createToken();
+    const client = makeClient(ctx.port);
+    await client.waitLine();
+    client.send({ type: "pair", hostId: UUID, displayName: "dev-box", token });
+    const { sessionKey } = await client.waitLine();
+
+    client.send({ type: "state", sessionKey, state: "attach", sessionId: "sess-12345678", tool: "claude" });
+    const ack = await client.waitLine();
+    assert.equal(ack.ok, false);
+    assert.equal(ack.error, "STATE_NOT_ALLOWED");
+    await new Promise((r) => setTimeout(r, 20));
+    assert.equal(ctx.events.length, 0, "observe-only：交互式诉求在入口被拒");
+    await client.end();
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("tunnel close emits disconnected completion, never fake running", async () => {
+  const ctx = await setupServer();
+  try {
+    const { token } = ctx.tokenManager.createToken();
+    const client = makeClient(ctx.port);
+    await client.waitLine();
+    client.send({ type: "pair", hostId: UUID, displayName: "dev-box", token });
+    const { sessionKey } = await client.waitLine();
+
+    client.send({ type: "state", sessionKey, state: "running", sessionId: "sess-12345678", tool: "claude" });
+    await client.waitLine();
+    client.socket.destroy();
+
+    await new Promise((r) => setTimeout(r, 50));
+    const close = ctx.events.find((e) => e.type === "sessionCompleted" && e.error === "remote-disconnected");
+    assert.ok(close, "disconnect must complete the session with a disconnected marker");
+    assert.equal(close.isSessionEnd, false);
+    assert.equal(close.remoteHostName, "dev-box");
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("reconnect from the same host supersedes the stale connection's disconnect events", async () => {
+  const ctx = await setupServer();
+  try {
+    const first = makeClient(ctx.port);
+    await first.waitLine();
+    const { token } = ctx.tokenManager.createToken();
+    first.send({ type: "pair", hostId: UUID, displayName: "dev-box", token });
+    const { sessionKey } = await first.waitLine();
+    first.send({ type: "state", sessionKey, state: "running", sessionId: "sess-12345678", tool: "claude" });
+    await first.waitLine();
+
+    // 同主机第二连接接管后，旧连接断开不应发断线收卡
+    const second = makeClient(ctx.port);
+    await second.waitLine();
+    second.send({ type: "state", sessionKey, state: "running", sessionId: "sess-12345678", tool: "claude" });
+    await second.waitLine();
+    first.socket.destroy();
+
+    await new Promise((r) => setTimeout(r, 50));
+    assert.equal(
+      ctx.events.some((e) => e.error === "remote-disconnected"),
+      false,
+      "superseded connection must not emit disconnect events"
+    );
+    second.socket.destroy();
+  } finally {
+    ctx.stop();
+    ctx.cleanup();
+  }
+});
+
+test("sync() starts and stops the listener with settings (loopback only)", () => {
+  const { store, cleanup } = makeStore();
+  try {
+    const server = new RemoteBridgeServer({ hostStore: store });
+    let status = server.sync({ enabled: false });
+    assert.equal(status.running, false);
+
+    status = server.sync({ enabled: true, port: 20000 + Math.floor(Math.random() * 20000) });
+    assert.equal(status.running, true);
+    assert.ok(status.port > 0);
+
+    status = server.sync({ enabled: false });
+    assert.equal(status.running, false);
+  } finally {
+    cleanup();
+  }
+});

--- a/tests/remote-protocol.test.mjs
+++ b/tests/remote-protocol.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const {
+  REMOTE_STATES,
+  createPairingTokenManager,
+  validatePairRequest,
+  validateStateEnvelope,
+  mapStateToAgentEvents,
+  buildDisconnectedEvents
+} = require("../src/main/remote-protocol.cjs");
+
+test("pairing token is single-use (D2)", () => {
+  const manager = createPairingTokenManager();
+  const { token } = manager.createToken();
+  assert.equal(manager.consume(token), true, "first consume must succeed");
+  assert.equal(manager.consume(token), false, "second consume must fail — 一次性");
+});
+
+test("pairing token expires after TTL (D2)", () => {
+  let clock = 1_000_000;
+  const manager = createPairingTokenManager({ now: () => clock });
+  const { token } = manager.createToken();
+  clock += 10 * 60 * 1000 + 1;
+  assert.equal(manager.consume(token), false, "expired token must be rejected");
+});
+
+test("pairing token unknown value is rejected", () => {
+  const manager = createPairingTokenManager();
+  assert.equal(manager.consume(""), false);
+  assert.equal(manager.consume("forged-token"), false);
+  assert.equal(manager.consume(undefined), false);
+});
+
+test("validatePairRequest accepts UUID hostId and sanitizes displayName", () => {
+  const pair = validatePairRequest({
+    hostId: "a1b2c3d4-e5f6-4a1b-8c2d-1234567890ab",
+    displayName: "  dev-box\n\u0007  "
+  });
+  assert.equal(pair.ok, true);
+  assert.equal(pair.hostId, "a1b2c3d4-e5f6-4a1b-8c2d-1234567890ab");
+  assert.equal(pair.displayName, "dev-box");
+  assert.ok(pair.displayName.length <= 64);
+});
+
+test("validatePairRequest rejects non-UUID hostId and falls back display name", () => {
+  assert.equal(validatePairRequest({ hostId: "not-a-uuid" }).ok, false);
+  assert.equal(validatePairRequest({ hostId: 42 }).ok, false);
+  const fallback = validatePairRequest({ hostId: "a1b2c3d4-e5f6-4a1b-8c2d-1234567890ab" });
+  assert.equal(fallback.ok, true);
+  assert.equal(fallback.displayName, "远程主机");
+});
+
+test("D3 whitelist: envelope with content fields only yields the four allowed fields", () => {
+  const envelope = validateStateEnvelope({
+    sessionKey: "k".repeat(32),
+    state: "running",
+    sessionId: "sess-12345678",
+    tool: "claude",
+    // 攻击性/内容字段：即使出现也绝不能进入返回对象
+    prompt: "内部机密提示词",
+    transcript: "==========",
+    cwd: "/home/user/secret-project",
+    apiKey: "sk-xxx"
+  });
+  assert.equal(envelope.ok, true);
+  assert.deepEqual(Object.keys(envelope).sort(), ["ok", "sessionId", "sessionKey", "state", "tool"]);
+  assert.equal(envelope.prompt, undefined);
+  assert.equal(envelope.transcript, undefined);
+  assert.equal(envelope.cwd, undefined);
+  assert.equal(envelope.apiKey, undefined);
+});
+
+test("D3 whitelist: interactive / unknown states are rejected", () => {
+  for (const state of REMOTE_STATES) {
+    assert.equal(validateStateEnvelope({ sessionKey: "k".repeat(32), state, sessionId: "sess-12345678", tool: "claude" }).ok, true, state);
+  }
+  for (const state of ["attach", "input", "read_screen", "exec", "running; drop table"]) {
+    assert.equal(validateStateEnvelope({ sessionKey: "k".repeat(32), state, sessionId: "sess-12345678", tool: "claude" }).ok, false, state);
+  }
+});
+
+test("validateStateEnvelope rejects malformed ids and tools", () => {
+  const base = { sessionKey: "k".repeat(32), state: "running" };
+  assert.equal(validateStateEnvelope({ ...base, sessionId: "short", tool: "claude" }).ok, false);
+  assert.equal(validateStateEnvelope({ ...base, sessionId: "has 空格 inside!", tool: "claude" }).ok, false);
+  assert.equal(validateStateEnvelope({ ...base, sessionId: "sess-12345678", tool: "Bad Tool" }).ok, false);
+  assert.equal(validateStateEnvelope({ ...base, sessionId: "sess-12345678", tool: "claude", sessionKey: "tiny" }).ok, false);
+});
+
+test("mapStateToAgentEvents produces fixed content-free shapes", () => {
+  const args = { sessionId: "sess-12345678", tool: "claude", timestamp: 1000, hostId: "h-uuid", hostName: "dev-box" };
+  const [running] = mapStateToAgentEvents({ state: "running", ...args });
+  assert.equal(running.type, "sessionStarted");
+  assert.equal(running.isRemote, true);
+  assert.equal(running.remoteHostName, "dev-box");
+  assert.equal(running.title, "claude · 345678");
+  assert.equal(running.latestUserPrompt, undefined);
+
+  const [approval] = mapStateToAgentEvents({ state: "approval_requested", ...args });
+  assert.equal(approval.type, "permissionRequested");
+  assert.deepEqual(Object.keys(approval.permissionRequest), ["toolName"], "observe-only：不带审批内容");
+
+  const [completed] = mapStateToAgentEvents({ state: "completed", ...args });
+  assert.equal(completed.type, "sessionCompleted");
+  assert.equal(completed.isSessionEnd, false);
+  assert.equal(completed.summary, "远程任务完成");
+
+  const [failed] = mapStateToAgentEvents({ state: "failed", ...args });
+  assert.equal(failed.type, "sessionCompleted");
+  assert.equal(failed.error, "remote-failed");
+
+  const [stale] = mapStateToAgentEvents({ state: "stale", ...args });
+  assert.equal(stale.type, "sessionCompleted");
+  assert.equal(stale.isSessionEnd, true);
+
+  // 所有远程事件都不允许携带内容型字段
+  for (const event of [running, approval, completed, failed, stale]) {
+    for (const forbidden of ["latestUserPrompt", "lastAssistantMessage", "currentActivity", "transcriptPath", "cwd"]) {
+      assert.equal(event[forbidden], undefined, `${event.type} must not carry ${forbidden}`);
+    }
+  }
+});
+
+test("buildDisconnectedEvents marks every tracked session without fake running", () => {
+  const sessions = new Map([["sess-12345678", "claude"], ["sess-aaaaaaaa", "codex"]]);
+  const events = buildDisconnectedEvents({ sessions, hostId: "h-uuid", hostName: "dev-box", timestamp: 42 });
+  assert.equal(events.length, 2);
+  for (const event of events) {
+    assert.equal(event.type, "sessionCompleted");
+    assert.equal(event.isRemote, true);
+    assert.equal(event.isSessionEnd, false);
+    assert.equal(event.error, "remote-disconnected");
+    assert.equal(event.summary, "远程连接已断开");
+  }
+});


### PR DESCRIPTION
## 概要

issue #116 第一阶段（**observe-only 远程接入**）落地。ADR-0005 D1–D7 于 2026-09-07 由负责人裁定通过（第一阶段），本 PR 按裁定范围交付 T2 协议 + T3 配对与主机管理 + T4 接入指南 + T5 岛上标注；**tmux attach / 交互式操作不在本 PR**（超出 D3 白名单，二期另裁，`feature/remote-pairing-ui` 分支名保留）。

## 安全边界（ADR-0005 对照）

| 项 | 实现 |
| --- | --- |
| D1 入口 | 仅 `127.0.0.1:7878` loopback 监听；端口占用可读报错、不静默换端口。隧道由远程侧 `ssh -L 17878:127.0.0.1:7878` 建立（修正了原稿 `ssh -R` 的方向问题，见 ADR 第 5 节附注 1） |
| D2 配对 | 一次性 10 分钟令牌，内存持有、从不落盘；换取持久会话密钥，密钥只存 SHA-256 哈希（`~/.flux/remote-hosts.json`，0600） |
| D3 白名单 | 入口只读取报文 `sessionKey / state / sessionId / tool` 四字段并重构事件对象，**其余字段（prompt/transcript/路径）物理不可达**；远程状态只映射为固定无内容的中文摘要事件（单测断言事件键集合） |
| D4 主机身份 | 远程侧 UUID host id + 可改显示名，按 host 标注分组 |
| D5 撤销 | 设置页撤销即删除记录（旧密钥立即失效）并断开现存连接 |
| D6 脚本分发 | 零依赖脚本入库 `resources/remote/workisland-remote.cjs`，指南内嵌 SHA-256 校验和，AI 执行前先校验 |
| D7 公网中转 | 不做，维持本地优先 |

## 交付内容

- **主进程**：`remote-protocol.cjs`（纯函数协议：令牌/校验/映射，全单测）、`remote-host-store.cjs`（主机注册表）、`remote-bridge-server.cjs`（observe-only TCP 入口）。远程 `agentEvent` 复用 bridge 事件总线 → 去重、通知、UI 推送与本地会话同一条管道
- **设置页**：Agents 页新增「远程主机」——启用开关、生成/复制配对令牌、已接入主机列表（在线状态 + 撤销）
- **岛上**：远程会话卡带主机名徽标；observe-only 不渲染审批/追问/跳转卡；断线以断线完成态收卡，恢复后自动覆盖，无假 running
- **远程侧**：`workisland-remote.cjs`（init/pair/hook/send/install-hooks，Claude Code 五个 hook 事件自动回传）+ AI 可读指南 `docs/REMOTE_ONBOARDING.md`
- **契约**：IPC 162 → 165，`scripts/test-source.mjs` 守卫同步

## 测试

- [x] `npm run check` 全绿（渲染层构建 + 源码契约 + 512/512 单测）
- [x] 新增 19 例单测：令牌一次性/过期、白名单剥离（内容字段断言不存在）、非白名单状态拒收、撤销即失效、断线收卡、同主机重连接管、loopback 启停
- [ ] 真机验收：一台真实远程主机端到端（令牌配对 → 状态上岛 → 断线恢复）；按 PRD-019 红线，索引上线前后重跑 #108 闲置 CPU 基准（<3%）

## 已知限制（第一阶段）

- 审批仍在远程终端完成，岛上远程卡无审批按钮（observe-only）
- 隧道断开期间事件丢失不补发；自动 hook 目前只装 Claude Code（其他 Agent 可用 `send` 手动回传）
- Mac 侧需用户自开「远程登录」（系统级 sshd），指南已写明前置

Refs #116
