### PR TITLE
merge: 收编社区 PR #36——贴边（dock）可选附件回归

### DIFF
--- a/scripts/test-source.mjs
+++ b/scripts/test-source.mjs
@@ -65,7 +65,9 @@ const {
 // set-preference, and did-change so all windows update live (165 -> 166).
 // SSH 远程设置页 adds remote-hosts:scan-ssh-config / invite / start-tunnel (166 -> 169, 2026-09).
 // Issue #148 adds the managed background-image picker and cropped-image installer (169 -> 171).
-assert.equal(Object.keys(IPC).length, 171, "IPC contract changed; review both main and preload consumers");
+// 贴边（dock）可选附件重新引入 island:drag-start / drag-end / placement /
+// get-placement 四个通道（171 -> 175）—— 与 #28 当初移除的是同一组。
+assert.equal(Object.keys(IPC).length, 175, "IPC contract changed; review both main and preload consumers");
 assert.equal(listProductCapabilities({ platform: "darwin" }).length, 15, "MCP product catalog must stay explicit");
 assert.equal(diagnoseMcpSubject("performance-details-not-visible", { settings: {} }).subject, "performance-details-not-visible");
 assert.equal(IPC.APP_UPDATE_DOWNLOAD, "app:update-download");

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -336,6 +336,8 @@
   "settings.general.behavior.displayMode.minimal": "Minimal",
   "settings.general.behavior.displayMode.persistent": "Persistent (Default)",
   "settings.general.behavior.displayMode.title": "Island Display Mode",
+  "settings.general.behavior.dock.description": "Leaves the notch and becomes a draggable edge bar: it shrinks to a square while you drag, and snaps to the nearest edge (top/left/right) on release. Left and right docks are vertical bars that expand into tall panels; the top dock is a horizontal bar. Off by default.",
+  "settings.general.behavior.dock.title": "Dock mode",
   "settings.general.behavior.fullscreen.description": "Hide the Island when a full-screen app is on the current display.",
   "settings.general.behavior.fullscreen.title": "Hide in Full Screen",
   "settings.general.behavior.hover.description": "Expand the panel when the pointer rests on the Island.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -336,6 +336,8 @@
   "settings.general.behavior.displayMode.minimal": "极简",
   "settings.general.behavior.displayMode.persistent": "常驻（默认）",
   "settings.general.behavior.displayMode.title": "Island 显示模式",
+  "settings.general.behavior.dock.description": "脱离顶部刘海，变成可拖动的贴边条：拖动时收成小方块，松手吸附到最近的边（上/左/右）。贴左右时是竖条、展开为竖长面板；贴顶部时是横条。默认关闭。",
+  "settings.general.behavior.dock.title": "贴边模式",
   "settings.general.behavior.fullscreen.description": "全屏应用位于当前屏幕时隐藏 Island。",
   "settings.general.behavior.fullscreen.title": "全屏时隐藏",
   "settings.general.behavior.hover.description": "鼠标停留在 Island 上时展开面板。",

--- a/src/main/index.cjs
+++ b/src/main/index.cjs
@@ -97,8 +97,9 @@ function setQuitting(value) {
   isQuitting = value;
 }
 const { createWindowClasses } = require("./windows.cjs");
+const { createDockableIslandWindow, attachIslandDock } = require("./island-dock.cjs");
 const {
-  IslandWindow,
+  IslandWindow: BaseIslandWindow,
   PetPanelWindow,
   PetWindow,
   SettingsWindow,
@@ -117,6 +118,9 @@ const {
   isVisibleInIsland,
   getIsQuitting: () => isQuitting
 });
+// 贴边落位是 IslandWindow 的可选附件：islandPlacement 为 notch（默认）时每个覆写
+// 都原样转给基类，刘海路径的行为与未接附件时完全一致。
+const IslandWindow = createDockableIslandWindow(BaseIslandWindow, { electron, IPC, log, fixPanel });
 function throttle(func, wait, options = {}) {
   let leading = true;
   let trailing = true;
@@ -917,6 +921,7 @@ async function runIslandApp() {
     }
   };
   let islandWindow;
+  let islandDock = null;
   let statusTray = null;
   let rendererCrashCount = 0;
   const MAX_RENDERER_RETRIES = 2;
@@ -932,6 +937,7 @@ async function runIslandApp() {
           browserWindow.webContents.send(IPC.ISLAND_WINDOW_BLUR);
         }
       });
+      islandDock = attachIslandDock(iw, coordinator, log);
       coordinator.setIslandWindow(iw.browserWindow);
       coordinator.setIslandWin(iw);
       coordinator.setDisplayManager(displayManager);
