### PR TITLE
chore(release): prepare v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 > **版本体系重置（2026-09-02）**：公开版本号统一归位——内测期整理为 `v0.1.0 – v0.10.0`（原 `v0.2.x` 系列与初版 `v0.1.0` 重排，各版本说明注明原版本号）；`v3.0.0 / v3.1.0 / v3.2.0` 分别平移为 `v1.0.0 / v1.1.0 / v1.2.0`；`v3.2.0-rc.1` 与整条 `v1.0.0-alpha`（Windows 试验线）已删除，Windows 支持暂停维护、欢迎社区贡献者主导适配。
 
+## [1.5.0] - 2026-09-10
+
+「远程与随手清理」版本：SSH 远程升级为独立设置页并由 WorkIsland 主动管理隧道，会话清理进岛工具栏，并修复刘海屏工具栏遮挡。
+
+### Added
+
+- **SSH 远程独立设置页**（#150，issue #116）：设置新增「SSH 远程」页——从 `~/.ssh/config` 发现主机（筛选/重新扫描/一键添加）、手动添加表单、主机接入与隧道状态、复制接入命令、重连隧道与撤销。隧道改由 WorkIsland 从 Mac 主动 `ssh -R` 建立并守护（指数退避重连），**Mac 不再需要开启「远程登录」**；observe-only 边界不变：只回传运行状态，不回传提示词、代码或路径。接入指南升级 v1.1（docs/REMOTE_ONBOARDING.md）。
+- **会话清理进工具栏**（#147/#149，issue #139）：岛工具栏新增「清理会话」操作，一键结束全部可见会话卡片；设置提供显示开关。
+
+### Fixed
+
+- **刘海屏工具栏遮挡**（#152，issue #151）：工具栏刘海禁区两侧各加 8px 安全边距——13/14 寸 MacBook 原生屏上边缘图标（如清理会话）不再被刘海物理遮挡；外接屏与无刘海屏行为不变。
+
+> **English summary:** Dedicated "SSH Remote" settings page (#150) — discover hosts from `~/.ssh/config` with filtering and one-click add, WorkIsland-managed reverse tunnels (no Mac Remote Login required), copyable setup commands and per-host tunnel status, observe-only boundaries unchanged; session cleanup moves into the island toolbar with a settings toggle (#147/#149); 8px camera-zone safety margin so toolbar icons are no longer occluded by the notch on 13"/14" MacBook displays (#152).
+
 ## [1.4.0] - 2026-09-07
 
 「覆盖与留存」第一阶段收口版本：把安静时段、Plan 确认卡 Markdown 渲染、本地开发者 API、用量发现通道、远程接入（observe-only 第一阶段）与全应用中英双语六项已验证能力正式发出，并首次公开闲置性能实测数据。

--- a/docs/RELEASE_NOTES_UNRELEASED.md
+++ b/docs/RELEASE_NOTES_UNRELEASED.md
@@ -1,41 +1,29 @@
-# WorkIsland v1.4.0 Release Notes（发布候选）
+# WorkIsland v1.5.0 Release Notes（发布候选）
 
 状态：`release-candidate — 范围冻结；Tag 推送后由 GitHub Actions 签名公证并创建正式 Release`
 
-本版主题「覆盖与留存 · 第一阶段收口」：把已合入 `main` 的留存/开放能力、远程接入 observe-only 第一阶段与全应用中英双语正式发出去，并首次公开性能实测数据。范围基线见 [`docs/03-roadmap/v1.4.0-版本规划-2026-09-06.md`](./03-roadmap/v1.4.0-版本规划-2026-09-06.md)；完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)。
-
-自本版起，GitHub Release 说明采用 **中文全文在前 + `### English Summary` 在后** 的双语结构（英文为摘要，不逐条直译），检查项见 [`RELEASE_PROCESS.md`](./RELEASE_PROCESS.md)。
+本版主题「远程与随手清理」：SSH 远程升级为独立设置页并由 WorkIsland 主动管理反向隧道，会话清理进岛工具栏，修复刘海屏工具栏遮挡。完整历史见仓库根目录的 [`CHANGELOG.md`](../CHANGELOG.md)。
 
 ## 中文说明（tag 时粘贴到 Release 页前半）
 
-### 覆盖与留存：五个新特性
+### SSH 远程：独立设置页 + WorkIsland 管理隧道
 
