### PR TITLE
feat(ops): sync merged delivery PRs to Feishu

### DIFF
--- a/.github/workflows/feishu-delivery-sync.yml
+++ b/.github/workflows/feishu-delivery-sync.yml
@@ -1,0 +1,47 @@
+name: sync-delivery-status-to-feishu
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sync:
+    # A merge is evidence that code landed, not evidence that device/user
+    # acceptance is complete. The script therefore moves a mapped task only to
+    # “待验收”. It never closes an issue, marks a release complete, or creates
+    # a Feishu task.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    env:
+      FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
+      FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+      FEISHU_BASE_TOKEN: ${{ secrets.FEISHU_BASE_TOKEN }}
+      FEISHU_TASK_TABLE_ID: ${{ secrets.FEISHU_TASK_TABLE_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check optional Feishu configuration
+        id: configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(FEISHU_APP_ID FEISHU_APP_SECRET FEISHU_BASE_TOKEN FEISHU_TASK_TABLE_ID)
+          missing=()
+          for name in "${required[@]}"; do
+            if [ -z "${!name:-}" ]; then missing+=("$name"); fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Feishu delivery sync is not configured; no status was written. Missing: ${missing[*]}"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+      - name: Sync merged delivery PR to Feishu
+        if: steps.configuration.outputs.ready == 'true'
+        run: npm run sync:feishu

--- a/docs/PRODUCT_OPERATING_SYSTEM.md
+++ b/docs/PRODUCT_OPERATING_SYSTEM.md
@@ -110,6 +110,15 @@ Tag `v*` 的创建权限只交给发布维护者。Beta Tag 必须生成 GitHub 
 | 每月 | Roadmap 校准：停止无证据方向，确认下一 Epic |
 | 每个版本后 | 24 小时和 7 天发布复盘，结论回流 Backlog |
 
-## 9. 完成定义
+## 9. GitHub → 飞书交付同步
+
+GitHub 是代码、PR、Issue 和发布证据的唯一执行事实源；飞书 Base 是认领、排期和验收可视化面。状态只允许从 GitHub 单向回写到飞书，避免两个客户端或两张看板分别手工改出冲突。
+
+- 合并 PR 后，`.github/workflows/feishu-delivery-sync.yml` 会查找任务标题或验收标准中显式引用的 `#PR号`，把该任务更新为“待验收”。合入不是完成：真实设备、隐私或用户验收仍需人工回填。
+- 未匹配的 PR、未配置凭证或没有飞书编辑权限时，工作流只输出 notice，不会失败、不会新建任务、也不会扩大版本范围。
+- 每个 v1.5 任务必须在飞书任务标题或验收标准中保留 GitHub Issue/PR 编号，确保可定位；新增任务先在 GitHub 建 Issue，再建飞书任务卡。
+- 首次启用前，在 GitHub Actions secrets 配置 `FEISHU_APP_ID`、`FEISHU_APP_SECRET`、`FEISHU_BASE_TOKEN` 和 `FEISHU_TASK_TABLE_ID`；并给该飞书应用编辑 `Workisland项目管理甘特图` 中“✅ 任务”表的权限。仓库不保存任何凭证或 Base token。
+
+## 10. 完成定义
 
 一个 Task 只有同时满足以下条件才能关闭：父 PRD/Issue 已链接，范围与非目标明确，代码和文档已合并，自动检查通过，必要的真实设备验证已留证，用户可见变化已进入手册/Release Notes，发布与回滚影响已记录。

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "package:mac:intel": "npm run build:assets && WORKISLAND_NATIVE_ARCH=x86_64 npm run build:native && npm run check && electron-builder --mac dmg --x64 --publish never",
     "package:win": "npm run build:assets && npm run check && electron-builder --win nsis portable --x64 --publish never",
     "release:check": "node ./scripts/release-check.mjs",
+    "sync:feishu": "node ./scripts/sync-feishu-delivery.mjs",
     "check": "npm run build:renderer && node ./scripts/check-i18n.mjs && node ./scripts/check.mjs && node ./scripts/test-source.mjs && npm run test:unit",
     "test:unit": "node --test tests/*.test.mjs",
     "smoke:hook": "node ./scripts/smoke-hook.mjs",

--- a/scripts/sync-feishu-delivery.mjs
+++ b/scripts/sync-feishu-delivery.mjs
@@ -1,0 +1,117 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const FEISHU_API = "https://open.feishu.cn/open-apis";
+const TASK_STATUS = {
+  merged: "待验收",
+};
+
+function requiredEnvironment(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+async function request(url, { method = "GET", token, body } = {}) {
+  const headers = { "Content-Type": "application/json; charset=utf-8" };
+  if (token) headers.Authorization = `Bearer ${token}`;
+  const response = await fetch(url, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload.code) {
+    throw new Error(`Feishu API request failed (${response.status}): ${payload.msg || payload.message || "unknown error"}`);
+  }
+  return payload;
+}
+
+export function taskMatchesPullRequest(task, pullRequestNumber) {
+  const needle = `#${pullRequestNumber}`;
+  return Object.values(task.fields || {}).some((value) => JSON.stringify(value).includes(needle));
+}
+
+export function updateForPullRequest(event) {
+  const pullRequest = event?.pull_request;
+  if (!pullRequest?.number || !pullRequest.merged) return null;
+  return {
+    pullRequestNumber: pullRequest.number,
+    status: TASK_STATUS.merged,
+    summary: `GitHub PR #${pullRequest.number} 已合入 ${pullRequest.base?.ref || "main"}，等待验收证据回填。`,
+  };
+}
+
+async function getTenantAccessToken() {
+  const payload = await request(`${FEISHU_API}/auth/v3/tenant_access_token/internal`, {
+    method: "POST",
+    body: {
+      app_id: requiredEnvironment("FEISHU_APP_ID"),
+      app_secret: requiredEnvironment("FEISHU_APP_SECRET"),
+    },
+  });
+  if (!payload?.tenant_access_token) throw new Error("Feishu did not return a tenant access token.");
+  return payload.tenant_access_token;
+}
+
+async function listRecords({ token, baseToken, tableId }) {
+  const records = [];
+  let pageToken = "";
+  do {
+    const query = new URLSearchParams({ page_size: "500" });
+    if (pageToken) query.set("page_token", pageToken);
+    const payload = await request(
+      `${FEISHU_API}/base/v3/bases/${encodeURIComponent(baseToken)}/tables/${encodeURIComponent(tableId)}/records?${query}`,
+      { token },
+    );
+    const data = payload.data || {};
+    records.push(...(data.items || []));
+    pageToken = data.has_more ? data.page_token : "";
+  } while (pageToken);
+  return records;
+}
+
+async function updateRecord({ token, baseToken, tableId, recordId, fields }) {
+  return request(
+    `${FEISHU_API}/base/v3/bases/${encodeURIComponent(baseToken)}/tables/${encodeURIComponent(tableId)}/records/${encodeURIComponent(recordId)}`,
+    { method: "PATCH", token, body: { fields } },
+  );
+}
+
+export async function syncPullRequest({ event, dryRun = false, api = { getTenantAccessToken, listRecords, updateRecord } }) {
+  const update = updateForPullRequest(event);
+  if (!update) return { skipped: true, reason: "The event is not a merged pull request." };
+
+  const token = await api.getTenantAccessToken();
+  const baseToken = requiredEnvironment("FEISHU_BASE_TOKEN");
+  const taskTableId = requiredEnvironment("FEISHU_TASK_TABLE_ID");
+  const tasks = await api.listRecords({ token, baseToken, tableId: taskTableId });
+  const task = tasks.find((candidate) => taskMatchesPullRequest(candidate, update.pullRequestNumber));
+  if (!task) return { skipped: true, reason: `No Feishu task references PR #${update.pullRequestNumber}.` };
+
+  const fields = { "状态": update.status };
+  if (dryRun) return { dryRun: true, recordId: task.record_id, fields, summary: update.summary };
+
+  await api.updateRecord({ token, baseToken, tableId: taskTableId, recordId: task.record_id, fields });
+  return { updated: true, recordId: task.record_id, fields, summary: update.summary };
+}
+
+function readEvent() {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) throw new Error("GITHUB_EVENT_PATH is required. Run this command from GitHub Actions or provide an event fixture in a test.");
+  return JSON.parse(readFileSync(eventPath, "utf8"));
+}
+
+async function main() {
+  const dryRun = process.argv.includes("--dry-run");
+  const result = await syncPullRequest({ event: readEvent(), dryRun });
+  console.log(JSON.stringify(result));
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/tests/feishu-delivery-sync.test.mjs
+++ b/tests/feishu-delivery-sync.test.mjs
@@ -1,0 +1,24 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { taskMatchesPullRequest, updateForPullRequest } from "../scripts/sync-feishu-delivery.mjs";
+
+test("extracts a pending-acceptance update only for merged pull requests", () => {
+  assert.deepEqual(updateForPullRequest({
+    pull_request: { number: 120, merged: true, base: { ref: "main" } },
+  }), {
+    pullRequestNumber: 120,
+    status: "待验收",
+    summary: "GitHub PR #120 已合入 main，等待验收证据回填。",
+  });
+  assert.equal(updateForPullRequest({ pull_request: { number: 120, merged: false } }), null);
+});
+
+test("finds a task by an explicit GitHub PR reference without depending on Feishu record ids", () => {
+  assert.equal(taskMatchesPullRequest({
+    fields: { "任务": "PR 1：搜索索引器 rebase 与合入判断（#120）" },
+  }, 120), true);
+  assert.equal(taskMatchesPullRequest({
+    fields: { "任务": "会话搜索 UI、隐私控制与回源（#127）" },
+  }, 120), false);
+});


### PR DESCRIPTION
Closes #160

## User outcome

When a mapped delivery PR merges, the corresponding task in the WorkIsland Feishu Base becomes `待验收`; merge is never treated as final delivery.

## Safety

- GitHub → Feishu only.
- Secrets and Base token are GitHub Actions secrets, not repository files.
- Missing configuration or permission emits a notice and does not fail delivery.
- The current Base is read-only to both configured identities; it must grant the Feishu app edit access before the workflow can write.

## Verification

- [x] `npm run check` (588 tests)
- [x] Targeted mapping tests
- [ ] Configure Base edit access and GitHub secrets, then verify with the next mapped merge.