### PR TITLE
fix(toolbar): reclaim fixed home slot

### DIFF
--- a/docs/superpowers/plans/2026-09-11-toolbar-free-home-slot.md
+++ b/docs/superpowers/plans/2026-09-11-toolbar-free-home-slot.md
@@ -1,0 +1,48 @@
+# Toolbar Free Home Slot Implementation Plan
+
+> **For agentic workers:** Implement inline with test-driven development.
+
+**Goal:** Remove the permanent Agent Home slot and return the reclaimed space to draggable toolbar tools.
+
+**Architecture:** Keep the existing two-bank slot model and persistence contract. Change only right-bank slot generation and selectable-tool activation; fixed action tools remain unchanged.
+
+**Tech Stack:** Electron renderer, React runtime, JavaScript, Node test runner.
+
+---
+
+### Task 1: Lock layout and navigation behavior
+
+**Files:**
+- Modify: `tests/toolbar-model.test.mjs`
+- Modify: `tests/productivity-toolbox-ui.test.mjs`
+
+- [x] Assert that no `home` position exists in the layout result.
+- [x] Assert that the reclaimed right slot remains outside the camera safety zone.
+- [x] Assert that re-selecting the active tool resolves to Agent Home.
+- [x] Run the focused tests and confirm they fail against the old implementation.
+
+### Task 2: Reclaim the slot
+
+**Files:**
+- Modify: `src/renderer/island/components/toolbar-model.mjs`
+- Modify: `src/renderer/island/components/ToolbarTools.js`
+- Modify: `src/renderer/island/components/IslandPanel.js`
+- Modify: `src/renderer/island/components/IslandPanel.css`
+
+- [x] Start right-bank slots at the already-expanded camera safety boundary.
+- [x] Remove the fixed Home control and its icon plumbing.
+- [x] Toggle an active selectable tool back to Agent Home.
+- [x] Keep action-only tools, More, Settings, and drag persistence unchanged.
+
+### Task 3: Verify and deliver
+
+**Files:**
+- Verify: `tests/toolbar-model.test.mjs`
+- Verify: `tests/productivity-toolbox-ui.test.mjs`
+- Verify: `tests/clear-sessions-toolbar.test.mjs`
+
+- [x] Run focused tests.
+- [x] Run `npm run check`.
+- [x] Build and install a local signed preview.
+- [x] Verify the visible toolbar and return interaction.
+- [x] Open a PR and wait for user acceptance before merge.

--- a/docs/superpowers/plans/2026-09-11-toolbar-free-home-slot.md
+++ b/docs/superpowers/plans/2026-09-11-toolbar-free-home-slot.md
@@ -32,6 +32,7 @@
 - [x] Start right-bank slots at the already-expanded camera safety boundary.
 - [x] Remove the fixed Home control and its icon plumbing.
 - [x] Toggle an active selectable tool back to Agent Home.
+- [x] Reuse the active tool's slot for a contextual Home icon and label.
 - [x] Keep action-only tools, More, Settings, and drag persistence unchanged.
 
 ### Task 3: Verify and deliver

--- a/docs/superpowers/specs/2026-09-11-toolbar-free-home-slot-design.md
+++ b/docs/superpowers/specs/2026-09-11-toolbar-free-home-slot-design.md
@@ -7,7 +7,7 @@ The expanded Island toolbar gives every safe slot around the physical notch to u
 ## Interaction
 
 - Selecting an inactive productivity tool opens it.
-- Selecting the active productivity tool again returns to Agent Home.
+- Selecting the active productivity tool again returns to Agent Home. While active, that tool's icon becomes the Home icon in the same slot, with an Agent Home tooltip and accessible label.
 - Action-only tools such as Clear Sessions and Pet keep their existing one-shot behavior.
 - More and Settings remain fixed system controls so every tool can be recovered or configured.
 - Dragging, cross-bank placement, intentional gaps, overflow, and stored slot preferences continue to use the existing toolbar model.
@@ -19,7 +19,7 @@ The camera exclusion zone already includes the physical-notch safety margin. The
 ## Acceptance
 
 - No fixed Home button is rendered.
+- A selected productivity tool exposes a visible Home icon without consuming another slot.
 - The representative 640 px / 200 px notch layout gains a fourth right-bank slot.
 - No tool overlaps the camera exclusion zone, More, or Settings.
 - Re-clicking an active selectable tool returns to Agent Home.
