### PR TITLE
fix(dumate): 历史会话静默归档——首启不弹旧卡

### DIFF
--- a/src/main/dumate-watcher.cjs
+++ b/src/main/dumate-watcher.cjs
@@ -81,6 +81,7 @@ function createDuMateWatcher({
   }
 
   function scan() {
+    const currentTime = now();
     for (const sandboxDir of listAccountSandboxDirs(homeDir)) {
       let files;
       try {
@@ -109,19 +110,25 @@ function createDuMateWatcher({
         } catch {
           // 读头失败不阻塞会话出现
         }
+        // 已闲置的历史会话（WorkIsland 关闭期间跑完的）静默归档，不弹卡；
+        // 只播报此刻仍在运行的新会话。
+        const alreadyIdle = currentTime - stat.mtimeMs >= idleCompleteMs;
         sessions.set(sessionId, {
           logPath,
           projectPath,
           lastMtimeMs: stat.mtimeMs,
           started: true,
-          completed: false
+          completed: alreadyIdle
         });
-        emit("sessionStarted", sessionId, projectPath);
-        logger.info?.("[DuMateWatcher]", `session started: ${sessionId} (${projectPath || "unknown dir"})`);
+        if (alreadyIdle) {
+          logger.debug?.("[DuMateWatcher]", `historical session archived silently: ${sessionId}`);
+        } else {
+          emit("sessionStarted", sessionId, projectPath);
+          logger.info?.("[DuMateWatcher]", `session started: ${sessionId} (${projectPath || "unknown dir"})`);
+        }
       }
     }
 
-    const currentTime = now();
     for (const [sessionId, session] of sessions) {
       if (session.completed) continue;
       let mtimeMs = session.lastMtimeMs;

--- a/tests/dumate-watcher.test.mjs
+++ b/tests/dumate-watcher.test.mjs
@@ -61,6 +61,14 @@ test("new sandbox session log emits start, idle emits completion, content never 
     // 已收卡不再重复
     watcher.scan();
     assert.equal(events.length, 2);
+
+    // 历史会话（出现即已闲置）静默归档，不弹卡
+    writeFileSync(join(fx.sandboxDir, "ses_old000000009.log"), "INFO service=sandbox.entry sandbox starting");
+    const past = clock - 60_000;
+    utimesSync(join(fx.sandboxDir, "ses_old000000009.log"), new Date(past), new Date(past));
+    watcher.scan();
+    assert.equal(events.length, 2, "historical idle session must be silent");
+    assert.equal(watcher.hasSession("old000000009"), true);
     watcher.stop();
   } finally {
     fx.cleanup();


### PR DESCRIPTION
WorkIsland 启动时沙箱目录里已闲置的历史 DuMate 会话（上次关闭期间跑完的）直接标记 completed 不发事件，只播报此刻仍在运行的新会话——避免首启把全部历史会话弹成完成卡。测试 602/602 绿（新增历史会话静默断言）。