-- **安静时段与锁屏静音**（#95）：设置 → 声音可配置勿扰时段（如 22:00 → 08:00，支持跨午夜），时段内不播放任务提示音；macOS 锁屏期间同样静音；两项独立开关。手机推送（Bark）刻意不受抑制——安静时段用户不在电脑前，推送正是通知出口。
-- **Plan 确认卡 Markdown 渲染**（#92）：Plan 确认文本按 Markdown 渲染（标题、列表、代码块，复用岛上既有渲染样式），默认折叠、一键展开全文；链接点击走系统浏览器。
-- **本地开发者 API**（#93）：设置 → 关于可开启只读状态端点 `127.0.0.1:9938/api/status`，返回会话状态 JSON；默认关闭，可选 Bearer 令牌鉴权；响应不含 prompt、路径或会话内容。详见 [DEVELOPER_API.md](./DEVELOPER_API.md)。
-- **用量发现通道（首批）**（#94）：zcode / opencode / claude 三个客户端的 token 用量改为主动从本地会话数据发现并入账，不再依赖 Hook 携带 `transcript_path`；此前这些客户端会话能上岛但用量不入账。
-- **全应用中英双语**（#110）：新增“跟随系统 / 简体中文 / English”语言偏好；切换会同步刷新灵动岛、设置、欢迎页、桌宠、托盘、原生对话框与可见诊断，但不会 reload 窗口、终端或工作台。801 组中英文词条与占位符由 CI 质量门持续校验。
+- **SSH Config 主机发现**（#150，issue #116）：设置 → SSH 远程，自动扫描 `~/.ssh/config`（支持筛选与重新扫描），常用服务器一键添加；也支持手动填写主机。
+- **隧道由 WorkIsland 守护**：添加主机后 WorkIsland 从 Mac 主动 `ssh -R` 建立反向隧道并自动重连——**Mac 不再需要开启「远程登录」**。
+- **接入三步走**：复制接入命令 → 第 1 步 Mac 终端拷脚本 → 第 2 步在远程主机执行配对与 hook 安装（可整段交给远程机器上的 AI 助手，指南见 [REMOTE_ONBOARDING.md](./REMOTE_ONBOARDING.md)）。
+- **observe-only 边界不变**：只回传运行状态（运行中 / 等待审批 / 完成 / 失败），不回传提示词、代码或路径；一次性配对令牌、按主机分组、随时撤销；tmux attach 等交互式能力属二期另裁。
 
-### 远程接入：observe-only 第一阶段
+### 随手清理
 
-- **远程主机状态上岛**（#116，ADR-0005 第一阶段裁定通过）：设置 → Agents → 远程主机生成一次性配对令牌（10 分钟有效、单次使用），远程机器上的 AI 助手按内置指南 [REMOTE_ONBOARDING.md](./REMOTE_ONBOARDING.md) 自助建立 SSH 隧道，远程 Agent 会话状态实时上岛并按主机分组标注。
-- **observe-only 安全边界**：只回传运行状态，不回传提示词、代码或路径——入口白名单只读取状态元数据并物理丢弃其余字段；本机仅新增 `127.0.0.1:7878` 一个 loopback 监听；隧道由用户自管 SSH 建立，公网中转不做；令牌可随时撤销，撤销立即生效。
-- **断线不骗人**：隧道断开时远程会话以「远程连接已断开」收卡，恢复后自动覆盖，不悬挂假 running。
-- tmux attach / 交互式操作超出 observe-only 白名单，属二期另裁，本版不含。
+- **会话清理进工具栏**（#147/#149，issue #139）：岛工具栏一键清理全部可见会话卡片，设置提供显示开关。
 
-### 性能
+### 修复
 
-- **闲置性能实测数据公开**（#108）：Apple M4 · v1.3.0 实测闲置 CPU 中位 **2.9%**（< 3% 达标，贴线）、内存 top 口径 535 MB / RSS 341 MB；测试方法与原始采样见 [PERFORMANCE.md](./PERFORMANCE.md)，`scripts/perf-idle-benchmark.mjs` 可复现。
-
-### 说明
-
-- 正式 DMG 只有在 GitHub Actions 完成 Developer ID 签名、Apple 公证、Staple 与 Gatekeeper 验证后才对外发布（SHA256 见随 Release 生成的 `SHA256SUMS.txt`）。
-- Intel（x64）安装包：#103 已修复 Intel 构建路径，本版 tag 是第一个验证点——x64 DMG 产出并通过签名公证后，才在宣发中解锁「支持 Intel」；发布后回填实际结果。
-- 装过 3.x 旧包的同学：由于版本号重置，旧包认不出 1.x 是新版，请手动下载重装这一次；此后应用内自动升级即生效。
+- **刘海屏工具栏遮挡**（#152，issue #151）：工具栏刘海禁区两侧各加 8px 安全边距，13/14 寸 MacBook 原生屏上边缘图标不再被刘海物理遮挡；外接屏与无刘海屏行为不变。
 
 ### English Summary
 
