### PR TITLE
docs(release): align v1.4 notes with merged i18n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## [1.4.0] - 2026-09-07
 
-「覆盖与留存」第一阶段收口版本：把安静时段、Plan 确认卡 Markdown 渲染、本地开发者 API、用量发现通道与远程接入（observe-only 第一阶段）五个已验证特性正式发出，并首次公开闲置性能实测数据；发布侧自本版起执行中英双语 Release Notes。
+「覆盖与留存」第一阶段收口版本：把安静时段、Plan 确认卡 Markdown 渲染、本地开发者 API、用量发现通道、远程接入（observe-only 第一阶段）与全应用中英双语六项已验证能力正式发出，并首次公开闲置性能实测数据。
 
 ### Added
 
@@ -14,11 +14,12 @@
 - **Plan 确认卡 Markdown 渲染**（#92）：Plan 确认文本按 Markdown 渲染（标题、列表、代码块，复用岛上既有渲染样式），默认折叠至固定高度、可一键展开全文；不新增依赖与 IPC 通道。
 - **本地开发者 API**（#93）：设置 → 关于可开启只读状态端点 `127.0.0.1:9938/api/status`，返回会话状态 JSON（id / Agent / phase / 时间戳 + 版本）；默认关闭，可选 Bearer 令牌鉴权；响应不含 prompt、路径或会话内容。详见 [DEVELOPER_API.md](docs/DEVELOPER_API.md)。
 - **用量发现通道（首批）**（#94）：zcode / opencode / claude 三个客户端的 token 用量改为主动从各客户端本地会话数据发现并入账，不再依赖 Hook 携带 `transcript_path`；此前这些客户端会话能上岛但用量不入账。剩余适配器在 issue #90 跟踪。
+- **全应用中英双语**（#110）：新增跟随系统、简体中文与 English 三种语言偏好；设置页切换后灵动岛、设置、欢迎页、桌宠、原生菜单/对话框和可见诊断原地同步刷新，不重启窗口、不丢失终端或工作台状态。801 组词条和占位符由 CI 守卫校验。
 - **性能实测数据公开**（#108）：Apple M4 · v1.3.0 实测闲置 CPU 中位 2.9%（达标 < 3%，贴线）、内存 top 口径 535 MB / RSS 341 MB；方法与原始采样见 [PERFORMANCE.md](docs/PERFORMANCE.md)，`scripts/perf-idle-benchmark.mjs` 可复现，README 增加展示位。
 
 - **远程接入 observe-only 第一阶段**（#116，ADR-0005）：设置 → Agents → 远程主机生成一次性配对令牌后，远程机器上的 AI 助手按内置指南（[REMOTE_ONBOARDING.md](docs/REMOTE_ONBOARDING.md)）自助建立 SSH 隧道，远程 Agent 会话状态（运行中 / 等待审批 / 完成 / 失败）实时上岛并按主机分组；只回传状态，不回传提示词、代码或路径，入口白名单强制剥离内容字段；本机仅新增 `127.0.0.1:7878` loopback 监听，令牌可随时撤销；tmux attach 等交互式能力属二期另裁。
 
