### PR TITLE
docs(release): v1.4.0 候选纳入远程接入第一阶段

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [1.4.0] - 2026-09-07
 
-「覆盖与留存」第一阶段收口版本：把安静时段、Plan 确认卡 Markdown 渲染、本地开发者 API 与用量发现通道四个已验证特性正式发出，并首次公开闲置性能实测数据；发布侧自本版起执行中英双语 Release Notes。
+「覆盖与留存」第一阶段收口版本：把安静时段、Plan 确认卡 Markdown 渲染、本地开发者 API、用量发现通道与远程接入（observe-only 第一阶段）五个已验证特性正式发出，并首次公开闲置性能实测数据；发布侧自本版起执行中英双语 Release Notes。
 
 ### Added
 
@@ -16,7 +16,9 @@
 - **用量发现通道（首批）**（#94）：zcode / opencode / claude 三个客户端的 token 用量改为主动从各客户端本地会话数据发现并入账，不再依赖 Hook 携带 `transcript_path`；此前这些客户端会话能上岛但用量不入账。剩余适配器在 issue #90 跟踪。
 - **性能实测数据公开**（#108）：Apple M4 · v1.3.0 实测闲置 CPU 中位 2.9%（达标 < 3%，贴线）、内存 top 口径 535 MB / RSS 341 MB；方法与原始采样见 [PERFORMANCE.md](docs/PERFORMANCE.md)，`scripts/perf-idle-benchmark.mjs` 可复现，README 增加展示位。
 
-> **English summary:** Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations now render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
+- **远程接入 observe-only 第一阶段**（#116，ADR-0005）：设置 → Agents → 远程主机生成一次性配对令牌后，远程机器上的 AI 助手按内置指南（[REMOTE_ONBOARDING.md](docs/REMOTE_ONBOARDING.md)）自助建立 SSH 隧道，远程 Agent 会话状态（运行中 / 等待审批 / 完成 / 失败）实时上岛并按主机分组；只回传状态，不回传提示词、代码或路径，入口白名单强制剥离内容字段；本机仅新增 `127.0.0.1:7878` loopback 监听，令牌可随时撤销；tmux attach 等交互式能力属二期另裁。
+
+> **English summary:** Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations now render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108); phase 1 of observe-only remote access (#116) — pair a remote machine with a one-time token and stream its agent session status to the Island over a user-managed SSH tunnel, grouped by host, status only with content fields dropped at the entry, interactive attach deferred.
 
 ## [1.3.0] - 2026-09-05
 

--- a/docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md
+++ b/docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md
@@ -14,6 +14,9 @@ v1.3.0 完成了公测门槛（Agent Doctor / 反馈通道 / 首启引导 / 签�
 | Plan 确认卡 Markdown 渲染 | #92 | 折叠展开，复用岛上既有渲染样式 |
 | 本地开发者 API | #93 | `127.0.0.1:9938`，默认关闭，Bearer 鉴权 |
 | 用量发现通道（首批） | #94 | zcode / opencode / claude 三数据源，不依赖 transcript_path |
+| 远程接入 observe-only 第一阶段 | #122 | issue #116 第一阶段：SSH 隧道状态上岛，设置 → Agents → 远程主机；指南 docs/REMOTE_ONBOARDING.md |
+
+> 范围修订 2026-09-07：负责人裁定 ADR-0005 第一阶段（observe-only）通过，#122 并入 v1.4.0 候选范围；tmux attach 等交互式能力属二期，另裁后开工（`feature/remote-pairing-ui` 保留）。
 
 ## 二、发布必做（chore，不完成不 tag）
 

--- a/docs/RELEASE_NOTES_UNRELEASED.md
+++ b/docs/RELEASE_NOTES_UNRELEASED.md
@@ -2,7 +2,7 @@
 
 状态：`release-candidate — 范围冻结；Tag 推送后由 GitHub Actions 签名公证并创建正式 Release`
 
-本版主题「覆盖与留存 · 第一阶段收口」：把已合入 `main` 验证的四个留存/开放特性正式发出去，并首次公开性能实测数据。范围基线见 [`docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md`](./03-roadmap/v1.4.0-版本规划-2026-09-06.md)；完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)。
+本版主题「覆盖与留存 · 第一阶段收口」：把已合入 `main` 验证的四个留存/开放特性与远程接入 observe-only 第一阶段正式发出去，并首次公开性能实测数据。范围基线见 [`docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md`](./03-roadmap/v1.4.0-版本规划-2026-09-06.md)；完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)。
 
 自本版起，GitHub Release 说明采用 **中文全文在前 + `### English Summary` 在后** 的双语结构（英文为摘要，不逐条直译），检查项见 [`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md)。
 
@@ -14,6 +14,13 @@
 - **Plan 确认卡 Markdown 渲染**（#92）：Plan 确认文本按 Markdown 渲染（标题、列表、代码块，复用岛上既有渲染样式），默认折叠、一键展开全文；链接点击走系统浏览器。
 - **本地开发者 API**（#93）：设置 → 关于可开启只读状态端点 `127.0.0.1:9938/api/status`，返回会话状态 JSON；默认关闭，可选 Bearer 令牌鉴权；响应不含 prompt、路径或会话内容。详见 [DEVELOPER_API.md](./DEVELOPER_API.md)。
 - **用量发现通道（首批）**（#94）：zcode / opencode / claude 三个客户端的 token 用量改为主动从本地会话数据发现并入账，不再依赖 Hook 携带 `transcript_path`；此前这些客户端会话能上岛但用量不入账。
+
+### 远程接入：observe-only 第一阶段
+
+- **远程主机状态上岛**（#116，ADR-0005 第一阶段裁定通过）：设置 → Agents → 远程主机生成一次性配对令牌（10 分钟有效、单次使用），远程机器上的 AI 助手按内置指南 [REMOTE_ONBOARDING.md](./REMOTE_ONBOARDING.md) 自助建立 SSH 隧道，远程 Agent 会话状态实时上岛并按主机分组标注。
+- **observe-only 安全边界**：只回传运行状态，不回传提示词、代码或路径——入口白名单只读取状态元数据并物理丢弃其余字段；本机仅新增 `127.0.0.1:7878` 一个 loopback 监听；隧道由用户自管 SSH 建立，公网中转不做；令牌可随时撤销，撤销立即生效。
+- **断线不骗人**：隧道断开时远程会话以「远程连接已断开」收卡，恢复后自动覆盖，不悬挂假 running。
+- tmux attach / 交互式操作超出 observe-only 白名单，属二期另裁，本版不含。
 
 ### 性能
 
@@ -27,7 +34,7 @@
 
 ### English Summary
 
-Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
+Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); phase 1 of observe-only remote access (#116) — pair a remote machine with a one-time token and stream its agent session status to the Island over a user-managed SSH tunnel, grouped by host; status only with content fields dropped at the entry, tunnel drops surface as explicit disconnected cards, interactive attach deferred; published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
 
 ## What's Changed
 


### PR DESCRIPTION
CHANGELOG / Release Notes / 版本规划三处同步 #122（issue #116 observe-only 第一阶段）进入 v1.4.0 候选范围；release:check v1.4.0 通过。纯文档，不改动代码。Refs #116