-Quiet Hours and lock-screen mute for local alert sounds, with Bark push deliberately unsuppressed (#95); Plan confirmations render as collapsible Markdown (#92); opt-in read-only local Developer API at `127.0.0.1:9938/api/status` with Bearer auth, off by default (#93); usage discovery covers zcode / opencode / claude without relying on `transcript_path` (#94); full Chinese/English localization (#110) supports system language, Chinese and English with live switching and no workspace reset; phase 1 of observe-only remote access (#116) — pair a remote machine with a one-time token and stream its agent session status to the Island over a user-managed SSH tunnel, grouped by host; status only with content fields dropped at the entry, tunnel drops surface as explicit disconnected cards, interactive attach deferred; published idle-performance benchmarks — 2.9% median idle CPU, reproducible via `scripts/perf-idle-benchmark.mjs` (#108).
+Dedicated "SSH Remote" settings page (#150) — discover hosts from `~/.ssh/config` with filtering and one-click add; WorkIsland-managed reverse tunnels remove the macOS Remote Login requirement; copyable setup commands hand the remote steps to the remote machine's AI assistant; observe-only boundaries unchanged. Session cleanup moves into the island toolbar with a settings toggle (#147/#149). An 8px camera-zone safety margin stops the notch from occluding toolbar icons on 13"/14" MacBook displays (#152).
 
 ## What's Changed
 
@@ -43,19 +31,15 @@ Quiet Hours and lock-screen mute for local alert sounds, with Bark push delibera
 
 ## 发布前验收
 
-- [ ] `package.json` 与 `package-lock.json` 均为 `1.4.0`（prepare 提交时更新）。
+- [ ] `package.json` 与 `package-lock.json` 均为 `1.5.0`。
 - [ ] `npm run check` 通过。
-- [ ] `npm run release:check -- --tag v1.4.0` 通过。
-- [ ] `CHANGELOG.md` 的 `[Unreleased]` 段改名为 `[1.4.0]` + 发布日期，英文摘要保留。
-- [ ] Release 页说明 = 本文件中文段在前 + `### English Summary` 在后。
-- [ ] 官网 `website/changelog/index.html` 加入 v1.4.0 条目（口径与 Release 页一致），随 Tag 部署，不提前上线。
-- [ ] GitHub Actions 双架构签名、公证、Staple、Gatekeeper 校验通过，生成 `SHA256SUMS.txt` / `SHA256SUMS-x64.txt`。
-- [ ] **tag 后验证 x64 管线**：确认 x64 DMG 真实产出并通过签名公证（第一个验证点，见上「说明」）。
-- [ ] Release 成为 `releases/latest`，应用内更新可检测到 v1.4.0。
+- [ ] `npm run release:check -- --tag v1.5.0` 通过。
+- [ ] 真机验收：一台真实 SSH 主机端到端（添加主机 → 隧道建立 → 状态上岛 → 撤销断隧道）；14 寸刘海屏确认清理图标完整可见。
+- [ ] Tag 后 GitHub Actions 签名、公证、Staple、Gatekeeper 校验通过，生成 `SHA256SUMS.txt`。
+- [ ] Release 成为 `releases/latest`，应用内更新可检测到 v1.5.0。
 
 ## 已知限制与回滚
 
-- Intel 机型的媒体工作台依赖 MediaRemote 私有框架，行为与 Apple Silicon 存在差异，属尽力支持（见 [COMPATIBILITY.md](./COMPATIBILITY.md)）。
-- Windows Alpha 为独立版本线，不在本版本范围（见版本规划第五节）。
-- 会话/tab 级聚焦抑制（#111）、五大终端 tab 级跳转（#112）与无刘海悬浮条（#109）明确顺延 v1.5+，勿提前开工。
-- 出现 P0 时发布新的 `v1.4.1`，绝不覆盖既有 Tag 或替换既有产物。
+- 隧道固定绑定远程机 17878 端口，被占用时设置页显示「隧道未建立」。
+- tmux attach / 交互式操作不在本版（二期另裁）。
+- 出现 P0 时发布新的 `v1.5.1`，绝不覆盖既有 Tag 或替换既有产物。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workisland",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workisland",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "workisland",
   "productName": "WorkIsland",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "macOS 与 Windows 本地 Work Agent 工作状态与注意力路由器",
   "private": true,
   "main": "./src/main/index.cjs",


### PR DESCRIPTION
v1.5.0 发布准备：版本号 1.5.0、CHANGELOG、Release Notes（SSH 远程页 #150 / 工具栏清理 #147/#149 / 刘海边距 #152）。release:check 通过。合并后从 main 构建候选 DMG 供真机验收；**本版暂不推 tag、不发 GitHub Release**（按负责人要求，先本地候选）。