@@ -1215,6 +1221,7 @@ async function runIslandApp() {
   coordinator.setOnSettingsChange((settings) => {
     displayManager?.setPreference(settings.displayPreference, settings.displayPreferenceLabel);
     shortcutService.setConfig(settings.shortcuts);
+    islandDock?.applySettings(settings);
   });
   coordinator.setOnApprovalStateChange((hasPending) => {
     if (hasPending) shortcutService.armApproval();

--- a/src/main/island-dock.cjs
+++ b/src/main/island-dock.cjs
@@ -1,0 +1,385 @@
+"use strict";
+/**
+ * 贴边（dock）落位 —— IslandWindow 的可选附件。
+ *
+ * 设计约束：对主代码零侵入。
+ *   - 以子类形式叠在 IslandWindow 上，只覆写少数几个方法，不改基类一行；
+ *   - islandPlacement = "notch"（默认）时，每个覆写都原样转给基类：行为与
+ *     没装这个附件时完全一致（tests/island-dock-addon.test.mjs 守着这一点）；
+ *   - 只有设置切到 "docked" 才接管窗口几何与鼠标策略。
+ *
+ * 落位模型：
+ *   - 主进程是唯一状态源 {placement, edge, mode, strip}，窗口尺寸与渲染层形状都由它推导；
+ *     分开各算各的正是此前「找不到 / 长条 / 竖侧边栏」的共同成因；
+ *   - 贴边期间窗口**固定为面板大小**（贴边锚定），条↔面板的切换全部交给渲染层的
+ *     clip-path 形变 —— 和刘海模式同构，所以一样丝滑；
+ *   - 窗口 bounds 只在拖动（小方块跟手）和吸附换边时变化。
+ */
+
+// 条的几何来自刘海胶囊本身：厚度 = 胶囊高度，长度 = 胶囊宽度。
+// 贴边条就是那颗胶囊换了个位置，而不是另一个尺寸的新控件 —— 从刘海切到贴边时
+// 大小不变，三条边也彼此一致。STRIP_* 只是取不到屏幕信息时的兜底。
+const DOCK = Object.freeze({
+  SQUARE: 56,          // 拖动中的小方块
+  STRIP_DEPTH: 25,     // 兜底厚度（≈菜单栏高度）
+  STRIP_LEN: 198,      // 兜底长度（≈无刘海屏的收起态胶囊宽度）
+  VPANEL_W: 380,       // 侧边展开的竖长面板
+  VPANEL_H: 560,
+  TOP_WINDOW_H: 620,   // 顶部贴边时的窗口高度（面板向下展开的空间）
+  HPANEL_W: 740,       // 顶部展开的横向面板
+  DRAG_POLL_MS: 16,
+  DRAG_MAX_MS: 15e3    // mouseup 丢失时的安全上限
+});
+
+const clamp01 = (v) => Math.max(0, Math.min(1, v));
+
+/**
+ * 收起态胶囊的尺寸，直接照搬刘海模式的算法。
+ * 贴边条沿用它，切换落位时大小不会跳变。
+ * 渲染层的胶囊会随会话相位继续变长（要放标题和计时）；贴边条不显示文字，
+ * 固定在空闲态那一档即可。
+ */
+function pillSize(screenInfo) {
+  const info = screenInfo ?? {};
+  const menuBarHeight = Number(info.menuBarHeight) || 0;
+  const depth = info.hasNotch
+    ? Number(info.notchHeight) || DOCK.STRIP_DEPTH
+    : menuBarHeight > 0 && menuBarHeight < 40 ? menuBarHeight : 24;
+  const notchWidth = info.hasNotch ? Number(info.notchWidth) || 126 : 126;
+  // 与渲染层空闲态一致：本体宽度 + 两侧留白（有刘海 62，无刘海 72）
+  const len = Math.max(notchWidth, 126) + (info.hasNotch ? 62 : 72);
+  return { len: Math.round(len) || DOCK.STRIP_LEN, depth: Math.max(1, Math.round(depth)) };
+}
+
+/**
+ * 贴边几何（纯函数，便于测试）。
+ * @param strip 条的尺寸 {len, depth}，由 pillSize() 从屏幕信息推出
+ * @returns {{bounds:{x,y,width,height}, strip:{spanOffset,len,depth}}}
+ *   bounds 是窗口矩形；strip 是收起态条形在窗口内沿边方向的起点/长度/厚度。
+ */
+function dockGeometry(display, edge, offset, strip) {
+  const b = display.bounds;
+  const wa = display.workArea ?? b;
+  const len = strip?.len ?? DOCK.STRIP_LEN;
+  const depth = strip?.depth ?? DOCK.STRIP_DEPTH;
+  if (edge === "top") {
+    const w = DOCK.HPANEL_W;
+    const winX = Math.max(b.x, Math.min(b.x + Math.round((b.width - w) * offset), b.x + b.width - w));
+    const stripX = Math.max(b.x, Math.min(b.x + Math.round((b.width - len) * offset), b.x + b.width - len));
+    return {
+      bounds: { x: winX, y: b.y, width: w, height: DOCK.TOP_WINDOW_H },
+      strip: { spanOffset: stripX - winX, len, depth }
+    };
+  }
+  const w = DOCK.VPANEL_W;
+  const h = DOCK.VPANEL_H;
+  const stripCenter = wa.y + offset * wa.height;
+  const stripTop = Math.max(wa.y, Math.min(Math.round(stripCenter - len / 2), wa.y + wa.height - len));
+  const winY = Math.max(wa.y, Math.min(stripTop, wa.y + wa.height - h));
+  const x = edge === "left" ? wa.x : wa.x + wa.width - w;
+  return {
+    bounds: { x, y: winY, width: w, height: h },
+    strip: { spanOffset: stripTop - winY, len, depth }
+  };
+}
+
+/** 松手时该吸到哪条边（上/左/右，不含底部），以及沿边位置的 0-1 比例。 */
+function nearestEdge(workArea, rect) {
+  const cx = rect.x + rect.width / 2;
+  const cy = rect.y + rect.height / 2;
+  const dTop = cy - workArea.y;
+  const dLeft = cx - workArea.x;
+  const dRight = workArea.x + workArea.width - cx;
+  const nearest = Math.min(dTop, dLeft, dRight);
+  const edge = nearest === dTop ? "top" : nearest === dLeft ? "left" : "right";
+  const offset = edge === "top"
+    ? clamp01((cx - workArea.x) / Math.max(1, workArea.width))
+    : clamp01((cy - workArea.y) / Math.max(1, workArea.height));
+  return { edge, offset };
+}
+
+/**
+ * 用贴边能力包装 IslandWindow。
+ * @param BaseIslandWindow createWindowClasses() 返回的 IslandWindow
+ * @param deps { electron, IPC, log, fixPanel }
+ */
+function createDockableIslandWindow(BaseIslandWindow, deps) {
+  const { electron, IPC, log, fixPanel } = deps;
+  const noop = () => {};
+  const logger = { info: log?.info ?? noop, warn: log?.warn ?? noop, debug: log?.debug ?? noop };
+
+  class DockableIslandWindow extends BaseIslandWindow {
+    _placement = "notch";
+    _dockEdge = "right";       // "top" | "left" | "right"
+    _dockOffset = 0.25;        // 沿边位置的 0-1 比例，跨分辨率仍成立
+    _dockDragging = false;
+    _dragTimer = null;
+    _dragOrigin = null;
+    // 渲染层是否处于展开态。只由渲染层的 PANEL_EXPANDED/COLLAPSED 上报驱动，
+    // 不用基类的 isPanelExpanded —— 后者会被隐藏路径提前置 false。
+    _rendererExpanded = false;
+    // 刘海形态下的窗口尺寸，切回 notch 时原样归还。
+    _notchSize = null;
+    /** 拖动吸附完成后的回调：{edge, offset}，由安装方写回设置。 */
+    onDockChange = null;
+
+    constructor(target, options) {
+      super(target, options);
+      this._notchSize = this.win.getSize();
+      this._onDragStart = (event) => {
+        if (!this.isDocked || this.win.isDestroyed() || event.sender !== this.win.webContents) return;
+        this.beginDrag();
+      };
+      this._onDragEnd = (event) => {
+        if (this.win.isDestroyed() || event.sender !== this.win.webContents) return;
+        this.stopDragFollow();
+        if (!this.isDocked) return;
+        this._dragOrigin = null;
+        this.snapToNearestEdge();
+      };
+      this._onPanelExpanded = (event) => {
+        if (this.win.isDestroyed() || event.sender !== this.win.webContents) return;
+        this._rendererExpanded = true;
+        if (this.isDocked) this.sendDockState(); // mode 变了（strip→panel），渲染层的形态类名要跟上
+      };
+      this._onPanelCollapsed = (event) => {
+        if (this.win.isDestroyed() || event.sender !== this.win.webContents) return;
+        this._rendererExpanded = false;
+        if (this.isDocked) this.sendDockState();
+      };
+      const { ipcMain } = electron;
+      ipcMain.on(IPC.ISLAND_DRAG_START, this._onDragStart);
+      ipcMain.on(IPC.ISLAND_DRAG_END, this._onDragEnd);
+      ipcMain.on(IPC.ISLAND_PANEL_EXPANDED, this._onPanelExpanded);
+      ipcMain.on(IPC.ISLAND_PANEL_COLLAPSED, this._onPanelCollapsed);
+      // 渲染层崩溃重建窗口时，旧 handler 可能还没随 closed 摘掉；先移除再注册。
+      ipcMain.removeHandler(IPC.ISLAND_GET_PLACEMENT);
+      // 必须返回完整 dock 状态。只回 {placement} 会把推送过的 edge/mode/strip
+      // 覆盖成 undefined，渲染层直接退化成一整块无裁切的黑矩形。
+      ipcMain.handle(IPC.ISLAND_GET_PLACEMENT, () => this.dockState());
+      // 补发落位状态。setPlacement 往往在页面加载完成前就调用过（启动时按设置
+      // 落位），那时 webContents.send 会被直接丢弃，渲染层便一直以为自己是
+      // notch 模式 —— 窗口已按面板尺寸摆好，渲染层却仍按刘海 clip-path 裁切。
+      this.win.webContents.on("did-finish-load", () => {
+        if (this.win.isDestroyed()) return;
+        this.sendDockState();
+        if (this.isDocked) this.applyDockBounds();
+      });
+      this.win.on("closed", () => this.disposeDock());
+    }
+
+    disposeDock() {
+      const { ipcMain } = electron;
+      ipcMain.removeListener(IPC.ISLAND_DRAG_START, this._onDragStart);
+      ipcMain.removeListener(IPC.ISLAND_DRAG_END, this._onDragEnd);
+      ipcMain.removeListener(IPC.ISLAND_PANEL_EXPANDED, this._onPanelExpanded);
+      ipcMain.removeListener(IPC.ISLAND_PANEL_COLLAPSED, this._onPanelCollapsed);
+      ipcMain.removeHandler(IPC.ISLAND_GET_PLACEMENT);
+      this.stopDragFollow();
+    }
+
+    get isDocked() {
+      return this._placement === "docked";
+    }
+
+    // ── 覆写：贴边态下接管，否则原样交还基类 ──────────────────────────────
+    /** 贴边是常驻卡片，不参与全屏隐身。 */
+    setFullscreenHidden(hidden) {
+      if (this.isDocked) return;
+      super.setFullscreenHidden(hidden);
+    }
+    /** 贴边是常驻卡片，不参与失焦隐身。 */
+    setFocusHidden(hidden) {
+      if (this.isDocked) return;
+      super.setFocusHidden(hidden);
+    }
+    /** 贴边态窗口固定为面板大小：高度上报只记录、不改窗口。 */
+    applyRequestedHeight(height) {
+      if (!this.isDocked) return super.applyRequestedHeight(height);
+      this.requestedHeight = Math.max(1, Math.round(height));
+    }
+    /** 贴边下没有「隐身到顶部热区」：收起只是回到穿透，让面板区域下方的应用可以正常点击。 */
+    applyClosedWindowTarget(target, options) {
+      if (!this.isDocked) return super.applyClosedWindowTarget(target, options);
+      if (this.win.isDestroyed()) return;
+      this.win.setOpacity(1);
+      this.win.setIgnoreMouseEvents(true, { forward: true });
+    }
+    /**
+     * moveToDisplay 之类的场景会先跑 fixPanel（它会把窗口甩回顶部居中），
+     * 贴边态必须把窗口按新显示器重新摆回边上。
+     */
+    syncWindowToCurrentState() {
+      if (!this.isDocked) return super.syncWindowToCurrentState();
+      this.applyDockBounds();
+      super.syncWindowToCurrentState();
+    }
+
+    // ── 贴边状态机 ────────────────────────────────────────────────────────
+    /**
+     * 切换落位形态。
+     * notch  = 顶部刘海居中（基类原有形态，fixPanel + 菜单栏对齐那套几何）
+     * docked = 贴边（位置由 edge + offset 决定）
+     */
+    setPlacement(placement, dock) {
+      if (this.win.isDestroyed()) return;
+      const next = placement === "docked" ? "docked" : "notch";
+      const changed = this._placement !== next;
+      this._placement = next;
+      if (next === "docked") {
+        // 常驻可见：把基类的隐身标记清零，「隐身到顶部热区」整套停用。
+        this._isFullscreenHidden = false;
+        this._isFocusHidden = false;
+        this.isHoverRevealedWhileFullscreenHidden = false;
+        this.shouldConcealAfterCloseAnimation = false;
+        if (dock?.edge === "top" || dock?.edge === "left" || dock?.edge === "right") this._dockEdge = dock.edge;
+        if (typeof dock?.offset === "number" && Number.isFinite(dock.offset)) this._dockOffset = clamp01(dock.offset);
+        this.applyDockBounds();
+        this.win.setOpacity(1);
+        // 空闲态穿透 + 转发：条的可点击性由渲染层 mouseenter → ISLAND_ENTER 开启，
+        // 和刘海模式同一套机制。
+        this.win.setIgnoreMouseEvents(true, { forward: true });
+      } else if (changed) {
+        this.stopDragFollow();
+        this._dragOrigin = null;
+        this._dockDragging = false;
+        // 把窗口尺寸/位置交还给基类那套几何：先恢复刘海形态的窗口宽度
+        // （侧边贴边时窗口只有 380 宽，刘海 clip-path 按 740 宽算，不还原会错位），
+        // 再 fixPanel 贴顶居中、压到收起高度。
+        const { display } = this.currentTarget;
+        const [w, h] = this._notchSize ?? this.win.getSize();
+        this.win.setBounds({
+          x: display.bounds.x + Math.round((display.bounds.width - w) / 2),
+          y: display.bounds.y,
+          width: w,
+          height: h
+        });
+        fixPanel?.(this.win.getNativeWindowHandle(), display.id);
+        this.applyRequestedHeight(this.getClosedHeight());
+        this.win.setOpacity(1);
+        this.win.setIgnoreMouseEvents(true, { forward: true });
+      }
+      if (changed) logger.info("[IslandDock] placement ->", next, next === "docked" ? this._dockEdge : "");
+      this.sendDockState();
+    }
+    /** 当前 dock 形态：dragging | strip | panel。 */
+    get dockMode() {
+      if (this._dockDragging) return "dragging";
+      return this._rendererExpanded ? "panel" : "strip";
+    }
+    dockGeometry() {
+      return dockGeometry(
+        this.currentTarget.display,
+        this._dockEdge,
+        this._dockOffset,
+        pillSize(this.currentTarget.screenInfo)
+      );
+    }
+    /** 把窗口摆到当前 dock 几何（瞬时）。形变动画在渲染层。 */
+    applyDockBounds() {
+      if (this.win.isDestroyed() || !this.isDocked || this._dockDragging) return;
+      this.win.setBounds(this.dockGeometry().bounds);
+      this.sendDockState();
+    }
+    /** 把完整 dock 状态推给渲染层。渲染层只照着画，不自行推断。 */
+    sendDockState() {
+      this.send(IPC.ISLAND_PLACEMENT, this.dockState());
+    }
+    dockState() {
+      const state = {
+        placement: this._placement,
+        edge: this._dockEdge,
+        mode: this.isDocked ? this.dockMode : "notch"
+      };
+      if (this.isDocked && !this._dockDragging) state.strip = this.dockGeometry().strip;
+      return state;
+    }
+    /** 按下即收成小方块落在光标下，之后由主进程轮询光标跟手。 */
+    beginDrag() {
+      const c = electron.screen.getCursorScreenPoint();
+      // 窗口是面板大小，保留原位置会让方块出现在面板左上角、离光标很远。
+      this._dockDragging = true;
+      const sx = c.x - Math.round(DOCK.SQUARE / 2);
+      const sy = c.y - Math.round(DOCK.SQUARE / 2);
+      this.win.setBounds({ x: sx, y: sy, width: DOCK.SQUARE, height: DOCK.SQUARE });
+      this._dragOrigin = { cx: c.x, cy: c.y, wx: sx, wy: sy, startedAt: Date.now() };
+      this.sendDockState();
+      // 轮询而不是依赖渲染层持续上报 mousemove：拖动中鼠标常常已经移出窗口范围，
+      // 渲染层就收不到事件了。
+      this.stopDragFollow();
+      this._dragTimer = setInterval(() => {
+        if (this.win.isDestroyed() || !this._dragOrigin) {
+          this.stopDragFollow();
+          return;
+        }
+        if (Date.now() - this._dragOrigin.startedAt > DOCK.DRAG_MAX_MS) {
+          // mouseup 没能传回来（例如鼠标在别的窗口上松开），别无限跟随。
+          this.stopDragFollow();
+          this._dragOrigin = null;
+          this.snapToNearestEdge();
+          return;
+        }
+        const now = electron.screen.getCursorScreenPoint();
+        this.win.setPosition(
+          this._dragOrigin.wx + (now.x - this._dragOrigin.cx),
+          this._dragOrigin.wy + (now.y - this._dragOrigin.cy)
+        );
+      }, DOCK.DRAG_POLL_MS);
+    }
+    stopDragFollow() {
+      if (this._dragTimer) {
+        clearInterval(this._dragTimer);
+        this._dragTimer = null;
+      }
+    }
+    /** 松手：一定吸附到最近的边（上/左/右，不含底部），并记住位置。 */
+    snapToNearestEdge() {
+      if (this.win.isDestroyed() || !this.isDocked) return;
+      const [width, height] = this.win.getSize();
+      const [x, y] = this.win.getPosition();
+      const rect = { x, y, width, height };
+      // 显示器归属仍由 DisplayManager 决定：这里只算边与比例，几何始终按
+      // currentTarget 那块屏摆放（拖到别的屏松手，会回到本屏对应位置）。
+      const { workArea } = electron.screen.getDisplayMatching(rect);
+      const { edge, offset } = nearestEdge(workArea, rect);
+      this._dockEdge = edge;
+      this._dockOffset = offset;
+      this._dockDragging = false;
+      this.applyDockBounds();
+      // 吸附完成后回到穿透态：窗口是面板大小，空闲时绝不能挡住下面的点击。
+      this.win.setIgnoreMouseEvents(true, { forward: true });
+      this.onDockChange?.({ edge, offset });
+    }
+  }
+  return DockableIslandWindow;
+}
+
+/**
+ * 把附件接到应用上：按设置落位、拖动后把位置写回设置。
+ * 返回 { applySettings }，在设置变更回调里调用即可让切换立即生效。
+ */
+function attachIslandDock(iw, coordinator, log) {
+  if (!iw || typeof iw.setPlacement !== "function") return null;
+  iw.onDockChange = (dock) => {
+    try {
+      coordinator.updateSettings({ islandDock: dock }, "island");
+    } catch (err) {
+      log?.warn?.("[IslandDock] 保存贴边位置失败:", err);
+    }
+  };
+  let applied = "notch";
+  const applySettings = (settings) => {
+    const placement = settings?.islandPlacement === "docked" ? "docked" : "notch";
+    if (placement === applied) return;
+    applied = placement;
+    try {
+      iw.setPlacement(placement, settings?.islandDock);
+    } catch (err) {
+      log?.warn?.("[IslandDock] 应用落位失败:", err);
+    }
+  };
+  applySettings(coordinator.getSettings?.() ?? {});
+  return { applySettings };
+}
+
+module.exports = { DOCK, pillSize, dockGeometry, nearestEdge, createDockableIslandWindow, attachIslandDock };

--- a/src/preload/island.js
+++ b/src/preload/island.js
@@ -225,6 +225,18 @@ electron.contextBridge.exposeInMainWorld("islandBridge", {
   surfaceDismissed() {
     electron.ipcRenderer.send(ipc.IPC.ISLAND_SURFACE_DISMISSED);
   },
+  dragStart() {
+    electron.ipcRenderer.send(ipc.IPC.ISLAND_DRAG_START);
+  },
+  dragEnd() {
+    electron.ipcRenderer.send(ipc.IPC.ISLAND_DRAG_END);
+  },
+  getPlacement() {
+    return electron.ipcRenderer.invoke(ipc.IPC.ISLAND_GET_PLACEMENT);
+  },
+  onPlacement(cb) {
+    electron.ipcRenderer.on(ipc.IPC.ISLAND_PLACEMENT, (_e, payload) => cb(payload));
+  },
   dragToPet(screenX, screenY) {
     electron.ipcRenderer.send(ipc.IPC.ISLAND_DRAG_TO_PET, { screenX, screenY });
   },

--- a/src/renderer/island/app.js
+++ b/src/renderer/island/app.js
@@ -7,6 +7,7 @@ import { I as IslandPanel, setIslandStatusAssets as setIslandPanelStatusAssets }
 import { enabledToolboxModules, resolveToolboxReopenModule } from "./components/productivity-toolbox-model.mjs";
 import { isVisibleInIsland } from "./session-model.mjs";
 import { resolveFocusLossPresentation, shouldCollapseOnFocusLoss } from "./focus-policy.mjs";
+import { u as useIslandDock, D as DockStatusDot } from "./dock/use-island-dock.js";
 import { applyIslandAppearance } from "./theme.mjs";
 const useSessionStore = create((set) => ({
   sessions: [],
@@ -727,6 +728,8 @@ function IslandApp() {
   });
   const clipPath = mounted ? isOpen ? openedShape.clipPath : closedShape.clipPath : closedShape.clipPath;
   const transition = mounted ? transitionClass : "";
+  // 贴边落位（可选附件）：落位是 notch 时下面每个表达式都退回原样。
+  const dock = useIslandDock({ mounted, isOpen, transitionClass, actualPanelH, panelHeight, pillWidth, notchH, hoverOpenTimer, requestCollapse: useSessionStore.getState().requestCollapse });
   const appearanceBackgroundShape = isOpen ? openedShape : closedShape;
   const appearanceBackgroundFrameStyle = {
     left: appearanceBackgroundShape.left,
@@ -980,8 +983,8 @@ function IslandApp() {
     /* @__PURE__ */ React.createElement(
       "div",
       {
-        className: `island ${transition}`,
-        style: { clipPath },
+        className: `island ${transition}${dock.islandClass}`,
+        style: { clipPath: dock.active ? dock.clipPath : clipPath },
         onMouseEnter: handleMouseEnter,
         onMouseLeave: handleMouseLeave
       },
@@ -999,8 +1002,9 @@ function IslandApp() {
         "div",
         {
           className: `island-pill-layer${isOpen ? " is-hidden" : ""}${pillFileDragActive ? " is-file-drop-target" : ""}`,
-          style: { width: pillWidth, height: notchH }
+          style: dock.pillLayerStyle ?? { width: pillWidth, height: notchH }
         },
+        /* @__PURE__ */ React.createElement(DockStatusDot, { dock, phase }),
         /* @__PURE__ */ React.createElement(
           IslandPill,
           {
@@ -1023,8 +1027,8 @@ function IslandApp() {
         "div",
         {
           ref: panelLayerRef,
-          className: `island-panel-layer${isOpen ? "" : " is-hidden"}`,
-          style: { width: panelWidth }
+          className: `island-panel-layer${isOpen ? "" : " is-hidden"}${dock.panelLayerClass}`,
+          style: dock.panelLayerStyle ?? { width: panelWidth }
         },
         /* @__PURE__ */ React.createElement(
           IslandPanel,

--- a/src/renderer/island/dock/dock-shape.js
+++ b/src/renderer/island/dock/dock-shape.js
@@ -1,0 +1,62 @@
+// 贴边形态的裁切路径。
+//
+// 复用刘海那套「贴边侧内凹、自由端凸圆角」的轮廓：与屏幕边缘相接处用一段反向
+// 弧线（sweep=0），看起来像是从边缘长出来的，而不是一块贴上去的圆角矩形。
+//
+// 路径先写在「沿边 u / 深度 v」坐标系里，再按边做 90° 旋转映射到窗口坐标。
+// 旋转是正交变换（行列式为 1），所以弧线的 sweep 标志无需改动即可保持方向。
+const MAP = {
+  // (u 沿边, v 深度) → (x, y)
+  top: (u, v) => [u, v],
+  right: (u, v, W) => [W - v, u],
+  left: (u, v, W, H) => [v, H - u]
+};
+
+/**
+ * @param edge      "top" | "left" | "right"
+ * @param winW/winH 窗口尺寸
+ * @param bodyLen   本体沿边方向的长度（不含两端内凹外扩的部分）
+ * @param depth     本体垂直于边的深度
+ * @param concaveR  贴边侧内凹半径
+ * @param convexR   自由端凸圆角半径
+ * @param spanStart 形状沿边方向的起点（窗口内坐标）；缺省时居中
+ */
+function buildDockClipPath({ edge, winW, winH, bodyLen, depth, concaveR, convexR, spanStart }) {
+  const map = MAP[edge] ?? MAP.top;
+  const p = (u, v) => {
+    const [x, y] = map(u, v, winW, winH);
+    return `${Math.round(x * 100) / 100},${Math.round(y * 100) / 100}`;
+  };
+  // 沿边方向的总跨度 = 本体 + 两端各一个内凹半径
+  const span = edge === "top" ? winW : winH;
+  const outer = Math.min(bodyLen + 2 * concaveR, span);
+  let u0 = spanStart == null
+    ? (span - outer) / 2
+    : Math.max(0, Math.min(spanStart, span - outer));
+  // 左边缘的旋转映射是 (u,v) → [v, H-u]，u 轴方向被翻转 —— 调用方传入的
+  // spanStart 语义是「距窗口顶部」，这里补一次翻转，否则形状会落到窗口底部、
+  // 与胶囊层（按顶部定位）分家：左侧贴边就只剩一块空黑。形状沿边对称，
+  // 翻转起点即完成整体镜像。
+  if (edge === "left") u0 = span - u0 - outer;
+  const u1 = u0 + outer;
+  const cR = Math.min(concaveR, outer / 4, depth / 4);
+  const vR = Math.min(convexR, outer / 4, depth / 2);
+  const d = depth;
+  // 轮廓自贴边侧起笔，顺序为：贴边侧内凹圆角 → 自由端凸圆角 → 对称收回。
+  // 注：段注释统一写在模板外 —— scripts/check-i18n.mjs 的扫描器不解析模板
+  // 字面量里的 ${} 嵌套，会把行尾注释误判成硬编码文案。
+  return `path('${[
+    `M ${p(u0, 0)}`,
+    `L ${p(u1, 0)}`,
+    `A ${cR},${cR} 0 0,0 ${p(u1 - cR, cR)}`,
+    `L ${p(u1 - cR, d - vR)}`,
+    `A ${vR},${vR} 0 0,1 ${p(u1 - cR - vR, d)}`,
+    `L ${p(u0 + cR + vR, d)}`,
+    `A ${vR},${vR} 0 0,1 ${p(u0 + cR, d - vR)}`,
+    `L ${p(u0 + cR, cR)}`,
+    `A ${cR},${cR} 0 0,0 ${p(u0, 0)}`,
+    "Z"
+  ].join(" ")}')`;
+}
+
+export { buildDockClipPath as b };

--- a/src/renderer/island/dock/dock.css
+++ b/src/renderer/island/dock/dock.css
@@ -1,0 +1,197 @@
+/* ── dock（贴边）落位 —— IslandApp 的可选附件样式 ───────────────────────────
+ * 只在 .island.is-docked（及其形态类 is-dock-{top|left|right} / is-dock-{strip|panel|dragging}）
+ * 下生效；刘海模式（默认）不会命中这里任何一条规则。由 island.html 单独引入。
+ *
+ * 贴边态下窗口尺寸已经紧贴可见形状，所以形状一律用 clip-path：
+ * 窗口和绘制形状同源，不会出现「窗口缩了但裁切没跟上」的条状残影。 */
+
+.island.is-docked {
+  background: #000;
+  border-radius: 0;
+}
+
+/* 拖动中的小方块没有贴边关系，用普通圆角 */
+.island.is-dock-dragging {
+  clip-path: none !important;
+  border-radius: 14px;
+}
+
+/* 阴影只朝屏幕内侧投，不能往贴边那一侧糊。
+ * 四周均匀的大模糊阴影会在黑色形状外糊出一圈暗晕，浅色背景下看起来就像
+ * 四角都是圆的、而且和屏幕边缘之间还有条缝 —— 贴边那侧必须是干净的直边。 */
+.island.is-dock-dragging {
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+/* 拖动中的小方块 */
+.island.is-dock-dragging {
+  border-radius: 14px;
+}
+
+
+
+
+
+/* ── 收起态条形的内容排布 ─────────────────────────────────────────────────
+ * 条的尺寸等于刘海胶囊（厚度 = 胶囊高度，长度 = 胶囊宽度），由主进程下发、
+ * JSX 内联给出；这里只管内容怎么摆。
+ *
+ * 条里一律不显示文字：宽度就那么点，截断的标题只是噪音，头像 + 数量 + 状态点
+ * 已经够用。两个方向完全镜像。 */
+
+/* 顶条：内容完全沿用刘海胶囊的排版（头像 + 标题 + 数量），一个字都不改 ——
+ * 从刘海切到贴边时只是位置变了，内容不该跟着变。这里只额外给状态点留出位置。
+ * 胶囊层贴的是形状的平直本体（两端弧线已由 JSX 内缩让开），所以 .pill 自身的
+ * 左右内边距保持上游的 10px 不动。 */
+.island.is-dock-top.is-dock-strip .pill {
+  padding-right: 24px;
+}
+
+/* 竖条：把同一排内容旋转 90°，起止留白与顶条镜像。 */
+.island.is-dock-left.is-dock-strip .pill,
+.island.is-dock-right.is-dock-strip .pill {
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  padding: 12px 0 26px;
+  gap: 6px;
+}
+
+.island.is-dock-left.is-dock-strip .pill-label,
+.island.is-dock-right.is-dock-strip .pill-label {
+  display: none;
+}
+
+.island.is-dock-left.is-dock-strip .pill-right,
+.island.is-dock-right.is-dock-strip .pill-right {
+  margin-left: 0;
+}
+
+/* 拖动中的小方块同样只显示头像 */
+.island.is-dock-dragging .pill {
+  justify-content: center;
+  padding: 0;
+  gap: 0;
+}
+
+.island.is-dock-dragging .pill-label,
+.island.is-dock-dragging .pill-right {
+  display: none;
+}
+
+/* ── 侧边窄幅面板排版 ──────────────────────────────────────────────────────
+ * 面板层占满 380 宽的窗口，内部按窄幅重排。会话行自身已有 min-width:0 +
+ * ellipsis，会自适应；需要动的是那些按 680+ 宽度设计的横向排布。 */
+
+/* 顶栏：配额格子和按钮组允许换行，行高放开 */
+/* 侧边面板兜底：内容永远不越出窗口（黑形状会盖住整窗高度时被裁切在形状内）。
+ * 用纯 CSS 而不是内联 height + React 状态：panelLayerRef 的 ResizeObserver
+ * 就挂在这个元素上，任何经 React 的高度反馈都有成环风险（实测会 #185 爆栈）。 */
+.island-panel-layer.is-side-dock {
+  max-height: 100%;
+  overflow: hidden;
+  /* 上下各让开一个自由端圆角（DOCK_CONVEX_R = 14）。
+   * 侧边面板的形状本体从 y=14 才开始 —— 自由端两个角是 14pt 圆角 —— 而面板
+   * 内容默认从 y=0 排起，顶栏那一行会被形状的上边缘削掉半截字。
+   * 内容整体下移一个圆角后正好落在本体内；面板跨度按内容高度 +16 计算，
+   * 这里多出的 28pt 会一并算进去，底部同样不会被削。 */
+  padding-top: 14px;
+  padding-bottom: 14px;
+}
+
+.island-panel-layer.is-side-dock .usage-row {
+  flex-wrap: wrap;
+  /* 左右各让开 20px：贴边侧顶端有 14px 的内凹弧线，12px 内边距会让
+   * 顶栏最外侧的按钮被弧线削掉一角 */
+  padding: 2px 20px 8px;
+  row-gap: 4px;
+  min-height: 0 !important;
+  height: auto;
+}
+
+.island-panel-layer.is-side-dock .usage-row-agents {
+  flex-basis: 100%;
+  overflow-x: auto;
+}
+
+.island-panel-layer.is-side-dock .usage-row-actions {
+  margin-left: auto;
+}
+
+/* 会话行：标题与元信息改为上下两行，不再左右争宽度 */
+.island-panel-layer.is-side-dock .session-headline {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 2px;
+}
+
+.island-panel-layer.is-side-dock .session-meta {
+  margin-left: 0;
+}
+
+/* 提示语与活动行给窄幅多留点行数 */
+.island-panel-layer.is-side-dock .session-prompt,
+.island-panel-layer.is-side-dock .session-activity {
+  white-space: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* 审批按钮组窄幅下允许换行 */
+.island-panel-layer.is-side-dock .approval-actions {
+  flex-wrap: wrap;
+}
+
+
+/* ── 竖条状态点 ───────────────────────────────────────────────────────────
+ * 相位配色与面板一致：running 蓝 / completed 绿 / 待批准橙 / 待回答黄。
+ * 挂在胶囊层内、头像下方；待处理相位加呼吸提醒。 */
+.dock-status-dot {
+  position: absolute;
+  left: 50%;
+  bottom: 10px;
+  transform: translateX(-50%);
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #5c564b;
+  pointer-events: none;
+}
+
+.dock-status-dot.is-running {
+  background: #6E9FFF;
+}
+
+.dock-status-dot.is-completed {
+  background: var(--isl-ok);
+}
+
+.dock-status-dot.is-waitingForApproval {
+  background: #FF9F0A;
+}
+
+.dock-status-dot.is-waitingForAnswer {
+  background: #FFD60A;
+}
+
+/* 顶条的状态点靠右垂直居中（竖条则是底部水平居中） */
+.dock-status-dot.dock-dot-top {
+  left: auto;
+  right: 10px;
+  bottom: auto;
+  top: 50%;
+  transform: translateY(-50%);
+}
+
+/* 呼吸只动透明度：transform 由各方位的定位持有，动画不能覆盖它 */
+@keyframes dock-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+
+.dock-status-dot.is-waitingForApproval,
+.dock-status-dot.is-waitingForAnswer {
+  animation: dock-dot-pulse 1.2s ease-in-out infinite;
+}

--- a/src/renderer/island/dock/use-island-dock.js
+++ b/src/renderer/island/dock/use-island-dock.js
@@ -1,0 +1,190 @@
+// 贴边（dock）落位 —— 渲染层附件。
+//
+// IslandApp 只在几处一行钩子里消费这里的返回值；落位是 notch（默认）时，
+// 返回的是一组「空」值（className 为空串、style 为 null），宿主表达式退回原样。
+//
+// dock 状态完全由主进程给定：{placement, edge, mode, strip}。渲染层不自行推断
+// 形状 —— 窗口尺寸和这里画的形状必须同源，各算各的正是此前「看不见 / 长条 /
+// 竖侧边栏」的共同成因。
+import { r as reactExports, R as React } from "../../vendor/react-runtime.js";
+import { b as buildDockClipPath } from "./dock-shape.js";
+
+// 贴边轮廓：与屏幕边缘相接处的内凹半径，以及自由端的凸圆角半径。
+const DOCK_CONCAVE_R = 14;
+const DOCK_CONVEX_R = 14;
+
+const INACTIVE = Object.freeze({
+  active: false,
+  dragging: false,
+  edge: "right",
+  mode: "notch",
+  clipPath: null,
+  wrapperClass: "",
+  islandClass: "",
+  pillLayerStyle: null,
+  panelLayerClass: "",
+  panelLayerStyle: null
+});
+
+/**
+ * @param mounted / isOpen / transitionClass  宿主的动画状态
+ * @param actualPanelH / panelHeight          宿主算出的面板高度（顶部贴边用前者定深度，侧边贴边用后者定跨度）
+ * @param hoverOpenTimer                      宿主的 hover 展开计时器 ref（拖动开始时要清掉）
+ * @param requestCollapse                     宿主的收起动作（窗口已缩成小方块，渲染层必须同步收起）
+ */
+function useIslandDock({ mounted, isOpen, transitionClass, actualPanelH, panelHeight, pillWidth, notchH, hoverOpenTimer, requestCollapse }) {
+  const [dock, setDock] = reactExports.useState({ placement: "notch", edge: "right", mode: "notch" });
+  reactExports.useEffect(() => {
+    const bridge = window.islandBridge;
+    bridge?.onPlacement?.((d) => d && setDock(d));
+    // 主动拉一次：did-finish-load 的补发与 React 挂载之间仍有空隙，落在空隙里的那次推送会丢。
+    void bridge?.getPlacement?.().then((d) => d && setDock(d)).catch(() => {});
+  }, []);
+  const active = dock.placement === "docked";
+  const dragging = active && dock.mode === "dragging";
+  const sideDock = active && dock.edge !== "top";
+
+  // 窗口尺寸：形状在窗口坐标系里生成，窗口在拖动/吸附换边时会变尺寸。只在贴边态监听。
+  const [winSize, setWinSize] = reactExports.useState(() => [window.innerWidth, window.innerHeight]);
+  reactExports.useEffect(() => {
+    if (!active) return;
+    const onResize = () => setWinSize([window.innerWidth, window.innerHeight]);
+    window.addEventListener("resize", onResize);
+    onResize();
+    return () => window.removeEventListener("resize", onResize);
+  }, [active]);
+
+  // Command + 拖动 = 移动贴边岛。
+  // 用 window 捕获阶段监听，而不是铺一层覆盖 div：覆盖层会连带吃掉面板内部的
+  // 点击。按住 Command 才拦截，其余情况事件原样流向面板内容。
+  reactExports.useEffect(() => {
+    if (!active) return;
+    const onDown = (e) => {
+      if (!e.metaKey) return;
+      e.preventDefault();
+      e.stopPropagation();
+      window.islandBridge?.dragStart?.();
+      const onUp = () => {
+        window.removeEventListener("mouseup", onUp, true);
+        window.islandBridge?.dragEnd?.();
+      };
+      window.addEventListener("mouseup", onUp, true);
+    };
+    window.addEventListener("mousedown", onDown, true);
+    return () => window.removeEventListener("mousedown", onDown, true);
+  }, [active]);
+
+  // 主进程一旦进入拖动形态，渲染层必须同步收起：窗口已经缩成 56×56 小方块，
+  // 若渲染层还在画展开面板，就又回到了「窗口与形状不同源」的老问题。
+  const latest = reactExports.useRef({ hoverOpenTimer, requestCollapse });
+  latest.current = { hoverOpenTimer, requestCollapse };
+  reactExports.useEffect(() => {
+    if (!dragging) return;
+    const { hoverOpenTimer: timer, requestCollapse: collapse } = latest.current;
+    if (timer?.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    collapse?.();
+  }, [dragging]);
+
+  // 贴边态的两个形状：条形与面板形，在同一（面板大小的）窗口坐标系下生成，
+  // 路径指令结构一致，CSS clip-path 过渡可以直接插值 —— 形变全在渲染层，
+  // 窗口 bounds 不动，这正是刘海模式丝滑的原因。
+  // 顶边贴边时，条就是那颗刘海胶囊：长度直接跟随渲染层算出的 pillWidth
+  // （它会随会话相位变长，要装下标题和计时），主进程给的 spanOffset 只当锚点。
+  // 左右竖条不走这条路 —— 竖排内容有自己的一套留白，保持原样。
+  const stripBox = reactExports.useMemo(() => {
+    if (!active || dragging || !dock.strip) return null;
+    if (dock.edge !== "top") return { start: dock.strip.spanOffset, len: dock.strip.len, depth: dock.strip.depth };
+    const depth = Math.max(1, Math.round(notchH ?? dock.strip.depth));
+    // 两端弧线各吃掉 cR，所以外沿要比胶囊本体宽 2×cR —— 这样平直本体才正好
+    // 等于 pillWidth，内容位置与刘海模式逐点对齐。
+    const cR = Math.min(DOCK_CONCAVE_R, depth / 4);
+    const body = Math.max(1, Math.round(pillWidth ?? dock.strip.len));
+    const len = Math.min(body + 2 * cR, winSize[0]);
+    const start = Math.max(0, Math.min(dock.strip.spanOffset, winSize[0] - len));
+    return { start, len, depth };
+  }, [active, dragging, dock, winSize, pillWidth, notchH]);
+
+  const clips = reactExports.useMemo(() => {
+    if (!active || dragging || !stripBox) return null;
+    const [w, h] = winSize;
+    const top = dock.edge === "top";
+    const span = top ? w : h;
+    const strip = buildDockClipPath({
+      edge: dock.edge,
+      winW: w,
+      winH: h,
+      bodyLen: Math.max(0, stripBox.len - 2 * DOCK_CONCAVE_R),
+      depth: stripBox.depth,
+      concaveR: DOCK_CONCAVE_R,
+      convexR: DOCK_CONVEX_R,
+      spanStart: stripBox.start
+    });
+    const panelDepth = top ? Math.min(actualPanelH + 8, h) : w;
+    // 侧边面板的纵向跨度跟随内容高度：内容短时不至于拖一大块空黑到屏幕下方。
+    const panelSpan = top ? span : Math.max(stripBox.len, Math.min(panelHeight + 16, span));
+    const panel = buildDockClipPath({
+      edge: dock.edge,
+      winW: w,
+      winH: h,
+      bodyLen: Math.max(0, panelSpan - 2 * DOCK_CONCAVE_R),
+      depth: panelDepth,
+      concaveR: DOCK_CONCAVE_R,
+      convexR: DOCK_CONVEX_R,
+      spanStart: 0
+    });
+    return { strip, panel };
+  }, [active, dragging, dock, stripBox, winSize, actualPanelH, panelHeight]);
+
+  if (!active) return INACTIVE;
+  const strip = stripBox;
+  // 胶囊层要贴的是形状的**平直本体**，不是含两端弧线的外沿：
+  // 直接用外沿会让头像压在弧线上（看起来像贴着边缘、中间空一大块）。
+  // 这个内缩量与 buildDockClipPath 内部对 concaveR 的收敛保持一致。
+  const concave = strip ? Math.min(DOCK_CONCAVE_R, strip.len / 4, strip.depth / 4) : 0;
+  const pillLayerStyle = dragging
+    ? { left: 0, top: 0, transform: "none", width: "100%", height: "100%" }
+    : dock.edge === "top"
+      ? {
+          left: (strip?.start ?? 0) + concave,
+          top: 0,
+          transform: "none",
+          width: Math.max(0, (strip?.len ?? 160) - 2 * concave),
+          height: strip?.depth ?? 44
+        }
+      : {
+          left: dock.edge === "left" ? 0 : "auto",
+          right: dock.edge === "right" ? 0 : "auto",
+          top: strip?.start ?? 0,
+          transform: "none",
+          width: strip?.depth ?? 44,
+          height: strip?.len ?? 160
+        };
+  return {
+    active,
+    dragging,
+    edge: dock.edge,
+    mode: dock.mode,
+    clipPath: dragging ? "none" : clips ? (mounted && isOpen ? clips.panel : clips.strip) : "none",
+    // 形变期的 drop-shadow 优化沿用上游的 .island-pop-wrapper.is-morphing，
+    // 附件不再自造一个同义类名。
+    wrapperClass: "",
+    islandClass: ` is-docked is-dock-${dock.edge} is-dock-${dock.mode}`,
+    pillLayerStyle,
+    panelLayerClass: sideDock ? " is-side-dock" : "",
+    panelLayerStyle: sideDock ? { left: 0, transform: "none", width: winSize[0] } : null
+  };
+}
+
+/** 条上的状态点：按会话主相位着色（见 dock.css 的 .dock-status-dot.is-*）。 */
+function DockStatusDot({ dock, phase }) {
+  if (!dock.active || dock.dragging) return null;
+  return React.createElement("div", {
+    className: `dock-status-dot is-${phase ?? "idle"} dock-dot-${dock.edge}`,
+    title: phase ?? "idle"
+  });
+}
+
+export { useIslandDock as u, DockStatusDot as D };

--- a/src/renderer/island/renderer/island.html
+++ b/src/renderer/island/renderer/island.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="../components/IslandPanel.css">
     <link rel="stylesheet" href="../../../../node_modules/@xterm/xterm/css/xterm.css">
     <link rel="stylesheet" href="../app.css">
+    <link rel="stylesheet" href="../dock/dock.css">
   </head>
   <body>
     <div id="root"></div>

--- a/src/renderer/settings-app.js
+++ b/src/renderer/settings-app.js
@@ -422,6 +422,7 @@ function generalPage() {
   const behavior = section(t("settings.general.behavior.sectionTitle"), t("settings.general.behavior.description"));
   behavior.append(
     row(t("settings.general.behavior.launchAtLogin.title"), t("settings.general.behavior.launchAtLogin.description"), toggle(state.settings.launchAtLogin, v => save({ launchAtLogin: v }), t("settings.general.behavior.launchAtLogin.title"))),
+    row(t("settings.general.behavior.dock.title"), t("settings.general.behavior.dock.description"), toggle(state.settings.islandPlacement === "docked", v => save({ islandPlacement: v ? "docked" : "notch" }), t("settings.general.behavior.dock.title"))),
     row(t("settings.general.behavior.hover.title"), t("settings.general.behavior.hover.description"), toggle(state.settings.hoverToOpen, v => save({ hoverToOpen: v }), t("settings.general.behavior.hover.title"))),
     row(t("settings.general.behavior.blur.title"), t("settings.general.behavior.blur.description"), toggle(state.settings.autoCollapseOnMouseLeave, v => save({ autoCollapseOnMouseLeave: v }), t("settings.general.behavior.blur.title"))),
     row(

--- a/src/shared/ipc.cjs
+++ b/src/shared/ipc.cjs
@@ -26,6 +26,11 @@ const IPC = Object.freeze({
   ISLAND_WINDOW_BLUR: "island:window-blur",
   ISLAND_FOCUS_LOSS_HIDE: "island:focus-loss-hide",
   ISLAND_SYNC_CLOSED_WINDOW: "island:sync-closed-window",
+  // floating 模式拖动：渲染层按下并上报位移，主进程移动窗口；松手时贴边吸附。
+  ISLAND_DRAG_START: "island:drag-start",
+  ISLAND_DRAG_END: "island:drag-end",
+  ISLAND_PLACEMENT: "island:placement",
+  ISLAND_GET_PLACEMENT: "island:get-placement",
   ISLAND_DRAG_TO_PET: "island:drag-to-pet",
   ISLAND_TODAY_BURN_UPDATE: "island:today-burn-update",
   ISLAND_RESIZE: "island:resize",

--- a/src/shared/settings.cjs
+++ b/src/shared/settings.cjs
@@ -106,6 +106,9 @@ const DEFAULT_SETTINGS = {
     events: { ...DEFAULT_SOUND_EVENTS },
     autoDetectProbing: false
   },
+  islandPlacement: "notch",
+  // 贴边状态：edge 为所贴的边，offset 是沿边位置的 0-1 比例（跨分辨率仍成立）。
+  islandDock: { edge: "right", offset: 0.25 },
   hoverToOpen: true,
   autoCollapseDelayMs: 4e3,
   hideWhenFullscreen: true,

--- a/tests/dock-clip-shape.test.mjs
+++ b/tests/dock-clip-shape.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+// dock-shape.js 是浏览器侧 ESM（无 import、单一 export），在 node 测试里
+// 以文本载入并剥掉 export 后求值 —— 与仓库内读 settings-app.js 源文本的
+// 测试同一思路，避免给渲染层文件引入打包器依赖。
+const source = readFileSync(new URL("../src/renderer/island/dock/dock-shape.js", import.meta.url), "utf8");
+const buildDockClipPath = new Function(
+  `${source.replace(/export\s*\{[^}]*\};?/, "")}\nreturn buildDockClipPath;`
+)();
+
+/** 取 path 里每个绘图命令的终点坐标（M/L 直接取，A 取末组坐标对）。 */
+function endpoints(clipPath) {
+  const inner = clipPath.match(/path\('(.*)'\)/)[1];
+  const pts = [];
+  for (const chunk of inner.split(/(?=[MLA])/)) {
+    const cmd = chunk[0];
+    if (cmd !== "M" && cmd !== "L" && cmd !== "A") continue;
+    const pairs = [...chunk.matchAll(/(-?\d+(?:\.\d+)?),(-?\d+(?:\.\d+)?)/g)];
+    if (pairs.length === 0) continue;
+    const last = pairs[pairs.length - 1];
+    pts.push([Number(last[1]), Number(last[2])]);
+  }
+  return pts;
+}
+
+const EDGES = ["top", "left", "right"];
+// 覆盖从小屏侧边面板到大屏顶部面板的窗口谱系 —— 形状必须在任何机器的
+// 任何窗口尺寸下都完整落在窗口内，越界即「贴边只剩空黑/形状被裁」级故障。
+const WINDOWS = [
+  [380, 560],
+  [740, 620],
+  [240, 320],
+  [1200, 300]
+];
+
+test("dock clip path stays inside the window for every edge and size", () => {
+  for (const edge of EDGES) {
+    for (const [winW, winH] of WINDOWS) {
+      const span = edge === "top" ? winW : winH;
+      const depth = edge === "top" ? Math.min(44, winH) : Math.min(44, winW);
+      for (const spanStart of [0, Math.floor(span / 3), span]) {
+        const clip = buildDockClipPath({
+          edge, winW, winH,
+          bodyLen: Math.min(132, span),
+          depth,
+          concaveR: 14, convexR: 14,
+          spanStart
+        });
+        for (const [x, y] of endpoints(clip)) {
+          assert.ok(x >= -0.5 && x <= winW + 0.5, `${edge} ${winW}x${winH} spanStart=${spanStart}: x=${x} 越界`);
+          assert.ok(y >= -0.5 && y <= winH + 0.5, `${edge} ${winW}x${winH} spanStart=${spanStart}: y=${y} 越界`);
+        }
+      }
+    }
+  }
+});
+
+test("the docked side is flush with the window edge", () => {
+  const cases = [
+    ["right", (pts, w) => Math.max(...pts.map(p => p[0])) === w],
+    ["left", (pts) => Math.min(...pts.map(p => p[0])) === 0],
+    ["top", (pts) => Math.min(...pts.map(p => p[1])) === 0]
+  ];
+  for (const [edge, flush] of cases) {
+    const clip = buildDockClipPath({
+      edge, winW: 380, winH: 560,
+      bodyLen: 132, depth: 44, concaveR: 14, convexR: 14, spanStart: 0
+    });
+    assert.ok(flush(endpoints(clip), 380), `${edge} 贴边侧不齐平`);
+  }
+});
+
+// 回归：左边缘的旋转映射 (u,v)→[v,H-u] 翻转了沿边方向，曾把条形画到窗口
+// 底部（与顶部定位的胶囊层分家，表现为「左侧吸附只剩一块空黑」）。
+// spanStart 的语义必须两侧一致：0 = 贴窗口顶部。
+test("left and right strips anchor at the same span position (regression)", () => {
+  for (const edge of ["left", "right"]) {
+    const clip = buildDockClipPath({
+      edge, winW: 380, winH: 560,
+      bodyLen: 132, depth: 44, concaveR: 14, convexR: 14, spanStart: 0
+    });
+    const ys = endpoints(clip).map(p => p[1]);
+    assert.equal(Math.min(...ys), 0, `${edge}: 条形应贴窗口顶部`);
+    assert.ok(Math.max(...ys) <= 160.5, `${edge}: 条形长度应为 160，实际延伸到 ${Math.max(...ys)}`);
+  }
+});
+
+// 左右互为镜像：同参数下左边形状 = 右边形状按 x → winW−x 翻转。
+// 端点集合逐点比对（排序后），任何一侧的映射改动都会在此暴露。
+test("left edge mirrors right edge exactly", () => {
+  const opts = { winW: 380, winH: 560, bodyLen: 132, depth: 44, concaveR: 14, convexR: 14, spanStart: 40 };
+  // 按去重点集比较：M 起点与闭合弧终点重合会产生一次重复，
+  // 两侧遍历方向不同导致重复落在不同角上，属提取伪差而非几何差异
+  const norm = (pts) => [...new Set(pts.map(([x, y]) => `${x.toFixed(2)},${y.toFixed(2)}`))]
+    .sort()
+    .join(" ");
+  const right = endpoints(buildDockClipPath({ edge: "right", ...opts }));
+  const left = endpoints(buildDockClipPath({ edge: "left", ...opts }));
+  const mirrored = left.map(([x, y]) => [380 - x, y]);
+  assert.equal(norm(mirrored), norm(right));
+});

--- a/tests/island-dock-addon.test.mjs
+++ b/tests/island-dock-addon.test.mjs
@@ -1,0 +1,285 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+const { DOCK, pillSize, dockGeometry, nearestEdge, createDockableIslandWindow, attachIslandDock } = require("../src/main/island-dock.cjs");
+const { IPC } = require("../src/shared/ipc.cjs");
+
+// ── 纯几何 ───────────────────────────────────────────────────────────────────
+const DISPLAYS = [
+  { id: 1, bounds: { x: 0, y: 0, width: 1440, height: 900 }, workArea: { x: 0, y: 25, width: 1440, height: 875 } },
+  { id: 2, bounds: { x: 1440, y: -200, width: 2560, height: 1440 }, workArea: { x: 1440, y: -175, width: 2560, height: 1345 } },
+  { id: 3, bounds: { x: -1920, y: 0, width: 1920, height: 1080 }, workArea: { x: -1920, y: 25, width: 1920, height: 990 } }
+];
+
+const NO_NOTCH = { hasNotch: false, menuBarHeight: 25 };
+const NOTCH = { hasNotch: true, notchHeight: 32, notchWidth: 200, menuBarHeight: 32 };
+const PILL = pillSize(NO_NOTCH);
+
+test("dock geometry keeps the window inside the display and the strip inside the window", () => {
+  for (const d of DISPLAYS) {
+    for (const edge of ["top", "left", "right"]) {
+      for (const offset of [0, 0.1, 0.25, 0.5, 0.9, 1]) {
+        const { bounds, strip } = dockGeometry(d, edge, offset, PILL);
+        const b = d.bounds;
+        assert.ok(bounds.x >= b.x && bounds.x + bounds.width <= b.x + b.width, `${edge}@${offset} x in display`);
+        assert.ok(bounds.y >= b.y && bounds.y + bounds.height <= b.y + b.height, `${edge}@${offset} y in display`);
+        const span = edge === "top" ? bounds.width : bounds.height;
+        assert.ok(strip.spanOffset >= 0 && strip.spanOffset + strip.len <= span, `${edge}@${offset} strip in window`);
+        assert.equal(strip.len, PILL.len, "every edge uses the pill length");
+        assert.equal(strip.depth, PILL.depth, "every edge uses the pill thickness");
+        if (edge === "top") {
+          assert.equal(bounds.y, b.y, "top dock is flush with the display top");
+        } else {
+          const wa = d.workArea;
+          assert.equal(edge === "left" ? bounds.x : bounds.x + bounds.width, edge === "left" ? wa.x : wa.x + wa.width, "side dock is flush with the work area edge");
+          assert.ok(bounds.y >= wa.y && bounds.y + bounds.height <= wa.y + wa.height, "side dock stays inside the work area");
+        }
+      }
+    }
+  }
+});
+
+test("the docked strip is exactly the notch pill, so switching placement never resizes it", () => {
+  // 无刘海屏：菜单栏高 25，收起态胶囊 126 + 72
+  assert.deepEqual(pillSize(NO_NOTCH), { len: 198, depth: 25 });
+  // 有刘海屏：厚度取刘海高度，长度取刘海宽度 + 62
+  assert.deepEqual(pillSize(NOTCH), { len: 262, depth: 32 });
+  // 三条边共用同一组尺寸 —— 顶部是它，侧边是它转 90°
+  const d = DISPLAYS[0];
+  const top = dockGeometry(d, "top", 0.5, PILL).strip;
+  const left = dockGeometry(d, "left", 0.5, PILL).strip;
+  const right = dockGeometry(d, "right", 0.5, PILL).strip;
+  assert.deepEqual([top.len, top.depth], [left.len, left.depth]);
+  assert.deepEqual([left.len, left.depth], [right.len, right.depth]);
+});
+
+test("pillSize falls back to sane numbers when screen info is missing", () => {
+  const fallback = pillSize(undefined);
+  assert.ok(fallback.len > 0 && fallback.depth > 0);
+  assert.equal(pillSize({ hasNotch: false, menuBarHeight: 0 }).depth, 24, "no menu bar → the renderer's 24pt fallback");
+  assert.equal(pillSize({ hasNotch: false, menuBarHeight: 99 }).depth, 24, "an absurd menu bar height is ignored");
+});
+
+test("nearestEdge never picks the bottom and reports a 0-1 offset", () => {
+  const wa = { x: 0, y: 25, width: 1440, height: 875 };
+  const sq = (x, y) => ({ x, y, width: 56, height: 56 });
+  assert.equal(nearestEdge(wa, sq(700, 30)).edge, "top");
+  assert.equal(nearestEdge(wa, sq(10, 450)).edge, "left");
+  assert.equal(nearestEdge(wa, sq(1380, 450)).edge, "right");
+  // 紧贴底部：离底边最近，但底部不在候选里，落到左右中更近的那个
+  const bottom = nearestEdge(wa, sq(300, 860));
+  assert.notEqual(bottom.edge, "bottom");
+  assert.equal(bottom.edge, "left");
+  for (const r of [sq(-100, -100), sq(5000, 5000), sq(700, 450)]) {
+    const { offset } = nearestEdge(wa, r);
+    assert.ok(offset >= 0 && offset <= 1);
+  }
+});
+
+// ── 子类：notch 下对基类零干扰，docked 下接管 ────────────────────────────────
+const harnessScreenInfo = { hasNotch: false, menuBarHeight: 25 };
+function makeHarness({ initialPlacement } = {}) {
+  const calls = [];
+  const record = (name) => (...args) => calls.push([name, ...args]);
+  const win = {
+    destroyed: false,
+    size: [740, 750],
+    pos: [350, 0],
+    isDestroyed() { return this.destroyed; },
+    getSize() { return this.size.slice(); },
+    getPosition() { return this.pos.slice(); },
+    setBounds(b) { calls.push(["win.setBounds", b]); this.size = [b.width, b.height]; this.pos = [b.x, b.y]; },
+    setSize(w, h) { calls.push(["win.setSize", w, h]); this.size = [w, h]; },
+    setPosition(x, y) { calls.push(["win.setPosition", x, y]); this.pos = [x, y]; },
+    setOpacity: record("win.setOpacity"),
+    setIgnoreMouseEvents: record("win.setIgnoreMouseEvents"),
+    getNativeWindowHandle: () => "handle",
+    webContents: { send: record("wc.send"), on: record("wc.on") },
+    on: record("win.on")
+  };
+  const baseCalls = [];
+  class BaseIslandWindow {
+    requestedHeight = 750;
+    isPanelExpanded = false;
+    _isFullscreenHidden = false;
+    _isFocusHidden = false;
+    isHoverRevealedWhileFullscreenHidden = false;
+    shouldConcealAfterCloseAnimation = false;
+    constructor(target) {
+      this.win = win;
+      this.currentTarget = target;
+    }
+    setFullscreenHidden(h) { baseCalls.push(["setFullscreenHidden", h]); }
+    setFocusHidden(h) { baseCalls.push(["setFocusHidden", h]); }
+    applyRequestedHeight(h) { baseCalls.push(["applyRequestedHeight", h]); this.win.setSize(this.win.getSize()[0], h); }
+    applyClosedWindowTarget(t, o) { baseCalls.push(["applyClosedWindowTarget", t, o]); }
+    syncWindowToCurrentState() { baseCalls.push(["syncWindowToCurrentState"]); }
+    getClosedHeight() { return 32; }
+    send(ch, payload) { this.win.webContents.send(ch, payload); }
+  }
+  const listeners = new Map();
+  const handlers = new Map();
+  const electron = {
+    ipcMain: {
+      on: (ch, fn) => listeners.set(ch, fn),
+      removeListener: (ch) => listeners.delete(ch),
+      handle: (ch, fn) => { if (handlers.has(ch)) throw new Error("double handler"); handlers.set(ch, fn); },
+      removeHandler: (ch) => handlers.delete(ch)
+    },
+    screen: {
+      cursor: { x: 500, y: 300 },
+      getCursorScreenPoint() { return { ...this.cursor }; },
+      getDisplayMatching: () => DISPLAYS[0]
+    }
+  };
+  const fixPanelCalls = [];
+  const Dockable = createDockableIslandWindow(BaseIslandWindow, {
+    electron,
+    IPC,
+    log: null,
+    fixPanel: (...a) => fixPanelCalls.push(a)
+  });
+  const target = { display: DISPLAYS[0], screenInfo: harnessScreenInfo };
+  const iw = new Dockable(target, {});
+  if (initialPlacement) iw.setPlacement(initialPlacement.placement, initialPlacement.dock);
+  return { iw, win, calls, baseCalls, electron, listeners, handlers, fixPanelCalls };
+}
+
+test("in notch placement every override forwards to the base class untouched", () => {
+  const { iw, calls, baseCalls, win } = makeHarness();
+  calls.length = 0;
+  assert.equal(iw.isDocked, false);
+  assert.deepEqual(iw.dockState(), { placement: "notch", edge: "right", mode: "notch" });
+  iw.setFullscreenHidden(true);
+  iw.setFocusHidden(true);
+  iw.applyRequestedHeight(400);
+  iw.applyClosedWindowTarget("hidden-hotspot", { interactive: true });
+  iw.syncWindowToCurrentState();
+  assert.deepEqual(baseCalls, [
+    ["setFullscreenHidden", true],
+    ["setFocusHidden", true],
+    ["applyRequestedHeight", 400],
+    ["applyClosedWindowTarget", "hidden-hotspot", { interactive: true }],
+    ["syncWindowToCurrentState"]
+  ]);
+  // 子类自己没碰窗口：唯一的 setSize 来自基类的 applyRequestedHeight
+  assert.deepEqual(calls.filter(([n]) => n.startsWith("win.")), [["win.setSize", 740, 400]]);
+  assert.deepEqual(win.size, [740, 400]);
+});
+
+test("docked placement takes over: hide calls are swallowed, height is only recorded, window sits on the edge", () => {
+  const { iw, calls, baseCalls, win } = makeHarness({ initialPlacement: { placement: "docked", dock: { edge: "left", offset: 0.5 } } });
+  const expected = dockGeometry(DISPLAYS[0], "left", 0.5, pillSize(harnessScreenInfo));
+  assert.deepEqual(win.size, [expected.bounds.width, expected.bounds.height]);
+  assert.deepEqual(win.pos, [expected.bounds.x, expected.bounds.y]);
+  calls.length = 0;
+  baseCalls.length = 0;
+  iw.setFullscreenHidden(true);
+  iw.setFocusHidden(true);
+  iw.applyRequestedHeight(400);
+  iw.applyClosedWindowTarget("hidden-hotspot");
+  assert.deepEqual(baseCalls, [], "base hide/height/close paths must not run while docked");
+  assert.equal(iw.requestedHeight, 400);
+  assert.deepEqual(win.size, [expected.bounds.width, expected.bounds.height], "window size is fixed while docked");
+  // 收起 = 可见 + 穿透
+  assert.deepEqual(calls.filter(([n]) => n === "win.setOpacity").at(-1), ["win.setOpacity", 1]);
+  assert.deepEqual(calls.filter(([n]) => n === "win.setIgnoreMouseEvents").at(-1), ["win.setIgnoreMouseEvents", true, { forward: true }]);
+  const state = iw.dockState();
+  assert.equal(state.placement, "docked");
+  assert.equal(state.edge, "left");
+  assert.equal(state.mode, "strip");
+  assert.deepEqual(state.strip, expected.strip);
+});
+
+test("syncWindowToCurrentState re-applies dock bounds (fixPanel may have thrown the window to the top)", () => {
+  const { iw, win, baseCalls } = makeHarness({ initialPlacement: { placement: "docked", dock: { edge: "right", offset: 0.3 } } });
+  win.setBounds({ x: 350, y: 0, width: 740, height: 32 }); // 模拟 fixPanel 把窗口甩回顶部
+  baseCalls.length = 0;
+  iw.syncWindowToCurrentState();
+  const expected = dockGeometry(DISPLAYS[0], "right", 0.3, pillSize(harnessScreenInfo)).bounds;
+  assert.deepEqual(win.pos, [expected.x, expected.y]);
+  assert.deepEqual(win.size, [expected.width, expected.height]);
+  assert.deepEqual(baseCalls, [["syncWindowToCurrentState"]], "still lets the base finish its own bookkeeping");
+});
+
+test("switching back to notch restores the original window size before handing geometry to the base", () => {
+  const { iw, win, baseCalls, fixPanelCalls } = makeHarness({ initialPlacement: { placement: "docked", dock: { edge: "left", offset: 0.5 } } });
+  assert.notDeepEqual(win.size, [740, 750]);
+  baseCalls.length = 0;
+  iw.setPlacement("notch");
+  assert.equal(iw.isDocked, false);
+  assert.equal(win.size[0], 740, "notch width restored");
+  assert.equal(fixPanelCalls.length, 1, "fixPanel re-run to re-anchor at the top");
+  assert.deepEqual(baseCalls, [["applyRequestedHeight", 32]], "base geometry takes over again");
+  assert.deepEqual(iw.dockState(), { placement: "notch", edge: "left", mode: "notch" });
+});
+
+test("drag: press shrinks to a square under the cursor, release snaps to the nearest edge and reports it", () => {
+  const { iw, win, electron, listeners } = makeHarness({ initialPlacement: { placement: "docked", dock: { edge: "right", offset: 0.25 } } });
+  const reported = [];
+  iw.onDockChange = (d) => reported.push(d);
+  const event = { sender: win.webContents };
+  electron.screen.cursor = { x: 100, y: 400 };
+  listeners.get(IPC.ISLAND_DRAG_START)(event);
+  assert.equal(iw.dockState().mode, "dragging");
+  assert.deepEqual(win.size, [DOCK.SQUARE, DOCK.SQUARE]);
+  assert.deepEqual(win.pos, [100 - DOCK.SQUARE / 2, 400 - DOCK.SQUARE / 2]);
+  listeners.get(IPC.ISLAND_DRAG_END)(event);
+  assert.equal(iw.dockState().mode, "strip");
+  assert.equal(iw.dockState().edge, "left");
+  assert.equal(reported.length, 1);
+  assert.equal(reported[0].edge, "left");
+  assert.ok(reported[0].offset > 0 && reported[0].offset < 1);
+  const expected = dockGeometry(DISPLAYS[0], "left", reported[0].offset, pillSize(harnessScreenInfo)).bounds;
+  assert.deepEqual(win.pos, [expected.x, expected.y]);
+  iw.stopDragFollow();
+});
+
+test("drag IPC from another window is ignored and notch placement never starts a drag", () => {
+  const { iw, win, listeners } = makeHarness({ initialPlacement: { placement: "docked", dock: { edge: "right", offset: 0.25 } } });
+  listeners.get(IPC.ISLAND_DRAG_START)({ sender: {} });
+  assert.equal(iw.dockState().mode, "strip");
+  iw.setPlacement("notch");
+  listeners.get(IPC.ISLAND_DRAG_START)({ sender: win.webContents });
+  assert.equal(iw.dockState().mode, "notch");
+  assert.equal(iw._dockDragging, false);
+});
+
+test("get-placement handler returns the full dock state and dispose removes every hook", () => {
+  const { iw, handlers, listeners, win } = makeHarness({ initialPlacement: { placement: "docked", dock: { edge: "top", offset: 0.5 } } });
+  const state = handlers.get(IPC.ISLAND_GET_PLACEMENT)();
+  assert.equal(state.placement, "docked");
+  assert.equal(state.edge, "top");
+  assert.ok(state.strip, "strip geometry must travel with the state (renderer draws from it)");
+  iw.disposeDock();
+  assert.equal(handlers.size, 0);
+  for (const ch of [IPC.ISLAND_DRAG_START, IPC.ISLAND_DRAG_END, IPC.ISLAND_PANEL_EXPANDED, IPC.ISLAND_PANEL_COLLAPSED]) {
+    assert.equal(listeners.has(ch), false, `${ch} removed`);
+  }
+});
+
+test("attachIslandDock: notch settings never call setPlacement; docked applies once and writes position back", () => {
+  const made = [];
+  const iw = { setPlacement: (...a) => made.push(a), onDockChange: null };
+  const updates = [];
+  const coordinator = {
+    settings: { islandPlacement: "notch", islandDock: { edge: "right", offset: 0.25 } },
+    getSettings() { return this.settings; },
+    updateSettings(partial, source) { updates.push([partial, source]); this.settings = { ...this.settings, ...partial }; }
+  };
+  const dock = attachIslandDock(iw, coordinator, null);
+  assert.deepEqual(made, [], "default placement must not touch the window at all");
+  dock.applySettings({ islandPlacement: "notch" });
+  assert.deepEqual(made, []);
+  dock.applySettings({ islandPlacement: "docked", islandDock: { edge: "left", offset: 0.4 } });
+  assert.deepEqual(made, [["docked", { edge: "left", offset: 0.4 }]]);
+  dock.applySettings({ islandPlacement: "docked", islandDock: { edge: "left", offset: 0.4 } });
+  assert.equal(made.length, 1, "same placement again is a no-op");
+  iw.onDockChange({ edge: "top", offset: 0.7 });
+  assert.deepEqual(updates, [[{ islandDock: { edge: "top", offset: 0.7 } }, "island"]]);
+  dock.applySettings({ islandPlacement: "notch" });
+  assert.deepEqual(made.at(-1), ["notch", undefined]);
+  assert.equal(attachIslandDock({}, coordinator, null), null, "a plain IslandWindow (no add-on) is left alone");
+});


### PR DESCRIPTION
收编 @skye46126-dotcom 的 PR #36（dock 收成可选附件，刘海路径不动），解决与 main 的守卫计数冲突（172 + 4 个 island:dock* 通道 = 176）。合并后 Closes #36，同时关闭关联的 #44（dock 与刘海冲突的原始 bug——dock 改为可选附件后不再抢占刘海）。624/624 绿。