-

--- a/docs/superpowers/specs/2026-09-11-toolbar-free-home-slot-design.md
+++ b/docs/superpowers/specs/2026-09-11-toolbar-free-home-slot-design.md
@@ -1,0 +1,25 @@
+# Toolbar Free Home Slot Design
+
+## Outcome
+
+The expanded Island toolbar gives every safe slot around the physical notch to user-arranged productivity tools. Agent Home remains the default workspace, but no longer occupies a permanent toolbar slot.
+
+## Interaction
+
+- Selecting an inactive productivity tool opens it.
+- Selecting the active productivity tool again returns to Agent Home.
+- Action-only tools such as Clear Sessions and Pet keep their existing one-shot behavior.
+- More and Settings remain fixed system controls so every tool can be recovered or configured.
+- Dragging, cross-bank placement, intentional gaps, overflow, and stored slot preferences continue to use the existing toolbar model.
+
+## Layout
+
+The camera exclusion zone already includes the physical-notch safety margin. The first right-bank tool may therefore begin at `cameraRight`; reserving another 32 px for Home is unnecessary. Removing that reservation restores one usable right-bank slot without reducing notch clearance.
+
+## Acceptance
+
+- No fixed Home button is rendered.
+- The representative 640 px / 200 px notch layout gains a fourth right-bank slot.
+- No tool overlaps the camera exclusion zone, More, or Settings.
+- Re-clicking an active selectable tool returns to Agent Home.
+

--- a/src/renderer/island/components/IslandPanel.css
+++ b/src/renderer/island/components/IslandPanel.css
@@ -63,6 +63,8 @@
 .toolbar-settings, .toolbar-more { position: absolute; top: 0; }
 .toolbar-tools .toolbar-tool, .toolbar-slot { width: 32px; height: 30px; flex: 0 0 32px; box-sizing: border-box; }
 .toolbar-tools .toolbar-tool { justify-content: center; padding: 6px; }
+.toolbar-tool-icon { display: grid; place-items: center; transition: transform 160ms ease, opacity 160ms ease; }
+.toolbar-tool-icon.is-home { transform: scale(.92); }
 .toolbar-slot { touch-action: none; user-select: none; }
 .toolbar-tools.is-sorting { cursor: grabbing; }
 .toolbar-slot > * { max-width: 32px; }

--- a/src/renderer/island/components/IslandPanel.css
+++ b/src/renderer/island/components/IslandPanel.css
@@ -60,7 +60,7 @@
 .toolbar-camera-space { position: absolute; top: 0; height: 100%; pointer-events: none; }
 .toolbar-tools { position: relative; width: 100%; min-width: 0; height: 32px; }
 .toolbar-leading { position: absolute; left: 0; top: 0; height: 32px; width: max-content; overflow: hidden; }
-.toolbar-home, .toolbar-settings, .toolbar-more { position: absolute; top: 0; }
+.toolbar-settings, .toolbar-more { position: absolute; top: 0; }
 .toolbar-tools .toolbar-tool, .toolbar-slot { width: 32px; height: 30px; flex: 0 0 32px; box-sizing: border-box; }
 .toolbar-tools .toolbar-tool { justify-content: center; padding: 6px; }
 .toolbar-slot { touch-action: none; user-select: none; }

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -128,12 +128,6 @@ function ClearSessionsToolIcon() {
     React.createElement("path", { d: "M3.2 5.2h11.6M6.1 5.2V3.7h5.8v1.5M4.7 5.2l.7 9.1h7.2l.7-9.1M7.2 7.8v4M10.8 7.8v4" })
   );
 }