-> **English summary:** Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations now render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108); phase 1 of observe-only remote access (#116) — pair a remote machine with a one-time token and stream its agent session status to the Island over a user-managed SSH tunnel, grouped by host, status only with content fields dropped at the entry, interactive attach deferred.
+> **English summary:** Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations now render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); full Chinese/English localization (#110) with system-language detection, live switching and 801 catalog pairs guarded in CI; published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108); phase 1 of observe-only remote access (#116) — pair a remote machine with a one-time token and stream its agent session status to the Island over a user-managed SSH tunnel, grouped by host, status only with content fields dropped at the entry, interactive attach deferred.
 
 ## [1.3.0] - 2026-09-05
 

--- a/docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md
+++ b/docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md
@@ -15,13 +15,14 @@ v1.3.0 完成了公测门槛（Agent Doctor / 反馈通道 / 首启引导 / 签�
 | 本地开发者 API | #93 | `127.0.0.1:9938`，默认关闭，Bearer 鉴权 |
 | 用量发现通道（首批） | #94 | zcode / opencode / claude 三数据源，不依赖 transcript_path |
 | 远程接入 observe-only 第一阶段 | #122 | issue #116 第一阶段：SSH 隧道状态上岛，设置 → Agents → 远程主机；指南 docs/REMOTE_ONBOARDING.md |
+| 全应用中英双语 | #138 | issue #110 已关闭：跟随系统 / 简体中文 / English、实时切换与词条质量门 |
 
-> 范围修订 2026-09-07：负责人裁定 ADR-0005 第一阶段（observe-only）通过，#122 并入 v1.4.0 候选范围；tmux attach 等交互式能力属二期，另裁后开工（`feature/remote-pairing-ui` 保留）。
+> 范围修订 2026-09-07：负责人裁定 ADR-0005 第一阶段（observe-only）通过，#122 并入 v1.4.0 候选范围；tmux attach 等交互式能力属二期，另裁后开工（`feature/remote-pairing-ui` 保留）。2026-09-09：#138 合入 `main` 并关闭 #110；中英双语以完整检查和真实 macOS 验收为前提纳入本候选。
 
 ## 二、发布必做（chore，不完成不 tag）
 
 - [ ] **Release Notes 中英双语**（#107，milestone 内）：v1.4.0 起 Release 页中英双语，CHANGELOG 每版配英文摘要
-- [ ] CHANGELOG 补录上述 4 个功能
+- [ ] CHANGELOG 与 Release Notes 补录本候选的全部六项用户能力
 - [ ] 官网 changelog 同步
 - [ ] **tag 后验证 x64 管线**：#103 修复了 Intel 构建路径，本版 tag 是第一个验证点——x64 DMG 若产出并过签名公证，宣发才解锁"支持 Intel"
 
@@ -34,7 +35,6 @@ v1.3.0 完成了公测门槛（Agent Doctor / 反馈通道 / 首启引导 / 签�
 | 条目 | Issue | 状态 | 前置 |
 | --- | --- | --- | --- |
 | 无刘海/内置屏悬浮条 | #109 | needs-prd | 形态 PRD（附件形态，复用 PR #36 设计，勿重蹈 #28→#43） |
-| 应用内中英 i18n | #110 | needs-prd | 字符串外置方案 |
 | 会话/tab 级聚焦抑制 | #111 | needs-validation | 终端焦点信号能力矩阵 |
 | 五大终端 tab 级跳转 | #112 | needs-validation | 逐终端实机验证 |
 

--- a/docs/RELEASE_NOTES_UNRELEASED.md
+++ b/docs/RELEASE_NOTES_UNRELEASED.md
@@ -2,18 +2,19 @@
 
 状态：`release-candidate — 范围冻结；Tag 推送后由 GitHub Actions 签名公证并创建正式 Release`
 
-本版主题「覆盖与留存 · 第一阶段收口」：把已合入 `main` 验证的四个留存/开放特性与远程接入 observe-only 第一阶段正式发出去，并首次公开性能实测数据。范围基线见 [`docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md`](./03-roadmap/v1.4.0-版本规划-2026-09-06.md)；完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)。
+本版主题「覆盖与留存 · 第一阶段收口」：把已合入 `main` 的留存/开放能力、远程接入 observe-only 第一阶段与全应用中英双语正式发出去，并首次公开性能实测数据。范围基线见 [`docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md`](./03-roadmap/v1.4.0-版本规划-2026-09-06.md)；完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)。
 
 自本版起，GitHub Release 说明采用 **中文全文在前 + `### English Summary` 在后** 的双语结构（英文为摘要，不逐条直译），检查项见 [`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md)。
 
 ## 中文说明（tag 时粘贴到 Release 页前半）
 
-### 覆盖与留存：四个新特性
+### 覆盖与留存：五个新特性
 
 - **安静时段与锁屏静音**（#95）：设置 → 声音可配置勿扰时段（如 22:00 → 08:00，支持跨午夜），时段内不播放任务提示音；macOS 锁屏期间同样静音；两项独立开关。手机推送（Bark）刻意不受抑制——安静时段用户不在电脑前，推送正是通知出口。
 - **Plan 确认卡 Markdown 渲染**（#92）：Plan 确认文本按 Markdown 渲染（标题、列表、代码块，复用岛上既有渲染样式），默认折叠、一键展开全文；链接点击走系统浏览器。
 - **本地开发者 API**（#93）：设置 → 关于可开启只读状态端点 `127.0.0.1:9938/api/status`，返回会话状态 JSON；默认关闭，可选 Bearer 令牌鉴权；响应不含 prompt、路径或会话内容。详见 [DEVELOPER_API.md](./DEVELOPER_API.md)。
 - **用量发现通道（首批）**（#94）：zcode / opencode / claude 三个客户端的 token 用量改为主动从本地会话数据发现并入账，不再依赖 Hook 携带 `transcript_path`；此前这些客户端会话能上岛但用量不入账。
+- **全应用中英双语**（#110）：新增“跟随系统 / 简体中文 / English”语言偏好；切换会同步刷新灵动岛、设置、欢迎页、桌宠、托盘、原生对话框与可见诊断，但不会 reload 窗口、终端或工作台。801 组中英文词条与占位符由 CI 质量门持续校验。
 
 ### 远程接入：observe-only 第一阶段
 
@@ -28,13 +29,13 @@
 
 ### 说明
 
-- 本 DMG 已 Developer ID 签名并通过 Apple 公证，下载后可直接打开（SHA256 见 `SHA256SUMS.txt`）。
+- 正式 DMG 只有在 GitHub Actions 完成 Developer ID 签名、Apple 公证、Staple 与 Gatekeeper 验证后才对外发布（SHA256 见随 Release 生成的 `SHA256SUMS.txt`）。
 - Intel（x64）安装包：#103 已修复 Intel 构建路径，本版 tag 是第一个验证点——x64 DMG 产出并通过签名公证后，才在宣发中解锁「支持 Intel」；发布后回填实际结果。
 - 装过 3.x 旧包的同学：由于版本号重置，旧包认不出 1.x 是新版，请手动下载重装这一次；此后应用内自动升级即生效。
 
 ### English Summary
 
-Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); phase 1 of observe-only remote access (#116) — pair a remote machine with a one-time token and stream its agent session status to the Island over a user-managed SSH tunnel, grouped by host; status only with content fields dropped at the entry, tunnel drops surface as explicit disconnected cards, interactive attach deferred; published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
+Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); full Chinese/English localization (#110) supports system language, Chinese and English with live switching and no workspace reset; phase 1 of observe-only remote access (#116) — pair a remote machine with a one-time token and stream its agent session status to the Island over a user-managed SSH tunnel, grouped by host; status only with content fields dropped at the entry, tunnel drops surface as explicit disconnected cards, interactive attach deferred; published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
 
 ## What's Changed
 
@@ -56,5 +57,5 @@ Quiet Hours and lock-screen mute for local alert sounds, with Bark push delibera
 
 - Intel 机型的媒体工作台依赖 MediaRemote 私有框架，行为与 Apple Silicon 存在差异，属尽力支持（见 [COMPATIBILITY.md](./COMPATIBILITY.md)）。
 - Windows Alpha 为独立版本线，不在本版本范围（见版本规划第五节）。
-- 会话/tab 级聚焦抑制（#111）、五大终端 tab 级跳转（#112）、无刘海悬浮条（#109）、应用内 i18n（#110）明确顺延 v1.5+，勿提前开工。
+- 会话/tab 级聚焦抑制（#111）、五大终端 tab 级跳转（#112）与无刘海悬浮条（#109）明确顺延 v1.5+，勿提前开工。
 - 出现 P0 时发布新的 `v1.4.1`，绝不覆盖既有 Tag 或替换既有产物。


### PR DESCRIPTION
Updates the v1.4.0 candidate scope after #138 merged and closed #110.

- records full Chinese/English localization in CHANGELOG, release notes, and scope baseline
- removes the stale claim that i18n is deferred to v1.5+
- makes signing/notarization a release gate instead of claiming it has already happened

Validation: `npm run release:check -- --tag v1.4.0`; `npm run check` (552 passing tests).

Refs #110 #134