### PR TITLE
fix(dumate): 会话触发改走沙箱日志观测——定制构建不加载第三方插件

### DIFF
--- a/src/main/app-coordinator.cjs
+++ b/src/main/app-coordinator.cjs
@@ -42,6 +42,7 @@ const { ClipboardHistoryService } = require("./clipboard-history-service.cjs");
 const { RemoteBridgeServer } = require("./remote-bridge-server.cjs");
 const { createRemoteHostStore } = require("./remote-host-store.cjs");
 const { createRemoteTunnelManager } = require("./remote-tunnel-manager.cjs");
+const { createDuMateWatcher, getQianfanXdgRoot } = require("./dumate-watcher.cjs");
 const { scanSshConfig, formatSshTarget } = require("./ssh-config.cjs");
 const crypto = require("node:crypto");
 const { TerminalService } = require("./terminal-service.cjs");
@@ -322,6 +323,15 @@ function createAppCoordinatorClass({
       this.remoteTunnels = createRemoteTunnelManager({
         getLocalPort: () => this.getSettings()?.remoteAccess?.port ?? 7878
       });
+      // DuMate 触发通道：dumate-opencode 定制构建不加载第三方插件（探测实测），
+      // 改为观测沙箱日志文件——新 ses_*.log 出现即会话开始，闲置即收卡。
+      if (fs.existsSync(getQianfanXdgRoot())) {
+        this.dumateWatcher = createDuMateWatcher({
+          onEvent: (event) => {
+            this.bridge.emit("agentEvent", event);
+          }
+        });
+      }
       // AI customization commands (workisland-cli) share the settings
       // pipeline: updateSettings persists once and broadcasts to the island,
       // settings, and pet windows.
@@ -543,6 +553,7 @@ function createAppCoordinatorClass({
         this.playAgentSound(eventId, context?.sessionId, context?.timestamp);
       });
       this.bridge.start();
+      this.dumateWatcher?.start();
       this.syncRemoteBridge();
       this.quotaService.start();
       this.processMonitor.start();
@@ -892,6 +903,7 @@ function createAppCoordinatorClass({
     }
     stop() {
       log.info("[AppCoordinator] stopping local services...");
+      this.dumateWatcher?.stop();
       this.remoteTunnels?.stopAll();
       this.remoteBridge.stop();
       this.bridge.stop();

--- a/src/main/dumate-watcher.cjs
+++ b/src/main/dumate-watcher.cjs
@@ -1,0 +1,173 @@
+"use strict";
+
+/**
+ * DuMate（百度搭子）触发通道 v1：沙箱日志观测。
+ *
+ * 背景（2026-09-13 实测定案）：dumate-opencode 定制构建不自动加载 config/opencode/plugin
+ * 目录（探测实验证实），插件路线对该构建不可靠。改用 WorkIsland 已验证的被动观测
+ * 模式（同 Codex transcript watcher）：每个 DuMate 会话在
+ *   ~/Library/Application Support/qianfan-desktop-app/qianfan_desk_xdg/<账号>/data/logs/sandbox/ses_*.log
+ * 留下生命周期日志——新文件出现 = 会话开始；文件闲置 = 会话结束（阈值判定，
+ * 先例：Codex 180s 闲置兜底）。只读取 sessionId / directory= 两个无内容字段，
+ * 日志正文（命令、消息分片）一律不进任何下游对象（observe-only，对齐 ADR-0005 D3）。
+ */
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const DUATE_DATA_ROOT_SEGMENTS = ["Library", "Application Support", "qianfan-desktop-app", "qianfan_desk_xdg"];
+const SCAN_INTERVAL_MS = 20 * 1000;
+const IDLE_COMPLETE_MS = 150 * 1000;
+const HEAD_PARSE_LIMIT = 80;
+
+function getQianfanXdgRoot(homeDir = os.homedir()) {
+  return path.join(homeDir, ...DUATE_DATA_ROOT_SEGMENTS);
+}
+
+function listAccountSandboxDirs(homeDir = os.homedir()) {
+  const root = getQianfanXdgRoot(homeDir);
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const dirs = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const sandboxDir = path.join(root, entry.name, "data", "logs", "sandbox");
+    if (fs.existsSync(sandboxDir)) dirs.push(sandboxDir);
+  }
+  return dirs.sort();
+}
+
+/** 从日志头部解析 directory=<项目路径>；只取这一个字段。 */
+function parseProjectDirFromHead(headText) {
+  for (const line of headText.split("\n")) {
+    const match = line.match(/directory=(\S+)/);
+    if (match) return match[1];
+  }
+  return "";
+}
+
+function shortSessionCode(sessionId) {
+  return sessionId.replace(/^ses_/, "").slice(-6);
+}
+
+function createDuMateWatcher({
+  homeDir = os.homedir(),
+  logger = { info() {}, debug() {}, warn() {}, error() {} },
+  onEvent = () => {},
+  scanIntervalMs = SCAN_INTERVAL_MS,
+  idleCompleteMs = IDLE_COMPLETE_MS,
+  now = Date.now
+} = {}) {
+  let timer = null;
+  // sessionId → { logPath, projectPath, lastMtimeMs, started, completed }
+  const sessions = /* @__PURE__ */ new Map();
+
+  function emit(type, sessionId, projectPath) {
+    onEvent({
+      type,
+      sessionId: `dumate-${sessionId}`,
+      tool: "dumate",
+      timestamp: now(),
+      // 合成标题与项目路径；沙箱日志正文（命令/消息分片）不进入事件
+      title: `DuMate · ${shortSessionCode(sessionId)}`,
+      projectPath: projectPath || "",
+      detectionSource: "dumate-sandbox-log"
+    });
+  }
+
+  function scan() {
+    for (const sandboxDir of listAccountSandboxDirs(homeDir)) {
+      let files;
+      try {
+        files = fs.readdirSync(sandboxDir, { withFileTypes: true });
+      } catch {
+        continue;
+      }
+      for (const file of files) {
+        if (!file.isFile() || !file.name.startsWith("ses_") || !file.name.endsWith(".log")) continue;
+        const sessionId = file.name.slice(4, -4);
+        if (!sessionId || sessions.has(sessionId)) continue;
+        const logPath = path.join(sandboxDir, file.name);
+        let stat;
+        try {
+          stat = fs.statSync(logPath);
+        } catch {
+          continue;
+        }
+        let projectPath = "";
+        try {
+          const fd = fs.openSync(logPath, "r");
+          const buffer = Buffer.alloc(16 * 1024);
+          const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+          fs.closeSync(fd);
+          projectPath = parseProjectDirFromHead(buffer.toString("utf8", 0, bytes));
+        } catch {
+          // 读头失败不阻塞会话出现
+        }
+        sessions.set(sessionId, {
+          logPath,
+          projectPath,
+          lastMtimeMs: stat.mtimeMs,
+          started: true,
+          completed: false
+        });
+        emit("sessionStarted", sessionId, projectPath);
+        logger.info?.("[DuMateWatcher]", `session started: ${sessionId} (${projectPath || "unknown dir"})`);
+      }
+    }
+
+    const currentTime = now();
+    for (const [sessionId, session] of sessions) {
+      if (session.completed) continue;
+      let mtimeMs = session.lastMtimeMs;
+      try {
+        mtimeMs = fs.statSync(session.logPath).mtimeMs;
+        session.lastMtimeMs = mtimeMs;
+      } catch {
+        // 日志文件被清理也视为结束
+      }
+      if (currentTime - mtimeMs >= idleCompleteMs) {
+        session.completed = true;
+        emit("sessionCompleted", sessionId, session.projectPath);
+        logger.info?.("[DuMateWatcher]", `session idle-complete: ${sessionId}`);
+      }
+    }
+  }
+
+  return {
+    start() {
+      if (timer) return;
+      scan();
+      timer = setInterval(() => scan(), scanIntervalMs);
+      timer.unref?.();
+    },
+    stop() {
+      if (timer) {
+        clearInterval(timer);
+        timer = null;
+      }
+      sessions.clear();
+    },
+    scan,
+    hasSession(sessionId) {
+      return sessions.has(sessionId);
+    },
+    sessionCount() {
+      return sessions.size;
+    }
+  };
+}
+
+module.exports = {
+  createDuMateWatcher,
+  getQianfanXdgRoot,
+  listAccountSandboxDirs,
+  parseProjectDirFromHead,
+  SCAN_INTERVAL_MS,
+  IDLE_COMPLETE_MS
+};

--- a/tests/dumate-watcher.test.mjs
+++ b/tests/dumate-watcher.test.mjs
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createRequire } from "node:module";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const { createDuMateWatcher, parseProjectDirFromHead, listAccountSandboxDirs } = require("../src/main/dumate-watcher.cjs");
+
+function makeFixture() {
+  const homeDir = mkdtempSync(join(tmpdir(), "dumate-watcher-"));
+  const sandboxDir = join(homeDir, "Library", "Application Support", "qianfan-desktop-app", "qianfan_desk_xdg", "acc1", "data", "logs", "sandbox");
+  mkdirSync(sandboxDir, { recursive: true });
+  return { homeDir, sandboxDir, cleanup: () => rmSync(homeDir, { recursive: true, force: true }) };
+}
+
+test("new sandbox session log emits start, idle emits completion, content never leaks", () => {
+  const fx = makeFixture();
+  try {
+    let clock = Date.now();
+    const events = [];
+    const watcher = createDuMateWatcher({
+      homeDir: fx.homeDir,
+      onEvent: (event) => events.push(event),
+      scanIntervalMs: 5,
+      idleCompleteMs: 1000,
+      now: () => clock
+    });
+    watcher.start();
+
+    writeFileSync(join(fx.sandboxDir, "ses_abc123456789.log"), [
+      "INFO service=sandbox.entry sandbox starting",
+      "INFO service=sandbox.entry directory=/Users/mac/demo-project bootstrap received",
+      "INFO service=bus type=message.part.updated publishing 绝密正文不应外泄"
+    ].join("\n"));
+    watcher.scan();
+
+    assert.equal(events.length, 1, "start event on first sighting");
+    const start = events[0];
+    assert.equal(start.type, "sessionStarted");
+    assert.equal(start.tool, "dumate");
+    assert.equal(start.sessionId, "dumate-abc123456789");
+    assert.equal(start.projectPath, "/Users/mac/demo-project");
+    assert.equal(start.title, "DuMate · 456789");
+    // observe-only：日志正文不进事件对象
+    assert.equal(JSON.stringify(start).includes("绝密正文"), false);
+
+    // 未闲置：不收卡
+    clock += 500;
+    watcher.scan();
+    assert.equal(events.length, 1);
+
+    // 闲置超过阈值 → completed
+    clock += 1200;
+    watcher.scan();
+    assert.equal(events.length, 2);
+    assert.equal(events[1].type, "sessionCompleted");
+    assert.equal(events[1].sessionId, "dumate-abc123456789");
+
+    // 已收卡不再重复
+    watcher.scan();
+    assert.equal(events.length, 2);
+    watcher.stop();
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("multiple accounts and session resume are handled", () => {
+  const fx = makeFixture();
+  try {
+    const sandbox2 = join(fx.homeDir, "Library", "Application Support", "qianfan-desktop-app", "qianfan_desk_xdg", "acc2", "data", "logs", "sandbox");
+    mkdirSync(sandbox2, { recursive: true });
+    assert.equal(listAccountSandboxDirs(fx.homeDir).length, 2);
+
+    const events = [];
+    const watcher = createDuMateWatcher({
+      homeDir: fx.homeDir,
+      onEvent: (event) => events.push(event),
+      idleCompleteMs: 1000,
+      now: () => Date.now()
+    });
+    writeFileSync(join(sandbox2, "ses_def000000000.log"), "INFO service=sandbox.entry handshake complete");
+    watcher.start();
+    assert.equal(events.length, 1);
+    assert.ok(watcher.hasSession("def000000000"));
+
+    // 同一会话重复扫描不重复发事件
+    watcher.scan();
+    assert.equal(events.length, 1);
+    watcher.stop();
+  } finally {
+    fx.cleanup();
+  }
+});
+
+test("missing qianfan root yields no directories and no events", () => {
+  const events = [];
+  const watcher = createDuMateWatcher({
+    homeDir: "/nonexistent-home",
+    onEvent: (event) => events.push(event),
+    now: () => Date.now()
+  });
+  watcher.start();
+  watcher.stop();
+  assert.equal(events.length, 0);
+});
+
+test("parseProjectDirFromHead picks the first directory field", () => {
+  assert.equal(parseProjectDirFromHead("INFO service=sandbox.entry directory=/Users/mac/p1 bootstrap"), "/Users/mac/p1");
+  assert.equal(parseProjectDirFromHead("INFO nothing here"), "");
+});


### PR DESCRIPTION
## 概要

DuMate「Configured 但永不 Connected」的根因与修复。

## 根因（本机探测实验实锤）

#159 走的是 OpenCode 插件路线（写 `config/opencode/plugin/`），对独立版 OpenCode 有效（设置页 OpenCode 显示 Connected 可证），但 **DuMate 内嵌的 dumate-opencode 定制构建不自动加载该目录**——把探测插件放进真实配置目录、复刻 DuMate 全量 50 个环境变量启动 `dumate-opencode serve`，插件标记文件始终不出现；运行中实例的 DEBUG trace 里也零插件痕迹。且 DuMate 每次启动整体重写 opencode.json，配置注册路线同样被冲掉。

## 修复：文件观测通道（WorkIsland 已验证模式）

同 Codex transcript watcher / 用量发现通道的被动观测模式：

- 监听 `qianfan_desk_xdg/<账号>/data/logs/sandbox/ses_*.log`（每个 DuMate 会话一份生命周期日志，实测存在）
- 新会话日志出现 → `sessionStarted`（合成标题 `DuMate · 短码`，解析 `directory=` 项目路径）；日志闲置 150s → `sessionCompleted`（阈值先例：Codex 180s 闲置兜底）
- **observe-only**：日志正文（命令、消息分片）不进任何事件对象，单测断言内容不泄露
- 多账号目录全覆盖；纯 fs 实现、logger 注入、4 例单测

## 附带核查

- 千问办公：hook 已正确写入 `~/.qoder/settings.json`；hook 装好后尚无新 qoder 会话产生（transcript 停在 6 月），「未触发」属无会话而非故障，待一次真实任务验证。
- 岛上会话卡图标为全 Agent 统一的状态图标（running/approval/complete），不含品牌位——设置页品牌 Logo 已随 #163 换官方版。

## 测试

- [x] `npm run check` 全绿（602/602）
- [ ] 真机验收：跑一次 DuMate 任务，岛上出现「DuMate · 短码」会话卡（运行 → 完成）

Refs #158 #159