-function AgentHomeIcon() {
-  return React.createElement(ToolIconFrame, null,
-    React.createElement("path", { d: "m3 8 6-5 6 5v6.5H3Z" }),
-    React.createElement("path", { d: "M7 14.5v-4h4v4" })
-  );
-}
 const TokenBurnFire = ({ tokenCount }) => {
   const iconSrc = reactExports.useMemo(() => {
     return getFireIconByTokenCount(tokenCount);
@@ -352,7 +346,7 @@ function AgentUsageRow({
       leading: React.createElement(React.Fragment, null, showUsageQuota ? quotaCells : null,
         pillFirstRow.upgradeButton && (hasUpdate || hasActiveUpdateFlow(updateState)) && React.createElement(UpdateStatusButton, { updateState, hasUpdate, onDownload: onUpdateDownload, onInstall: onUpdateInstall, onOpenRelease })),
       onSelect: onToolboxModuleChange, onOrder: onToolboxModuleReorder,
-      homeIcon: React.createElement(AgentHomeIcon), settingsIcon: React.createElement('img', { src: settingIcon, alt: '' }),
+      settingsIcon: React.createElement('img', { src: settingIcon, alt: '' }),
       onSettings: () => onOpenSettings('display'), extras: [
         ...(clearSessionsEnabled ? [{ id: 'clear-sessions', label: t('session.clear'), icon: React.createElement(ClearSessionsToolIcon),
           disabled: visibleSessionIds.length === 0, action: () => window.islandBridge?.deleteSessions?.(visibleSessionIds) }] : []),

--- a/src/renderer/island/components/IslandPanel.js
+++ b/src/renderer/island/components/IslandPanel.js
@@ -128,6 +128,12 @@ function ClearSessionsToolIcon() {
     React.createElement("path", { d: "M3.2 5.2h11.6M6.1 5.2V3.7h5.8v1.5M4.7 5.2l.7 9.1h7.2l.7-9.1M7.2 7.8v4M10.8 7.8v4" })
   );
 }
+function AgentHomeIcon() {
+  return React.createElement(ToolIconFrame, null,
+    React.createElement("path", { d: "m3 8 6-5 6 5v6.5H3Z" }),
+    React.createElement("path", { d: "M7 14.5v-4h4v4" })
+  );
+}
 const TokenBurnFire = ({ tokenCount }) => {
   const iconSrc = reactExports.useMemo(() => {
     return getFireIconByTokenCount(tokenCount);
@@ -346,7 +352,7 @@ function AgentUsageRow({
       leading: React.createElement(React.Fragment, null, showUsageQuota ? quotaCells : null,
         pillFirstRow.upgradeButton && (hasUpdate || hasActiveUpdateFlow(updateState)) && React.createElement(UpdateStatusButton, { updateState, hasUpdate, onDownload: onUpdateDownload, onInstall: onUpdateInstall, onOpenRelease })),
       onSelect: onToolboxModuleChange, onOrder: onToolboxModuleReorder,
-      settingsIcon: React.createElement('img', { src: settingIcon, alt: '' }),
+      homeIcon: React.createElement(AgentHomeIcon), settingsIcon: React.createElement('img', { src: settingIcon, alt: '' }),
       onSettings: () => onOpenSettings('display'), extras: [
         ...(clearSessionsEnabled ? [{ id: 'clear-sessions', label: t('session.clear'), icon: React.createElement(ClearSessionsToolIcon),
           disabled: visibleSessionIds.length === 0, action: () => window.islandBridge?.deleteSessions?.(visibleSessionIds) }] : []),

--- a/src/renderer/island/components/ToolbarTools.js
+++ b/src/renderer/island/components/ToolbarTools.js
@@ -1,9 +1,9 @@
 import { R as React } from '../../vendor/react-runtime.js';
 import { t } from '../../shared/i18n.js';
-import { insertTool, moveToolbarTool, TOOL_SLOT, toolbarSlots, toolbarDropTarget, visibleToolbarOrder, placeToolbarTools } from './toolbar-model.mjs';
+import { insertTool, moveToolbarTool, TOOL_SLOT, toolbarActivationTarget, toolbarSlots, toolbarDropTarget, visibleToolbarOrder, placeToolbarTools } from './toolbar-model.mjs';
 
 export function ToolbarTools({ modules, active, onSelect, onOrder, order = [], hiddenModules = [], moduleSides = {}, moduleSlots = {},
-  homeIcon, settingsIcon, onSettings, extras = [], leading, notchWidth = 0, notchHeight = 32 }) {
+  settingsIcon, onSettings, extras = [], leading, notchWidth = 0, notchHeight = 32 }) {
   const root = React.useRef(null);
   const leadingRef = React.useRef(null);
   const dragRef = React.useRef(null);
@@ -144,7 +144,7 @@ export function ToolbarTools({ modules, active, onSelect, onOrder, order = [], h
   };
   const activate = tool => {
     if (tool.disabled) return;
-    if (tool.action) tool.action(); else onSelect(tool.id);
+    if (tool.action) tool.action(); else onSelect(toolbarActivationTarget(active, tool.id));
     setMenu(false);
   };
   const promote = tool => {
@@ -159,12 +159,15 @@ export function ToolbarTools({ modules, active, onSelect, onOrder, order = [], h
       { ...moduleSlots, ...Object.fromEntries([...placements].map(([id, slot]) => [id, slot.key])) });
     setMenu(false);
   };
-  const basicButton = (tool, labelled = false) => React.createElement('button', {
+  const basicButton = (tool, labelled = false) => {
+    const label = !tool.action && active === tool.id ? t('toolbar.agentHome') : tool.label;
+    return React.createElement('button', {
     type: 'button', className: 'panel-btn toolbar-tool' + (tool.id === 'pet' ? ' panel-pet-button' : '') + (active === tool.id ? ' is-active' : ''),
-    'aria-label': tool.label, title: tool.label, 'aria-pressed': tool.action ? undefined : active === tool.id,
+    'aria-label': label, title: label, 'aria-pressed': tool.action ? undefined : active === tool.id,
     'aria-disabled': tool.disabled,
     onClick: () => activate(tool)
-  }, tool.icon, labelled && React.createElement('span', null, tool.label));
+    }, tool.icon, labelled && React.createElement('span', null, tool.label));
+  };
 
   const positions = new Map();
   const slots = all.map(tool => {
@@ -189,8 +192,6 @@ export function ToolbarTools({ modules, active, onSelect, onOrder, order = [], h
     },
       React.createElement('div', { ref: leadingRef, className: 'usage-row-agents toolbar-leading', style: { maxWidth: layout.cameraLeft } }, leading),
       React.createElement('div', { className: 'toolbar-camera-space', 'aria-hidden': true, style: { left: layout.cameraLeft, width: notchWidth } }),
-      React.createElement('button', { type: 'button', className: 'panel-btn toolbar-tool toolbar-home' + (active === 'agent' ? ' is-active' : ''),
-        style: { left: layout.home }, title: t('toolbar.agentHome'), 'aria-label': t('toolbar.agentHome'), 'aria-pressed': active === 'agent', onClick: () => onSelect('agent') }, homeIcon),
       ...slots,
       drag && layout.slots.map((slot, index) => ![...placements.values()].some(position => position.index === index) && React.createElement('div', {
         key: 'empty-' + index, className: 'toolbar-empty-slot', style: { left: slot.x }, 'aria-hidden': true

--- a/src/renderer/island/components/ToolbarTools.js
+++ b/src/renderer/island/components/ToolbarTools.js
@@ -3,7 +3,7 @@ import { t } from '../../shared/i18n.js';
 import { insertTool, moveToolbarTool, TOOL_SLOT, toolbarActivationTarget, toolbarSlots, toolbarDropTarget, visibleToolbarOrder, placeToolbarTools } from './toolbar-model.mjs';
 
 export function ToolbarTools({ modules, active, onSelect, onOrder, order = [], hiddenModules = [], moduleSides = {}, moduleSlots = {},
-  settingsIcon, onSettings, extras = [], leading, notchWidth = 0, notchHeight = 32 }) {
+  homeIcon, settingsIcon, onSettings, extras = [], leading, notchWidth = 0, notchHeight = 32 }) {
   const root = React.useRef(null);
   const leadingRef = React.useRef(null);
   const dragRef = React.useRef(null);
@@ -160,13 +160,16 @@ export function ToolbarTools({ modules, active, onSelect, onOrder, order = [], h
     setMenu(false);
   };
   const basicButton = (tool, labelled = false) => {
-    const label = !tool.action && active === tool.id ? t('toolbar.agentHome') : tool.label;
+    const returnsHome = !tool.action && active === tool.id;
+    const label = active === tool.id ? t('toolbar.agentHome') : tool.label;
+    const icon = active === tool.id ? homeIcon : tool.icon;
     return React.createElement('button', {
     type: 'button', className: 'panel-btn toolbar-tool' + (tool.id === 'pet' ? ' panel-pet-button' : '') + (active === tool.id ? ' is-active' : ''),
     'aria-label': label, title: label, 'aria-pressed': tool.action ? undefined : active === tool.id,
     'aria-disabled': tool.disabled,
     onClick: () => activate(tool)
-    }, tool.icon, labelled && React.createElement('span', null, tool.label));
+    }, React.createElement('span', { className: 'toolbar-tool-icon' + (returnsHome ? ' is-home' : '') }, icon),
+      labelled && React.createElement('span', null, returnsHome ? label : tool.label));
   };
 
   const positions = new Map();

--- a/src/renderer/island/components/toolbar-model.mjs
+++ b/src/renderer/island/components/toolbar-model.mjs
@@ -14,6 +14,10 @@ export function insertTool(order, source, index) {
   return next;
 }
 
+export function toolbarActivationTarget(active, selected) {
+  return active === selected ? 'agent' : selected;
+}
+
 // All coordinates are relative to the toolbar's content box. The two banks
 // share one reading order, but no slot intersects the physical camera.
 export function toolbarSlots(width, notchWidth, leadingWidth) {
@@ -26,7 +30,7 @@ export function toolbarSlots(width, notchWidth, leadingWidth) {
   const leftStart = Math.min(cameraLeft, Math.max(0, leadingWidth) + (leadingWidth ? 8 : 0));
   const slots = [];
   for (let x = leftStart; x + TOOL_SLOT <= cameraLeft; x += TOOL_SLOT) slots.push({ x, bank: 'left' });
-  for (let x = cameraRight + TOOL_SLOT; x + TOOL_SLOT <= width - 2 * TOOL_SLOT; x += TOOL_SLOT) slots.push({ x, bank: 'right' });
+  for (let x = cameraRight; x + TOOL_SLOT <= width - 2 * TOOL_SLOT; x += TOOL_SLOT) slots.push({ x, bank: 'right' });
   const right = slots.filter(slot => slot.bank === 'right');
   const slack = right.length ? width - 2 * TOOL_SLOT - right.at(-1).x - TOOL_SLOT : 0;
   const counts = { left: 0, right: 0 };
@@ -34,7 +38,7 @@ export function toolbarSlots(width, notchWidth, leadingWidth) {
     if (slot.bank === 'right') slot.x += slack;
     slot.key = slot.bank + ':' + counts[slot.bank]++;
   }
-  return { slots, cameraLeft, cameraRight, home: cameraRight, more: width - 2 * TOOL_SLOT, settings: width - TOOL_SLOT };
+  return { slots, cameraLeft, cameraRight, more: width - 2 * TOOL_SLOT, settings: width - TOOL_SLOT };
 }
 
 export function toolbarDropTarget(layout, x, y, height) {

--- a/tests/productivity-toolbox-ui.test.mjs
+++ b/tests/productivity-toolbox-ui.test.mjs
@@ -6,9 +6,12 @@ const read = (name) => readFileSync(new URL(`../src/renderer/island/components/$
 
 test("productivity modules live in the compact top action row", () => {
   const source = read("IslandPanel.js") + read("ToolbarTools.js");
-  for (const label of ["toolbar.agentHome", "toolbox.shelf", "toolbox.clipboard", "toolbox.terminal"]) assert.match(source, new RegExp(label.replaceAll(".", "\\.")));
+  for (const label of ["toolbox.shelf", "toolbox.clipboard", "toolbox.terminal"]) assert.match(source, new RegExp(label.replaceAll(".", "\\.")));
   assert.match(source, /toolbar-tool/);
   assert.match(source, /aria-pressed/);
+  assert.match(source, /toolbarActivationTarget\(active, tool\.id\)/);
+  assert.match(source, /active === tool\.id \? t\('toolbar\.agentHome'\) : tool\.label/);
+  assert.doesNotMatch(source, /toolbar-home/);
   assert.doesNotMatch(source, /ToolboxSwitcher/);
   assert.doesNotMatch(source, /pillFirstRow\.tokenCount[\s\S]*TokenUsage/);
   assert.match(source, /function ShelfToolIcon/);

--- a/tests/productivity-toolbox-ui.test.mjs
+++ b/tests/productivity-toolbox-ui.test.mjs
@@ -11,6 +11,8 @@ test("productivity modules live in the compact top action row", () => {
   assert.match(source, /aria-pressed/);
   assert.match(source, /toolbarActivationTarget\(active, tool\.id\)/);
   assert.match(source, /active === tool\.id \? t\('toolbar\.agentHome'\) : tool\.label/);
+  assert.match(source, /active === tool\.id \? homeIcon : tool\.icon/);
+  assert.match(source, /function AgentHomeIcon/);
   assert.doesNotMatch(source, /toolbar-home/);
   assert.doesNotMatch(source, /ToolboxSwitcher/);
   assert.doesNotMatch(source, /pillFirstRow\.tokenCount[\s\S]*TokenUsage/);

--- a/tests/toolbar-model.test.mjs
+++ b/tests/toolbar-model.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { toolbarCapacity, insertTool, toolbarSlots, toolbarDropTarget, visibleToolbarOrder, placeToolbarTools, moveToolbarTool, TOOL_CAMERA_MARGIN } from '../src/renderer/island/components/toolbar-model.mjs';
-test('overflow reserves home, settings and more without consuming camera space', () => {
+import { toolbarActivationTarget, toolbarCapacity, insertTool, toolbarSlots, toolbarDropTarget, visibleToolbarOrder, placeToolbarTools, moveToolbarTool, TOOL_CAMERA_MARGIN } from '../src/renderer/island/components/toolbar-model.mjs';
+test('overflow reserves settings and more without consuming camera space', () => {
   assert.equal(toolbarCapacity(256, 6), 6);
   assert.equal(toolbarCapacity(224, 6), 4);
   assert.equal(toolbarCapacity(96, 6), 0);
@@ -10,11 +10,11 @@ test('overflow reserves home, settings and more without consuming camera space',
 test('balances real spare space around the camera without covering quota', () => {
   const layout = toolbarSlots(640, 200, 92);
   assert.deepEqual(layout.slots.filter(s => s.bank === 'left').map(s => s.x), [100,132,164]);
-  // #151 刘海禁区两侧各外扩 TOOL_CAMERA_MARGIN：home 从 420 移到 428。
-  assert.equal(layout.home, 420 + TOOL_CAMERA_MARGIN);
+  assert.equal(Object.hasOwn(layout, 'home'), false);
+  assert.equal(layout.slots.filter(s => s.bank === 'right').length, 4);
   for (const slot of layout.slots) {
     assert.ok(slot.x >= 100);
-    assert.ok(slot.x + 32 <= layout.cameraLeft || slot.x >= layout.cameraRight + 32);
+    assert.ok(slot.x + 32 <= layout.cameraLeft || slot.x >= layout.cameraRight);
     assert.ok(slot.x + 32 <= layout.more);
   }
   assert.equal(toolbarDropTarget(layout, 300, 15, 32), null);
@@ -49,11 +49,17 @@ test('#151 every slot keeps the camera margin from the physical notch edges', ()
         assert.ok(slot.x + 32 <= layout.cameraLeft, 'left slot ends inside camera margin');
         if (notch > 0) assert.ok(notchLeft - (slot.x + 32) >= TOOL_CAMERA_MARGIN - 1e-9, 'left slot too close to the notch');
       } else {
-        assert.ok(slot.x >= layout.cameraRight + 32 - 1e-9, 'right slot starts inside camera margin');
+        assert.ok(slot.x >= layout.cameraRight - 1e-9, 'right slot starts inside camera margin');
         if (notch > 0) assert.ok(slot.x - notchRight >= TOOL_CAMERA_MARGIN - 1e-9, 'right slot too close to the notch');
       }
     }
   }
+});
+
+test('selecting the active utility returns to Agent home without a dedicated home slot', () => {
+  assert.equal(toolbarActivationTarget('terminal', 'terminal'), 'agent');
+  assert.equal(toolbarActivationTarget('terminal', 'clipboard'), 'clipboard');
+  assert.equal(toolbarActivationTarget('agent', 'terminal'), 'terminal');
 });
 
 test('#151 narrow notch panel keeps zero slots and a full-margin camera zone', () => {


### PR DESCRIPTION
## 影响

- 移除刘海右侧永久占位的主页按钮，将该槽位还给用户拖动排列的效率工具
- 当前效率工具再次点击即可返回智能体主页
- 活跃工具的提示文本会明确显示“智能体主页”，提升返回行为的可发现性
- 保留刘海安全边距、“更多”和“设置”固定入口，以及已有跨侧拖动/溢出逻辑

## 根因

布局模型已经把 `cameraRight` 扩展到物理刘海安全边距之外，却又额外预留了一个 32px Home 槽位，导致右侧无谓损失一个用户快捷位。

## 验证

- `npm run check`
- 572/572 unit tests passed
- 832 i18n keys aligned
- Focused toolbar tests 33/33 passed

## 验收流程

PR 保持未合并；先安装本地预览，由产品验收后再合并。