### PR TITLE
fix(island): 工具栏刘海图标安全边距——按屏幕自适应（#151）

### DIFF
--- a/src/renderer/island/components/toolbar-model.mjs
+++ b/src/renderer/island/components/toolbar-model.mjs
@@ -1,4 +1,8 @@
 export const TOOL_SLOT = 32;
+// #151 刘海屏安全边距：任何工具槽位与物理刘海边缘保持的最小间距。
+// 窄屏（面板宽 ≈ 刘海 + 40px）上几像素的中心偏差就会让边缘图标被刘海
+// 物理遮挡，两侧各留 TOOL_CAMERA_MARGIN 后边界图标不再贴玻璃。
+export const TOOL_CAMERA_MARGIN = 8;
 export function toolbarCapacity(width, count) {
   const slots = Math.max(0, Math.floor(width / TOOL_SLOT) - 2);
   return count <= slots ? count : Math.max(0, slots - 1);
@@ -14,8 +18,11 @@ export function insertTool(order, source, index) {
 // share one reading order, but no slot intersects the physical camera.
 export function toolbarSlots(width, notchWidth, leadingWidth) {
   const cameraWidth = Math.max(0, Math.min(notchWidth, width));
-  const cameraLeft = (width - cameraWidth) / 2;
-  const cameraRight = cameraLeft + cameraWidth;
+  // 禁区在物理刘海两侧各外扩 TOOL_CAMERA_MARGIN；无刘海（notchWidth=0）
+  // 时不引入边距，行为与之前完全一致。
+  const cameraHalf = cameraWidth / 2 + (cameraWidth > 0 ? TOOL_CAMERA_MARGIN : 0);
+  const cameraLeft = Math.max(0, width / 2 - cameraHalf);
+  const cameraRight = Math.min(width, width / 2 + cameraHalf);
   const leftStart = Math.min(cameraLeft, Math.max(0, leadingWidth) + (leadingWidth ? 8 : 0));
   const slots = [];
   for (let x = leftStart; x + TOOL_SLOT <= cameraLeft; x += TOOL_SLOT) slots.push({ x, bank: 'left' });

--- a/tests/toolbar-model.test.mjs
+++ b/tests/toolbar-model.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { toolbarCapacity, insertTool, toolbarSlots, toolbarDropTarget, visibleToolbarOrder, placeToolbarTools, moveToolbarTool } from '../src/renderer/island/components/toolbar-model.mjs';
+import { toolbarCapacity, insertTool, toolbarSlots, toolbarDropTarget, visibleToolbarOrder, placeToolbarTools, moveToolbarTool, TOOL_CAMERA_MARGIN } from '../src/renderer/island/components/toolbar-model.mjs';
 test('overflow reserves home, settings and more without consuming camera space', () => {
   assert.equal(toolbarCapacity(256, 6), 6);
   assert.equal(toolbarCapacity(224, 6), 4);
@@ -10,7 +10,8 @@ test('overflow reserves home, settings and more without consuming camera space',
 test('balances real spare space around the camera without covering quota', () => {
   const layout = toolbarSlots(640, 200, 92);
   assert.deepEqual(layout.slots.filter(s => s.bank === 'left').map(s => s.x), [100,132,164]);
-  assert.equal(layout.home, 420);
+  // #151 刘海禁区两侧各外扩 TOOL_CAMERA_MARGIN：home 从 420 移到 428。
+  assert.equal(layout.home, 420 + TOOL_CAMERA_MARGIN);
   for (const slot of layout.slots) {
     assert.ok(slot.x >= 100);
     assert.ok(slot.x + 32 <= layout.cameraLeft || slot.x >= layout.cameraRight + 32);
@@ -36,6 +37,31 @@ test('external screens and dense quota never produce slots inside the camera', (
     const layout = toolbarSlots(width, notch, quota);
     for (const slot of layout.slots) assert.ok(slot.x+32 <= layout.cameraLeft || slot.x >= layout.cameraRight);
   }
+});
+
+test('#151 every slot keeps the camera margin from the physical notch edges', () => {
+  for (const width of [220,258,420,704]) for (const notch of [0,180,194,240]) {
+    const layout = toolbarSlots(width, notch, 0);
+    const notchLeft = width / 2 - Math.min(notch, width) / 2;
+    const notchRight = width / 2 + Math.min(notch, width) / 2;
+    for (const slot of layout.slots) {
+      if (slot.bank === 'left') {
+        assert.ok(slot.x + 32 <= layout.cameraLeft, 'left slot ends inside camera margin');
+        if (notch > 0) assert.ok(notchLeft - (slot.x + 32) >= TOOL_CAMERA_MARGIN - 1e-9, 'left slot too close to the notch');
+      } else {
+        assert.ok(slot.x >= layout.cameraRight + 32 - 1e-9, 'right slot starts inside camera margin');
+        if (notch > 0) assert.ok(slot.x - notchRight >= TOOL_CAMERA_MARGIN - 1e-9, 'right slot too close to the notch');
+      }
+    }
+  }
+});
+
+test('#151 narrow notch panel keeps zero slots and a full-margin camera zone', () => {
+  // 14 寸刘海屏收起态：面板宽 ≈ 刘海 + 40，两侧各只剩 ~20px，不允许出槽位。
+  const layout = toolbarSlots(220, 180, 0);
+  assert.deepEqual(layout.slots, []);
+  assert.equal(layout.cameraLeft, (220 - 180) / 2 - TOOL_CAMERA_MARGIN);
+  assert.equal(layout.cameraRight, (220 + 180) / 2 + TOOL_CAMERA_MARGIN);
 });
 test('consecutive moves retain the previously arranged order', () => {
   const first = insertTool(['shelf','clipboard','terminal','usage'], 'usage', 0);


### PR DESCRIPTION
刘海禁区两侧各外扩 8px：13/14 寸刘海屏上工具栏边缘图标（清理会话等）不再被刘海物理遮挡；27 寸外接与 16 寸行为不变（无刘海屏不引入边距）。含 toolbar-model 边距断言单测。

Closes #151